### PR TITLE
Add ANY/ALL compound query grammar with uniform token prefix format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.cursor/
 mgb_lvef/
 mgb_lvef_pt/
 mgb_ecg_pt/

--- a/src/every_query/config.yaml
+++ b/src/every_query/config.yaml
@@ -73,6 +73,9 @@ trainer:
     config:
       query_codes: ${train_codes.codes}
       num_query_codes: ${list_len:${train_codes.codes}}
+      geometric_p: ${query.geometric_p}
+      max_query_codes: ${query.max_query_codes}
+      queries_per_shard: ${query.queries_per_shard}
   callbacks:
     _target_: __main__.values_as_list
     learning_rate_monitor:

--- a/src/every_query/config.yaml
+++ b/src/every_query/config.yaml
@@ -15,6 +15,9 @@ query:
   codes: ${train_codes.codes}
   duration_min: 30
   duration_max: 366
+  compound_fraction: 0.3
+  min_compound_size: 2
+  max_compound_size: 10
 
 datamodule:
   _target_: meds_torchdata.extensions.lightning_datamodule.Datamodule

--- a/src/every_query/config.yaml
+++ b/src/every_query/config.yaml
@@ -17,6 +17,7 @@ query:
   duration_max: 366
   geometric_p: 0.5
   max_query_codes: 20
+  queries_per_shard: ${list_len:${query.codes}}
 
 datamodule:
   _target_: meds_torchdata.extensions.lightning_datamodule.Datamodule

--- a/src/every_query/config.yaml
+++ b/src/every_query/config.yaml
@@ -15,9 +15,8 @@ query:
   codes: ${train_codes.codes}
   duration_min: 30
   duration_max: 366
-  compound_fraction: 0.3
-  min_compound_size: 2
-  max_compound_size: 10
+  geometric_p: 0.5
+  max_query_codes: 20
 
 datamodule:
   _target_: meds_torchdata.extensions.lightning_datamodule.Datamodule

--- a/src/every_query/dataset.py
+++ b/src/every_query/dataset.py
@@ -21,7 +21,8 @@ class EveryQueryBatch(MEDSTorchBatch):
     """MEDS batch with EveryQuery-specific annotations.
 
     Applies only the outlined changes on top of MEDSTorchBatch:
-      - Adds optional per-sample annotations `occurs` and `query`.
+      - Adds optional per-sample annotations (`occurs`, `duration_days`,
+        `query_embed_position`, etc.).
       - Extends `LABEL_TENSOR_NAMES` to include them for printing.
       - Validates their shapes in `__post_init__` if provided.
 
@@ -56,12 +57,13 @@ class EveryQueryBatch(MEDSTorchBatch):
     prediction_time: torch.LongTensor | None = None
     censor: torch.BoolTensor | None = None
     occurs: torch.LongTensor | None = None
-    query: torch.LongTensor | None = None
+    quantifier: list | None = None
+    query_codes: list | None = None
     duration_days: torch.FloatTensor | None = None
     query_embed_position: torch.LongTensor | None = None
 
     # Include new annotations in label tensor names for display
-    LABEL_TENSOR_NAMES: ClassVar[tuple[str]] = ("boolean_value", "censor", "occurs", "query", "duration_days")
+    LABEL_TENSOR_NAMES: ClassVar[tuple[str]] = ("boolean_value", "censor", "occurs", "duration_days")
 
     def __post_init__(self):
         # Run base validations
@@ -72,8 +74,14 @@ class EveryQueryBatch(MEDSTorchBatch):
             self._MEDSTorchBatch__check_shape("censor", (self.batch_size,))
         if self.occurs is not None:
             self._MEDSTorchBatch__check_shape("occurs", (self.batch_size,))
-        if self.query is not None:
-            self._MEDSTorchBatch__check_shape("query", (self.batch_size,))
+        if self.quantifier is not None and len(self.quantifier) != self.batch_size:
+            raise ValueError(
+                f"Expected quantifier length {self.batch_size}, got {len(self.quantifier)}"
+            )
+        if self.query_codes is not None and len(self.query_codes) != self.batch_size:
+            raise ValueError(
+                f"Expected query_codes length {self.batch_size}, got {len(self.query_codes)}"
+            )
         if self.duration_days is not None:
             self._MEDSTorchBatch__check_shape("duration_days", (self.batch_size,))
         if self.query_embed_position is not None:
@@ -277,7 +285,7 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
         if getattr(self, "has_occurs", False):
             out["occurs"] = self.occurs[idx]
         if getattr(self, "has_quantifier", False):
-            out["quantifier"] = self.quantifier[idx]
+            out["quantifier"] = quantifier_str
         if getattr(self, "has_query_codes", False):
             out["query_codes"] = self.query_codes[idx]
         if getattr(self, "has_duration_days", False):
@@ -296,6 +304,10 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
             out["censor"] = out[self.LABEL_COL]
         if getattr(self, "has_occurs", False):
             out["occurs"] = torch.Tensor([item["occurs"] for item in batch]).long()
+        if getattr(self, "has_quantifier", False):
+            out["quantifier"] = [item["quantifier"] for item in batch]
+        if getattr(self, "has_query_codes", False):
+            out["query_codes"] = [item["query_codes"] for item in batch]
         if getattr(self, "has_duration_days", False):
             out["duration_days"] = torch.as_tensor([item["duration_days"] for item in batch]).float()
         out["query_embed_position"] = torch.as_tensor(

--- a/src/every_query/dataset.py
+++ b/src/every_query/dataset.py
@@ -221,11 +221,11 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
             logger.info("Old-format Parquet detected: synthesizing 'query_codes' from 'query' column.")
             self.has_query_codes = True
         if not self.has_duration_days:
-            logger.warning(
-                "Task labels missing 'duration_days'; defaulting to 30. "
-                "For accurate results, add a 'duration_days' column to the task Parquet."
+            raise ValueError(
+                "Task Parquet is missing a 'duration_days' column. "
+                "Every task file must specify the prediction horizon explicitly. "
+                "Add a 'duration_days' column to the task Parquet."
             )
-            self.has_duration_days = True
 
         self.occurs = self.schema_df["occurs"] if self.has_occurs else None
         self.quantifier = (
@@ -238,10 +238,7 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
             else [[q] for q in self.schema_df["query"].to_list()] if has_old_query
             else None
         )
-        self.duration_days = (
-            self.schema_df["duration_days"] if "duration_days" in schema_names
-            else [30.0] * len(self.schema_df)
-        )
+        self.duration_days = self.schema_df["duration_days"]
         # Load code vocabulary mapping (string code -> integer vocab index) for encoding queries
         try:
             code_meta = pl.read_parquet(

--- a/src/every_query/dataset.py
+++ b/src/every_query/dataset.py
@@ -103,7 +103,7 @@ class QueryData(NamedTuple):
                 query_dict = {
                     "time_delta_days": [np.nan],
                     "code": [self.code],
-                    "numeric_value": [np.nan],
+                    "numeric_value": [[np.nan for _ in range(len(self.code))]],
                 }
             case BatchMode.SM:
                 query_dict = {
@@ -154,9 +154,12 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
         if "occurs" in label_names:
             group_cols.append("occurs")
             out_cols.append("occurs")
-        if "query" in label_names:
-            group_cols.append("query")
-            out_cols.append("query")
+        if "quantifier" in label_names:
+            group_cols.append("quantifier")
+            out_cols.append("quantifier")
+        if "query_codes" in label_names:
+            group_cols.append("query_codes")
+            out_cols.append("query_codes")
         if "duration_days" in label_names:
             group_cols.append("duration_days")
             out_cols.append("duration_days")
@@ -183,10 +186,12 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
 
         # Extra task annotations
         self.has_occurs: bool = "occurs" in self.schema_df.collect_schema().names()
-        self.has_query: bool = "query" in self.schema_df.collect_schema().names()
+        self.has_quantifier: bool = "quantifier" in self.schema_df.collect_schema().names()
+        self.has_query_codes: bool = "query_codes" in self.schema_df.collect_schema().names()
         self.has_duration_days: bool = "duration_days" in self.schema_df.collect_schema().names()
         self.occurs = self.schema_df["occurs"] if self.has_occurs else None
-        self.query = self.schema_df["query"] if self.has_query else None
+        self.quantifier = self.schema_df["quantifier"] if self.has_quantifier else None
+        self.query_codes = self.schema_df["query_codes"] if self.has_query_codes else None
         self.duration_days = self.schema_df["duration_days"] if self.has_duration_days else None
         # Load code vocabulary mapping (string code -> integer vocab index) for encoding queries
         try:
@@ -213,7 +218,7 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
         def read_df(fp: Path) -> pl.DataFrame:
             schema = pq.read_schema(fp)
             extras = []
-            for extra_col in [self.LABEL_COL, "occurs", "query", "duration_days"]:
+            for extra_col in [self.LABEL_COL, "occurs", "quantifier", "query_codes", "duration_days"]:
                 if extra_col in schema.names:
                     extras.append(extra_col)
             label_cols = [*required_cols, *extras]
@@ -239,14 +244,16 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
         dynamic_data = out["dynamic"]
         schema = dynamic_data.schema
         schema["code"] = np.int16
-        query_data = QueryData(code=[self.encode_query(self.query[idx])])
+        query_data = QueryData(code=[self.encode_query(c) for c in self.query_codes[idx]])
         query_as_JNRT = query_data.to_JNRT(self.config.batch_mode, schema)
         out["dynamic"] = JointNestedRaggedTensorDict.concatenate([query_as_JNRT, dynamic_data])
 
         if getattr(self, "has_occurs", False):
             out["occurs"] = self.occurs[idx]
-        if getattr(self, "has_query", False):
-            out["query"] = self.query[idx]
+        if getattr(self, "has_quantifier", False):
+            out["quantifier"] = self.quantifier[idx]
+        if getattr(self, "has_query_codes", False):
+            out["query_codes"] = self.query_codes[idx]
         if getattr(self, "has_duration_days", False):
             out["duration_days"] = self.duration_days[idx]
 
@@ -263,9 +270,6 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
             out["censor"] = out[self.LABEL_COL]
         if getattr(self, "has_occurs", False):
             out["occurs"] = torch.Tensor([item["occurs"] for item in batch]).long()
-        if getattr(self, "has_query", False):
-            query_ids = [self.encode_query(item["query"]) for item in batch]
-            out["query"] = torch.as_tensor(query_ids).long()
         if getattr(self, "has_duration_days", False):
             out["duration_days"] = torch.as_tensor([item["duration_days"] for item in batch]).float()
         return EveryQueryBatch(**out)

--- a/src/every_query/dataset.py
+++ b/src/every_query/dataset.py
@@ -28,6 +28,29 @@ class EveryQueryBatch(MEDSTorchBatch):
     All other behavior is inherited unchanged.
     """
 
+    # Special token IDs for the uniform query prefix format:
+    #   [QUANT, c1, ..., cN, SEP, DUR, SEP, patient_event_1, ..., PAD...]
+    # Assigned at runtime via configure_special_tokens(backbone_vocab_size).
+    NUM_SPECIAL_TOKENS: ClassVar[int] = 4
+    ANY_TOKEN_ID: ClassVar[int | None] = None
+    ALL_TOKEN_ID: ClassVar[int | None] = None
+    SEP_TOKEN_ID: ClassVar[int | None] = None
+    DUR_TOKEN_ID: ClassVar[int | None] = None
+
+    @classmethod
+    def configure_special_tokens(cls, backbone_vocab_size: int) -> int:
+        """Assign special-token IDs starting at *backbone_vocab_size*.
+
+        Must be called once before any batch is created (e.g. during model or
+        dataset initialization).  Returns the total effective vocab size so
+        callers can resize the backbone's embedding table if needed.
+        """
+        cls.ANY_TOKEN_ID = backbone_vocab_size
+        cls.ALL_TOKEN_ID = backbone_vocab_size + 1
+        cls.SEP_TOKEN_ID = backbone_vocab_size + 2
+        cls.DUR_TOKEN_ID = backbone_vocab_size + 3
+        return backbone_vocab_size + cls.NUM_SPECIAL_TOKENS
+
     # Extra task annotations (subject-level)
     subject_id: torch.LongTensor | None = None
     prediction_time: torch.LongTensor | None = None
@@ -35,6 +58,7 @@ class EveryQueryBatch(MEDSTorchBatch):
     occurs: torch.LongTensor | None = None
     query: torch.LongTensor | None = None
     duration_days: torch.FloatTensor | None = None
+    query_embed_position: torch.LongTensor | None = None
 
     # Include new annotations in label tensor names for display
     LABEL_TENSOR_NAMES: ClassVar[tuple[str]] = ("boolean_value", "censor", "occurs", "query", "duration_days")
@@ -52,6 +76,8 @@ class EveryQueryBatch(MEDSTorchBatch):
             self._MEDSTorchBatch__check_shape("query", (self.batch_size,))
         if self.duration_days is not None:
             self._MEDSTorchBatch__check_shape("duration_days", (self.batch_size,))
+        if self.query_embed_position is not None:
+            self._MEDSTorchBatch__check_shape("query_embed_position", (self.batch_size,))
 
 
 class QueryData(NamedTuple):

--- a/src/every_query/dataset.py
+++ b/src/every_query/dataset.py
@@ -81,35 +81,45 @@ class EveryQueryBatch(MEDSTorchBatch):
 
 
 class QueryData(NamedTuple):
-    """Simple data structure to hold query data, capturing codes.
+    """Holds the full query prefix token sequence for encoding into a JNRT.
 
-    As a `NamedTuple`, can be accessed both by index (e.g. `data[0]`) and by attribute (e.g. `data.code`).
+    ``prefix_tokens`` contains the complete prefix::
 
-    Attributes:
-        code: List of integer codes.
+        [QUANT, c1, ..., cN, SEP, DUR, SEP]
+
+    where QUANT is ANY or ALL, c1..cN are medical-code vocab indices,
+    and SEP / DUR are special tokens assigned by
+    ``EveryQueryBatch.configure_special_tokens``.
+
+    DUR will later be overwritten by a continuous time embedding.
+
+    All tokens are placed in the JNRT ``code`` column with ``NaN``
+    ``time_delta_days`` and ``numeric_value`` (same as patient events
+    without those fields).
     """
 
-    code: list[int]
+    prefix_tokens: list[int]
 
     def to_JNRT(self, batch_mode: BatchMode, schema: dict | None = None) -> JointNestedRaggedTensorDict:
-        """Converts the query data into a JointNestedRaggedTensorDict representation.
+        """Converts the query prefix into a JointNestedRaggedTensorDict.
 
         Raises:
             ValueError: If the batch mode is not SEM or SM.
         """
 
+        n = len(self.prefix_tokens)
         match batch_mode:
             case BatchMode.SEM:
                 query_dict = {
                     "time_delta_days": [np.nan],
-                    "code": [self.code],
-                    "numeric_value": [[np.nan for _ in range(len(self.code))]],
+                    "code": [self.prefix_tokens],
+                    "numeric_value": [[np.nan] * n],
                 }
             case BatchMode.SM:
                 query_dict = {
-                    "time_delta_days": [np.nan for _ in range(len(self.code))],
-                    "code": self.code,
-                    "numeric_value": [np.nan for _ in range(len(self.code))],
+                    "time_delta_days": [np.nan] * n,
+                    "code": self.prefix_tokens,
+                    "numeric_value": [np.nan] * n,
                 }
             case _:
                 raise ValueError(f"Invalid batch mode {batch_mode}!")
@@ -227,8 +237,8 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
         logger.info(f"Reading tasks from {self.config.task_labels_fps}")
         return pl.concat([read_df(fp) for fp in self.config.task_labels_fps], how="vertical")
 
-    def encode_query(self, code_name: str) -> int:
-        """Encode query using the canonical code vocabulary mapping."""
+    def encode_query_code(self, code_name: str) -> int:
+        """Encode query code using the canonical code vocabulary mapping."""
         try:
             return int(self.code_to_index.get(code_name, EveryQueryBatch.PAD_INDEX))
         except Exception:
@@ -244,9 +254,25 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
         dynamic_data = out["dynamic"]
         schema = dynamic_data.schema
         schema["code"] = np.int16
-        query_data = QueryData(code=[self.encode_query(c) for c in self.query_codes[idx]])
+
+        quantifier_str = self.quantifier[idx]
+        quant_token = (
+            EveryQueryBatch.ANY_TOKEN_ID if quantifier_str == "ANY" else EveryQueryBatch.ALL_TOKEN_ID
+        )
+        encoded_codes = [self.encode_query_code(c) for c in self.query_codes[idx]]
+        prefix_tokens = [
+            quant_token,
+            *encoded_codes,
+            EveryQueryBatch.SEP_TOKEN_ID,
+            EveryQueryBatch.DUR_TOKEN_ID,
+            EveryQueryBatch.SEP_TOKEN_ID,
+        ]
+
+        query_data = QueryData(prefix_tokens=prefix_tokens)
         query_as_JNRT = query_data.to_JNRT(self.config.batch_mode, schema)
         out["dynamic"] = JointNestedRaggedTensorDict.concatenate([query_as_JNRT, dynamic_data])
+
+        out["query_embed_position"] = len(prefix_tokens) - 1
 
         if getattr(self, "has_occurs", False):
             out["occurs"] = self.occurs[idx]
@@ -272,4 +298,7 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
             out["occurs"] = torch.Tensor([item["occurs"] for item in batch]).long()
         if getattr(self, "has_duration_days", False):
             out["duration_days"] = torch.as_tensor([item["duration_days"] for item in batch]).float()
+        out["query_embed_position"] = torch.as_tensor(
+            [item["query_embed_position"] for item in batch]
+        ).long()
         return EveryQueryBatch(**out)

--- a/src/every_query/dataset.py
+++ b/src/every_query/dataset.py
@@ -181,6 +181,9 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
         if "duration_days" in label_names:
             group_cols.append("duration_days")
             out_cols.append("duration_days")
+        if "query" in label_names:
+            group_cols.append("query")
+            out_cols.append("query")
 
         return (
             label_df.join(schema_df, on=DataSchema.subject_id_name, how="inner", maintain_order="left")
@@ -207,10 +210,38 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
         self.has_quantifier: bool = "quantifier" in self.schema_df.collect_schema().names()
         self.has_query_codes: bool = "query_codes" in self.schema_df.collect_schema().names()
         self.has_duration_days: bool = "duration_days" in self.schema_df.collect_schema().names()
+
+        schema_names = self.schema_df.collect_schema().names()
+        has_old_query = "query" in schema_names
+
+        if has_old_query and not self.has_quantifier:
+            logger.info("Old-format Parquet detected: synthesizing 'quantifier' from 'query' column.")
+            self.has_quantifier = True
+        if has_old_query and not self.has_query_codes:
+            logger.info("Old-format Parquet detected: synthesizing 'query_codes' from 'query' column.")
+            self.has_query_codes = True
+        if not self.has_duration_days:
+            logger.warning(
+                "Task labels missing 'duration_days'; defaulting to 30. "
+                "For accurate results, add a 'duration_days' column to the task Parquet."
+            )
+            self.has_duration_days = True
+
         self.occurs = self.schema_df["occurs"] if self.has_occurs else None
-        self.quantifier = self.schema_df["quantifier"] if self.has_quantifier else None
-        self.query_codes = self.schema_df["query_codes"] if self.has_query_codes else None
-        self.duration_days = self.schema_df["duration_days"] if self.has_duration_days else None
+        self.quantifier = (
+            self.schema_df["quantifier"] if "quantifier" in schema_names
+            else ["ANY"] * len(self.schema_df) if has_old_query
+            else None
+        )
+        self.query_codes = (
+            self.schema_df["query_codes"] if "query_codes" in schema_names
+            else [[q] for q in self.schema_df["query"].to_list()] if has_old_query
+            else None
+        )
+        self.duration_days = (
+            self.schema_df["duration_days"] if "duration_days" in schema_names
+            else [30.0] * len(self.schema_df)
+        )
         # Load code vocabulary mapping (string code -> integer vocab index) for encoding queries
         try:
             code_meta = pl.read_parquet(
@@ -236,7 +267,7 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
         def read_df(fp: Path) -> pl.DataFrame:
             schema = pq.read_schema(fp)
             extras = []
-            for extra_col in [self.LABEL_COL, "occurs", "quantifier", "query_codes", "duration_days"]:
+            for extra_col in [self.LABEL_COL, "occurs", "quantifier", "query_codes", "duration_days", "query"]:
                 if extra_col in schema.names:
                     extras.append(extra_col)
             label_cols = [*required_cols, *extras]

--- a/src/every_query/dataset.py
+++ b/src/every_query/dataset.py
@@ -292,7 +292,7 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
 
         dynamic_data = out["dynamic"]
         schema = dynamic_data.schema
-        schema["code"] = np.int16
+        schema["code"] = np.int64
 
         quantifier_str = self.quantifier[idx]
         quant_token = (

--- a/src/every_query/model.py
+++ b/src/every_query/model.py
@@ -457,8 +457,9 @@ class EveryQueryModel(torch.nn.Module):
 
     def _forward(self, batch: EveryQueryBatch) -> tuple[torch.FloatTensor, BaseModelOutput]:
         outputs = self.HF_model(**self._hf_inputs(batch))
-        embeddings = outputs.last_hidden_state  # (batch_size, seq_len + query_len, hidden_size)
-        query_embed = embeddings[:, 0, :]  # 0 is query_index (batch_size, hidden_size)
+        embeddings = outputs.last_hidden_state  # (batch_size, seq_len, hidden_size)
+        batch_idx = torch.arange(embeddings.size(0), device=embeddings.device)
+        query_embed = embeddings[batch_idx, batch.query_embed_position, :]  # (batch_size, hidden_size)
 
         censor_logits = self.censor_mlp(query_embed)
         censor_loss = self._get_loss(censor_logits, batch.censor, mask=None)

--- a/src/every_query/model.py
+++ b/src/every_query/model.py
@@ -436,7 +436,9 @@ class EveryQueryModel(torch.nn.Module):
         """
         attention_mask = batch.code != batch.PAD_INDEX  # (B, seq_len)
 
-        word_embeds = self.HF_model.embeddings.word_embeddings(batch.code)  # (B, seq_len, H)
+        # Work on a copy: the embedding output sits in the autograd graph, and the
+        # in-place DUR overwrite below would corrupt gradient bookkeeping without clone().
+        word_embeds = self.HF_model.embeddings.word_embeddings(batch.code).clone()  # (B, seq_len, H)
 
         dur_norm = (batch.duration_days / 365.0).unsqueeze(-1)  # (B, 1)
         dur_emb = self.duration_embed(dur_norm)                  # (B, H)

--- a/src/every_query/model.py
+++ b/src/every_query/model.py
@@ -311,6 +311,7 @@ class EveryQueryModel(torch.nn.Module):
           - The input must not contain out-of-vocabulary tokens.
           - The input must not contain inf or nan values.
           - The input must not contain only padding tokens.
+          - The query_embed_position must be within sequence bounds for each sample.
 
         Args:
             batch: The input batch of data.
@@ -327,11 +328,10 @@ class EveryQueryModel(torch.nn.Module):
             raise ValueError(f"Batch mode {batch.mode} is not supported.")
 
         _batch_size, seq_len = code.shape
-        effective_seq_len = seq_len + (1 if batch.duration_days is not None else 0)
 
-        if effective_seq_len > self.max_seq_len:
+        if seq_len > self.max_seq_len:
             raise ValueError(
-                f"Input sequence length {effective_seq_len} (including duration token) exceeds model max "
+                f"Input sequence length {seq_len} exceeds model max "
                 f"sequence length {self.max_seq_len}."
             )
         elif seq_len <= 1:
@@ -342,10 +342,11 @@ class EveryQueryModel(torch.nn.Module):
         torch._assert(~torch.isinf(code).any(), "Batch code contains inf values.")
         torch._assert(~torch.isnan(code).any(), "Batch code contains nan values.")
 
-        out_of_vocab = code >= self.vocab_size
+        num_embeddings = self.HF_model.get_input_embeddings().num_embeddings
+        out_of_vocab = code >= num_embeddings
         out_of_vocab_msg = (
             f"Input sequence contains {out_of_vocab.sum()} out-of-vocabulary tokens "
-            f"(max {batch.code.max()} for vocab size {self.vocab_size})."
+            f"(max {batch.code.max()} for vocab size {num_embeddings})."
         )
 
         torch._assert(~out_of_vocab.any(), out_of_vocab_msg)
@@ -358,6 +359,14 @@ class EveryQueryModel(torch.nn.Module):
             f"Batch size: {code.shape[0]}, Sequence length: {code.shape[1]}"
         )
         torch._assert(~all_samples_pad.any(), all_samples_pad_msg)
+
+        if batch.query_embed_position is not None:
+            bad_pos = batch.query_embed_position >= seq_len
+            if bad_pos.any().item():
+                raise ValueError(
+                    f"{_val(bad_pos.sum())} sample(s) have query_embed_position >= seq_len ({seq_len}). "
+                    f"Max position: {_val(batch.query_embed_position.max())}."
+                )
 
     def _check_parameters(self):
         """Logs a warning about the finiteness of any parameters in the model.

--- a/src/every_query/model.py
+++ b/src/every_query/model.py
@@ -299,8 +299,8 @@ class EveryQueryModel(torch.nn.Module):
 
     @property
     def vocab_size(self) -> int:
-        """The vocabulary size of the model."""
-        return self.HF_model_config.vocab_size
+        """The vocabulary size of the model (after any embedding resizing)."""
+        return self.HF_model.get_input_embeddings().num_embeddings
 
     def _check_inputs(self, batch: EveryQueryBatch):
         """Checks the inputs for various validity properties.

--- a/src/every_query/model.py
+++ b/src/every_query/model.py
@@ -261,6 +261,9 @@ class EveryQueryModel(torch.nn.Module):
 
         self.HF_model = ModernBertModel._from_config(self.HF_model_config, **extra_kwargs)
 
+        total_vocab = EveryQueryBatch.configure_special_tokens(self.HF_model_config.vocab_size)
+        self.HF_model.resize_token_embeddings(total_vocab)
+
         self.do_grad_ckpt = do_grad_ckpt
         if self.do_grad_ckpt and hasattr(self.HF_model, "gradient_checkpointing_enable"):
             self.HF_model.gradient_checkpointing_enable()

--- a/src/every_query/model.py
+++ b/src/every_query/model.py
@@ -410,37 +410,32 @@ class EveryQueryModel(torch.nn.Module):
     def _hf_inputs(self, batch: EveryQueryBatch) -> dict[str, torch.Tensor]:
         """Converts the EveryQueryBatch to a dictionary of inputs for the Hugging Face model.
 
-        HF relevant input keys:
-            - input_ids: The input sequence of token IDs. Captured in `batch.code`.
-            - attention_mask: A mask to avoid attending to padding tokens. See the
-              [documentation](https://huggingface.co/docs/transformers/en/model_doc/gpt_neox#transformers.GPTNeoXModel.forward.attention_mask)
-              for more details. Should be a tensor of shape `(batch_size, seq_len)` (same as `input_ids`) with
-              0s for tokens that are masked and 1s for tokens that are not masked. This means it is given by
-              `batch.code != batch.PAD_INDEX` as whenever the code is not a padding token, it should be
-              attended to.
+        Every query uses the uniform prefix ``[QUANT, c1..cN, SEP, DUR, SEP, ...]``
+        so the DUR placeholder already occupies a real token slot in ``batch.code``.
+        We always take the ``inputs_embeds`` path: look up word embeddings for every
+        token, then overwrite the DUR slot (at ``query_embed_position - 1``) with the
+        continuous duration embedding produced by ``self.duration_embed``.
 
         Args:
             batch: The input batch of data.
 
         Returns:
-            A dictionary of inputs for the Hugging Face model.
+            A dictionary with ``inputs_embeds`` and ``attention_mask`` for the Hugging Face Model.
         """
-        attention_mask = batch.code != batch.PAD_INDEX  # (batch_size, seq_len)
+        attention_mask = batch.code != batch.PAD_INDEX  # (B, seq_len)
 
-        if batch.duration_days is not None:
-            word_embeds = self.HF_model.embeddings.word_embeddings(batch.code)  # (B, seq_len, H)
-            dur_norm = (batch.duration_days / 365.0).unsqueeze(-1)  # (B, 1)
-            dur_emb = self.duration_embed(dur_norm).unsqueeze(1)    # (B, 1, H)
-            # Insert duration embedding at position 1 (after query token at position 0)
-            inputs_embeds = torch.cat([word_embeds[:, :1, :], dur_emb, word_embeds[:, 1:, :]], dim=1)
-            dur_mask = torch.ones(batch.code.shape[0], 1, dtype=torch.bool, device=batch.code.device)
-            attention_mask = torch.cat([attention_mask[:, :1], dur_mask, attention_mask[:, 1:]], dim=1)
-            return {"inputs_embeds": inputs_embeds, "attention_mask": attention_mask}
+        word_embeds = self.HF_model.embeddings.word_embeddings(batch.code)  # (B, seq_len, H)
 
-        return {
-            "input_ids": batch.code,
-            "attention_mask": attention_mask,
-        }
+        dur_norm = (batch.duration_days / 365.0).unsqueeze(-1)  # (B, 1)
+        dur_emb = self.duration_embed(dur_norm)                  # (B, H)
+
+        # Overwrite the DUR placeholder with the learned duration embedding.
+        # Fancy-index because the DUR position differs across samples.
+        batch_idx = torch.arange(word_embeds.size(0), device=word_embeds.device)
+        dur_pos = batch.query_embed_position - 1
+        word_embeds[batch_idx, dur_pos, :] = dur_emb
+
+        return {"inputs_embeds": word_embeds, "attention_mask": attention_mask}
 
     def _forward_demo(self, batch: EveryQueryBatch) -> tuple[torch.FloatTensor, BaseModelOutput]:
         """A demo forward pass that adds more checks and assertions."""

--- a/src/every_query/train.py
+++ b/src/every_query/train.py
@@ -85,7 +85,14 @@ def collate_tasks(cfg: DictConfig) -> str:
     task_dir = cfg.query.task_dir
     durations = list(range(cfg.query.duration_min, cfg.query.duration_max))
 
-    task_str = f"{'|'.join(sorted(cfg.query.codes))}_{'|'.join(str(d) for d in sorted(durations))}"
+    compound_fraction = cfg.query.get("compound_fraction", 0.0)
+    min_compound_size = cfg.query.get("min_compound_size", 2)
+    max_compound_size = cfg.query.get("max_compound_size", 10)
+
+    task_str = (
+        f"{'|'.join(sorted(cfg.query.codes))}_{'|'.join(str(d) for d in sorted(durations))}"
+        f"_cf{compound_fraction}_min{min_compound_size}_max{max_compound_size}"
+    )
     hash_hex = hashlib.md5(task_str.encode()).hexdigest()
     write_dir = f"{task_dir}/collated/{hash_hex}"
 
@@ -113,9 +120,14 @@ def collate_tasks(cfg: DictConfig) -> str:
                     .with_columns(pl.lit(duration).alias("duration_days"))
                     .unpivot(
                         index=["subject_id", "prediction_time", "censored", "duration_days"],
-                        variable_name="query",
+                        variable_name="_code_name",
                         value_name="occurs",
                     )
+                    .with_columns(
+                        pl.lit("ANY").alias("quantifier"),
+                        pl.concat_list("_code_name").alias("query_codes"),
+                    )
+                    .drop("_code_name")
                 )
 
             shard = (

--- a/src/every_query/train.py
+++ b/src/every_query/train.py
@@ -150,6 +150,12 @@ def collate_tasks(cfg: DictConfig) -> str:
                         "duration_days",
                         occurs_expr.alias("occurs"),
                         pl.lit(quantifier).alias("quantifier"),
+                        # Broadcasts a single list value (e.g. ["A", "B"]) as a constant column across
+                        # all rows, tagging each row with the codes that define this query.
+                        # Wrapping a Python list in a one-element Series of dtype List, then calling
+                        # .first() collapses the length-1 Series to a scalar so Polars can broadcast it.
+                        # This is brittle: future Polars versions may change lit(Series) semantics or
+                        # alignment rules, and the .first() trick silently masks shape mismatches.
                         pl.lit(pl.Series("query_codes", [codes_subset])).first().alias("query_codes"),
                     )
                     query_frames.append(query_frame)

--- a/src/every_query/train.py
+++ b/src/every_query/train.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from typing import Any
 
 import hydra
+import numpy as np
 import polars as pl
 import torch
 from hydra.utils import instantiate
@@ -82,23 +83,33 @@ def find_checkpoint_path(output_dir: Path) -> Path | None:
 
 
 def collate_tasks(cfg: DictConfig) -> str:
+    """Build training task rows with geometric query generation.
+
+    For each shard, pre-generates ``len(cfg.query.codes)`` query definitions
+    (matching the row count that the old unpivot approach produced).  Each
+    definition draws ``k ~ Geometric(geometric_p)`` codes, caps at
+    ``max_query_codes``, picks a random ANY/ALL quantifier, and computes
+    ``occurs`` via ``pl.any_horizontal`` / ``pl.all_horizontal``.
+    """
     task_dir = cfg.query.task_dir
     durations = list(range(cfg.query.duration_min, cfg.query.duration_max))
 
-    compound_fraction = cfg.query.get("compound_fraction", 0.0)
-    min_compound_size = cfg.query.get("min_compound_size", 2)
-    max_compound_size = cfg.query.get("max_compound_size", 10)
+    geometric_p = cfg.query.geometric_p
+    max_query_codes = cfg.query.max_query_codes
+    seed = cfg.get("seed", 1)
 
     task_str = (
         f"{'|'.join(sorted(cfg.query.codes))}_{'|'.join(str(d) for d in sorted(durations))}"
-        f"_cf{compound_fraction}_min{min_compound_size}_max{max_compound_size}"
+        f"_gp{geometric_p}_mqc{max_query_codes}_qps{num_queries}_seed{seed}"
     )
     hash_hex = hashlib.md5(task_str.encode()).hexdigest()
     write_dir = f"{task_dir}/collated/{hash_hex}"
 
     first_duration = durations[0]
+    all_codes = list(cfg.query.codes)
+    num_queries = cfg.query.queries_per_shard
+    rng = np.random.default_rng(seed)
 
-    # Eval tasks generated in separate file
     for split in [train_split, tuning_split]:
         os.makedirs(f"{write_dir}/{split}", exist_ok=True)
 
@@ -110,31 +121,46 @@ def collate_tasks(cfg: DictConfig) -> str:
                 logger.info(f"Skipping shard. Already collated at {f}.")
                 continue
 
+            query_defs: list[tuple[str, list[str]]] = []
+            for _ in range(num_queries):
+                k = int(min(rng.geometric(geometric_p), max_query_codes, len(all_codes)))
+                codes_subset = rng.choice(all_codes, size=k, replace=False).tolist()
+                quantifier = str(rng.choice(["ANY", "ALL"]))
+                query_defs.append((quantifier, codes_subset))
+
             duration_shards = []
             for duration in durations:
-                duration_shards.append(
-                    pl.read_parquet(
-                        source=f"{task_dir}/{duration}/{split}/{file_name}",
-                        columns=["subject_id", "prediction_time", "censored", *cfg.query.codes],
+                wide_df = pl.read_parquet(
+                    source=f"{task_dir}/{duration}/{split}/{file_name}",
+                    columns=["subject_id", "prediction_time", "censored", *all_codes],
+                ).with_columns(pl.lit(duration).alias("duration_days"))
+
+                query_frames = []
+                for quantifier, codes_subset in query_defs:
+                    code_exprs = [pl.col(c) for c in codes_subset]
+                    if quantifier == "ANY":
+                        occurs_expr = pl.any_horizontal(*code_exprs)
+                    else:
+                        occurs_expr = pl.all_horizontal(*code_exprs)
+
+                    query_frame = wide_df.select(
+                        "subject_id",
+                        "prediction_time",
+                        "censored",
+                        "duration_days",
+                        occurs_expr.alias("occurs"),
+                        pl.lit(quantifier).alias("quantifier"),
+                        pl.lit(pl.Series("query_codes", [codes_subset])).first().alias("query_codes"),
                     )
-                    .with_columns(pl.lit(duration).alias("duration_days"))
-                    .unpivot(
-                        index=["subject_id", "prediction_time", "censored", "duration_days"],
-                        variable_name="_code_name",
-                        value_name="occurs",
-                    )
-                    .with_columns(
-                        pl.lit("ANY").alias("quantifier"),
-                        pl.concat_list("_code_name").alias("query_codes"),
-                    )
-                    .drop("_code_name")
-                )
+                    query_frames.append(query_frame)
+
+                duration_shards.append(pl.concat(query_frames))
 
             shard = (
                 pl.concat(duration_shards)
                 .rename({"censored": "boolean_value"})
                 .with_columns(pl.col("occurs").fill_null(False))
-                .sample(fraction=1, shuffle=True, seed=cfg.get("seed", 1))
+                .sample(fraction=1, shuffle=True, seed=seed)
                 .group_by(["subject_id"])
                 .head(cfg.query.sample_times_per_subject)
             )

--- a/src/every_query/train.py
+++ b/src/every_query/train.py
@@ -97,6 +97,7 @@ def collate_tasks(cfg: DictConfig) -> str:
     geometric_p = cfg.query.geometric_p
     max_query_codes = cfg.query.max_query_codes
     seed = cfg.get("seed", 1)
+    num_queries = cfg.query.queries_per_shard
 
     task_str = (
         f"{'|'.join(sorted(cfg.query.codes))}_{'|'.join(str(d) for d in sorted(durations))}"
@@ -107,7 +108,6 @@ def collate_tasks(cfg: DictConfig) -> str:
 
     first_duration = durations[0]
     all_codes = list(cfg.query.codes)
-    num_queries = cfg.query.queries_per_shard
     rng = np.random.default_rng(seed)
 
     for split in [train_split, tuning_split]:


### PR DESCRIPTION
## Summary

Introduces a **uniform query token prefix format** that encodes both single-code and multi-code (compound) queries into a fixed grammar prepended to every patient sequence:

```
[QUANT, c1, ..., cN, SEP, DUR, SEP, patient_event_1, ..., patient_event_M, PAD...]
```

This replaces the previous single-code query approach with a compositional ANY/ALL grammar that supports 1–20 medical codes per query, enabling the model to learn set-level clinical concepts.

### Key changes

- **4 new special tokens** (`ANY`, `ALL`, `SEP`, `DUR`) allocated above ModernBERT's 50,368 vocab range; the backbone embedding table is dynamically resized at init via `configure_special_tokens()`
- **Compound query generation** (`train.py`): each shard draws `k ~ Geometric(p)` codes (capped at `max_query_codes`), assigns a random ANY/ALL quantifier, and computes labels via `pl.any_horizontal` (OR) / `pl.all_horizontal` (AND)
- **Per-sample `query_embed_position`**: the query representation is extracted from the second SEP token rather than a hardcoded position, since prefix length now varies across samples
- **Duration embedding overwrite**: the DUR placeholder token occupies a real slot in `batch.code`; its embedding is overwritten in-place by `MLP(duration_days / 365)` in `_hf_inputs`, replacing the old concat-based insertion
- **Gradient correctness fix**: word embeddings are `.clone()`d before the in-place DUR overwrite to avoid corrupting the autograd graph
- **Backward compatibility**: old-format Parquet files with a single `query` column are auto-wrapped as `[ANY, code, SEP, DUR, SEP]` with synthesized `quantifier` and `query_codes` columns
- **New config knobs**: `geometric_p`, `max_query_codes`, `queries_per_shard` control the compound query distribution

### Files changed

| File | What changed |
|---|---|
| `config.yaml` | Added `geometric_p`, `max_query_codes`, `queries_per_shard` params and wired them to the trainer |
| `dataset.py` | `EveryQueryBatch` gains special-token class vars and `configure_special_tokens()`; `QueryData` now holds full prefix token list; `EveryQueryPytorchDataset` encodes the prefix, tracks `query_embed_position`, and handles old-format Parquet migration |
| `model.py` | Dynamic vocab resize at init, in-place DUR embedding overwrite with clone-for-grad-safety, per-sample query embedding extraction via fancy indexing, `query_embed_position` bounds checking |
| `train.py` | Geometric compound query sampling, ANY/ALL label computation via `any_horizontal`/`all_horizontal`, deterministic seeded RNG, updated task-string hashing |

## Test plan

- [ ] Verify single-code queries still train correctly (backward compat path with old Parquet)
- [ ] Verify compound queries (k > 1) produce correct ANY/ALL labels against manual spot-checks
- [ ] Confirm gradient flow through the DUR overwrite (no NaN/inf in early training steps)
- [ ] Check that `query_embed_position` is always within sequence bounds across varying prefix lengths
- [ ] Validate that the geometric distribution produces the expected code-count distribution with different `geometric_p` values

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced geometric random query generation for training with configurable parameters.

* **Refactor**
  * Restructured query annotations in datasets with enhanced organization.
  * Improved query embedding position handling in the model.
  * Updated training pipeline to use geometric random sampling instead of column unpivoting.

* **Chores**
  * Added new configuration parameters for query generation control.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->