### PR TITLE
chore: fix pre-commit drift failing Code Quality Main CI

### DIFF
--- a/scripts/launch_sweep.sh
+++ b/scripts/launch_sweep.sh
@@ -44,7 +44,7 @@ echo ""
 echo "Sweep ID: $SWEEP_ID"
 echo "Submitting $NUM_AGENTS agents ..."
 
-for i in $(seq 1 "$NUM_AGENTS"); do
+for _ in $(seq 1 "$NUM_AGENTS"); do
     sbatch scripts/sweep_worker.sh "$SWEEP_ID"
 done
 

--- a/scripts/sweep_layers.sh
+++ b/scripts/sweep_layers.sh
@@ -1,18 +1,22 @@
 #!/bin/bash
 # Sweep over num_hidden_layers: 6, 12, 16, 22
-# Submits all jobs simultaneously via sbatch
+# Submits all jobs with a 30s stagger between submissions.
 
 set -euo pipefail
 
-for N_LAYERS in 6 12 16 22; do
-    echo "Submitting job with lr=$N_LAYERS"
+LAYER_SIZES=(6 12 16 22)
+NUM_LAYERS=${#LAYER_SIZES[@]}
+
+for i in "${!LAYER_SIZES[@]}"; do
+    N_LAYERS="${LAYER_SIZES[$i]}"
+    echo "Submitting job with num_hidden_layers=$N_LAYERS"
     sbatch --job-name="eq_layers_${N_LAYERS}" \
         scripts/train_eq.sh \
-        lightning_module.model.num_hidden_layers=$N_LAYERS \
+        "lightning_module.model.num_hidden_layers=$N_LAYERS" \
         only_preprocess=false
 
-    # If this is NOT the last job, wait 30 seconds
-    if [ $((i + 1)) -lt $NUM_LAYERS ]; then
+    # If this is NOT the last job, wait 30 seconds.
+    if [ $((i + 1)) -lt "$NUM_LAYERS" ]; then
         echo "Waiting 30 seconds before next submission..."
         sleep 30
     fi

--- a/scripts/sweep_worker.sh
+++ b/scripts/sweep_worker.sh
@@ -30,6 +30,7 @@ echo "Sweep agent on $(hostname) at $(date)"
 cd "${SLURM_SUBMIT_DIR:-$PWD}"
 
 set -a
+# shellcheck source=/dev/null
 . ./.env
 set +a
 

--- a/src/every_query/_env.py
+++ b/src/every_query/_env.py
@@ -1,8 +1,7 @@
 """Load .env and validate that required environment variables are set.
 
-Imported early by both train.py and tasks.py so that a missing .env on a fresh
-machine surfaces a single clear error rather than a mid-run KeyError or Hydra
-InterpolationResolutionError.
+Imported early by both train.py and tasks.py so that a missing .env on a fresh machine surfaces a single clear
+error rather than a mid-run KeyError or Hydra InterpolationResolutionError.
 """
 
 import os

--- a/src/every_query/config.yaml
+++ b/src/every_query/config.yaml
@@ -102,7 +102,7 @@ trainer:
   accelerator: "auto"
   devices: 1
   strategy: "auto"
-  accumulate_grad_batches: 4  # set to 1 for no gradient accumulation, >1 for gradient accumulation
+  accumulate_grad_batches: 4 # set to 1 for no gradient accumulation, >1 for gradient accumulation
   log_every_n_steps: 50
   # perform a validation loop every N training epochs
   check_val_every_n_epoch: 1

--- a/src/every_query/eval.py
+++ b/src/every_query/eval.py
@@ -49,7 +49,9 @@ def _setup_model(model_run_dir: str | Path, ckpt_name: str | None = None):
     )
     ckpt_path = next((p for p in candidates if p.is_file()), None)
     if ckpt_path is None:
-        raise FileNotFoundError(f"No checkpoint found in {model_run_dir} (tried {[str(p) for p in candidates]})")
+        raise FileNotFoundError(
+            f"No checkpoint found in {model_run_dir} (tried {[str(p) for p in candidates]})"
+        )
     if ckpt_path != candidates[0]:
         logger.warning(f"{candidates[0].name} not found, falling back to {ckpt_path}")
 
@@ -256,7 +258,9 @@ def main(cfg: DictConfig) -> None:
                 logger.info(f"Saved predictions to {out_fp}")
                 logger.info(f"Saved embeddings to {embed_fp}")
             else:
-                test_df = _run_test(cfg, train_cfg, M, trainer, task_set_dir, model_name, durations, ckpt_name)
+                test_df = _run_test(
+                    cfg, train_cfg, M, trainer, task_set_dir, model_name, durations, ckpt_name
+                )
                 if test_df.is_empty():
                     logger.warning(f"No test results generated for {model_name}.")
                     continue

--- a/src/every_query/eval_suite/README.md
+++ b/src/every_query/eval_suite/README.md
@@ -1,7 +1,9 @@
 # Instructions
 
 - Run gen_index_times.py to generate prediction times indices
+
 - Run gen_task.py to generate EQ task df's for each code with index times generated before
+
 - Run eval.py (configured by eval_config.yaml via hydra) to eval a model on a set of codes
 
 - Run select_model.py to perform model selection based on task pairwise auc winrate across models listed in conf/select_model_config.yaml

--- a/src/every_query/eval_suite/conf/eval_config.yaml
+++ b/src/every_query/eval_suite/conf/eval_config.yaml
@@ -2,33 +2,33 @@ defaults:
   - _self_
   - eval_codes: 10000_ID__8db2be6fadf8
 
-# Model run directory (or list of directories). 
+# Model run directory (or list of directories).
 # Paths are rooted at $OUTPUT_DIR so they move with .env across machines
 model_run_dirs:
   - ${oc.env:OUTPUT_DIR}/outputs/2026-04-02/23-43-54 # 256, 22
   - ${oc.env:OUTPUT_DIR}/outputs/2026-04-02/23-54-43 # 1028, 22
-  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-08/16-38-46/                                                                                     
-  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-03/00-29-53 #2048,6                                                                       
-  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-02/23-56-55 # 1028, 6                                                                     
-  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-02/23-58-42 # 1028, 12                                                                    
-  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-04/14-08-24 # 1028, 16                                                                    
-  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-02/23-54-43 # 1028, 22                                                                    
-  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-03/13-28-12 # 256, 6                                                                      
-  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-03/12-58-10 # 256, 12                                                                     
+  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-08/16-38-46/
+  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-03/00-29-53 #2048,6
+  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-02/23-56-55 # 1028, 6
+  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-02/23-58-42 # 1028, 12
+  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-04/14-08-24 # 1028, 16
+  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-02/23-54-43 # 1028, 22
+  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-03/13-28-12 # 256, 6
+  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-03/12-58-10 # 256, 12
   # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-02/23-43-55 # 256, 16
-  
+
 #
 # Checkpoints to evaluate within each run dir (names without .ckpt extension)
 # Set to null to just use ckpt_path (single checkpoint)
 ckpt_names:
-  # - "best"  
+  # - "best"
   # - "epoch=0-step=1382"
   # - "epoch=0-step=4146"
   # - "epoch=0-step=6911"
   # - "epoch=0-step=11058"
-  
+
 # Durations (in days) to evaluate at; This must be a list!
-durations: [30,90,180,365,731]
+durations: [30, 90, 180, 365, 731]
 
 index_time_hash: 7573f855c4b050a9d79d57fefd8a139c
 split: held_out

--- a/src/every_query/eval_suite/select_model.py
+++ b/src/every_query/eval_suite/select_model.py
@@ -37,9 +37,7 @@ def _compute_win_rates(df: pl.DataFrame) -> tuple[pl.DataFrame, pl.DataFrame]:
     pivot = pivot.drop_nulls()
     dropped = before - pivot.height
     if dropped:
-        logger.warning(
-            f"Dropped {dropped}/{before} (code, duration) pairs not covered by every model"
-        )
+        logger.warning(f"Dropped {dropped}/{before} (code, duration) pairs not covered by every model")
 
     models = [c for c in pivot.columns if c not in ("code", "duration_days")]
     n_pairs = pivot.height
@@ -48,7 +46,7 @@ def _compute_win_rates(df: pl.DataFrame) -> tuple[pl.DataFrame, pl.DataFrame]:
     if len(models) < 2:
         raise ValueError(f"Need at least 2 models to compare, got {len(models)}")
 
-    fractions: dict[str, dict[str, float]] = {m: {m2: 0.0 for m2 in models} for m in models}
+    fractions: dict[str, dict[str, float]] = {m: dict.fromkeys(models, 0.0) for m in models}
     for a, b in combinations(models, 2):
         col_a = pivot[a]
         col_b = pivot[b]
@@ -57,9 +55,7 @@ def _compute_win_rates(df: pl.DataFrame) -> tuple[pl.DataFrame, pl.DataFrame]:
         fractions[a][b] = frac_a
         fractions[b][a] = 1.0 - frac_a
 
-    win_matrix = pl.DataFrame(
-        {"model": models, **{m: [fractions[row][m] for row in models] for m in models}}
-    )
+    win_matrix = pl.DataFrame({"model": models, **{m: [fractions[row][m] for row in models] for m in models}})
 
     total_wins = [sum(fractions[m].values()) for m in models]
     win_rate_vals = [w / (len(models) - 1) for w in total_wins]
@@ -89,11 +85,7 @@ def main(cfg: DictConfig) -> None:
         print(f"\n=== Overall win rate ranking ({split}, aggregated across durations) ===")
         print(ranking.with_columns(pl.col("win_rate").round(3)))
         print("\nPairwise win matrix (row beats column):")
-        print(
-            win_matrix.with_columns(
-                [pl.col(c).round(3) for c in win_matrix.columns if c != "model"]
-            )
-        )
+        print(win_matrix.with_columns([pl.col(c).round(3) for c in win_matrix.columns if c != "model"]))
 
     best = ranking.row(0, named=True)
     print(f"\n>>> Best model: {best['model']} (win rate: {best['win_rate']:.3f})")

--- a/src/every_query/tasks_config.yaml
+++ b/src/every_query/tasks_config.yaml
@@ -1,5 +1,5 @@
 shard_index: ${oc.env:SLURM_ARRAY_TASK_ID,null}
-durations: null  # explicit list of durations in days, e.g. [30, 90, 180, 365]. If null, samples n_durations.
+durations: null # explicit list of durations in days, e.g. [30, 90, 180, 365]. If null, samples n_durations.
 n_durations: 200
 duration_seed: 140799
 min_context: 50

--- a/src/every_query/train.py
+++ b/src/every_query/train.py
@@ -6,7 +6,7 @@ import os
 import shutil
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any
 
@@ -29,7 +29,7 @@ _RUN_ID = None
 def run_id():
     global _RUN_ID
     if _RUN_ID is None:
-        _RUN_ID = datetime.now(timezone.utc).strftime("%Y-%m-%d/%H-%M-%S")
+        _RUN_ID = datetime.now(UTC).strftime("%Y-%m-%d/%H-%M-%S")
     return _RUN_ID
 
 

--- a/tests/test_eval.py
+++ b/tests/test_eval.py
@@ -1,6 +1,7 @@
 """Tests for eval.py: _setup_model, _run_test, _run_predict."""
 
 from pathlib import Path
+from typing import ClassVar
 from unittest.mock import MagicMock, patch
 
 import polars as pl
@@ -190,7 +191,7 @@ def run_test_deps(tmp_path):
 
 
 class TestRunTestOutputSchema:
-    EXPECTED_COLUMNS = {
+    EXPECTED_COLUMNS: ClassVar[set[str]] = {
         "model",
         "duration_days",
         "code",
@@ -533,7 +534,7 @@ class TestRunPredictRowGeneration:
 class TestMultiCheckpointLoop:
     """Tests for evaluating multiple checkpoints from the same run directory."""
 
-    CKPT_NAMES = ["epoch=0-step=100", "epoch=0-step=200", "epoch=0-step=300"]
+    CKPT_NAMES: ClassVar[list[str]] = ["epoch=0-step=100", "epoch=0-step=200", "epoch=0-step=300"]
 
     def _make_multi_ckpt_run_dir(self, tmp_path):
         ckpt_locations = [f"checkpoints/{name}.ckpt" for name in self.CKPT_NAMES]
@@ -569,11 +570,19 @@ class TestMultiCheckpointLoop:
     def test_ckpt_names_fallback_to_ckpt_path(self):
         # Simulates the resolution logic from main()
         cfg_with_names = OmegaConf.create({"ckpt_names": ["a", "b"], "ckpt_path": "best"})
-        result = list(cfg_with_names.ckpt_names) if cfg_with_names.get("ckpt_names") else [cfg_with_names.get("ckpt_path")]
+        result = (
+            list(cfg_with_names.ckpt_names)
+            if cfg_with_names.get("ckpt_names")
+            else [cfg_with_names.get("ckpt_path")]
+        )
         assert result == ["a", "b"]
 
         cfg_without_names = OmegaConf.create({"ckpt_names": None, "ckpt_path": "best"})
-        result = list(cfg_without_names.ckpt_names) if cfg_without_names.get("ckpt_names") else [cfg_without_names.get("ckpt_path")]
+        result = (
+            list(cfg_without_names.ckpt_names)
+            if cfg_without_names.get("ckpt_names")
+            else [cfg_without_names.get("ckpt_path")]
+        )
         assert result == ["best"]
 
     def test_all_ckpts_results_in_single_dataframe(self, tmp_path):
@@ -598,5 +607,5 @@ class TestMultiCheckpointLoop:
             all_dfs.append(df)
 
         combined = pl.concat(all_dfs, how="vertical")
-        # 3 ckpts × 2 codes × 2 durations = 12 rows
+        # 3 ckpts x 2 codes x 2 durations = 12 rows
         assert len(combined) == 3 * 2 * 2


### PR DESCRIPTION
## Summary

`Code Quality Main` workflow has been red since PRs #36 / #37 / #38 / #39 merged. That workflow runs `pre-commit run --all-files`, whereas the per-PR job (`Code Quality PR`) only runs against changed files — so the drift accumulated on main without any individual PR noticing.

This PR makes `pre-commit run --all-files` green again with no semantic changes. Tests still pass: `176 passed`.

## Three categories of fixes

1. **Auto-fixable drift (9 files).** `ruff-format`, `trim-whitespace`, `end-of-file-fixer`, `docformatter`, `mdformat`, and `prettier` all had pending rewrites. No semantic changes; this is purely formatting that pre-commit's own hooks produced when re-run.

2. **Non-autofixable ruff lints in `tests/test_eval.py`:**
    - **RUF012 (×2)**: `TestRunTestOutputSchema.EXPECTED_COLUMNS` and `TestMultiCheckpointLoop.CKPT_NAMES` were mutable class attributes without a `typing.ClassVar` annotation. Annotated both.
    - **RUF003 (×2)**: a comment used `×` (U+00D7 MULTIPLICATION SIGN) where `x` was meant. Replaced.

3. **Non-autofixable shellcheck issues in `scripts/`:**
    - `launch_sweep.sh`: renamed unused loop variable `i` → `_` (SC2034).
    - `sweep_layers.sh`: the wait-between-submissions branch referenced an undefined `$i` *and* misspelled `$NUM_LAYERS` (the loop variable was `N_LAYERS`). This was a latent bug — the `if` condition was always evaluating `$((<unset> + 1)) -lt <unset>`, which shell quietly treats as `0 -lt 0 = false`, so the 30-second sleep between sbatch submissions had been silently disabled since the script landed. Rewrote as an indexed loop over a `LAYER_SIZES` array so both the counter and `NUM_LAYERS` are actually defined, quoted the hydra override, and fixed the unrelated `echo "... lr=$N_LAYERS"` that mislabelled the parameter as a learning rate. (SC2154, SC2086, SC2153)
    - `sweep_worker.sh`: added `# shellcheck source=/dev/null` above `. ./.env` since the file is generated at deploy time and can't be followed statically (SC1091).

## Test plan

- [x] `uv run pre-commit run --all-files` — all 23 hooks pass.
- [x] `uv run pytest -q` — 176 passed, 12 warnings (unchanged from `main`).
- [ ] CI `Code Quality Main` turns green after merge.
- [ ] `Tests` workflow stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)