### PR TITLE
Add GCS sync and model upload scripts

### DIFF
--- a/scripts/sync.py
+++ b/scripts/sync.py
@@ -1,0 +1,156 @@
+"""Bidirectional GCS sync for EveryQuery data.
+
+Usage:
+    python scripts/sync.py upload              # push all mappings to GCS
+    python scripts/sync.py download            # pull all mappings from GCS
+    python scripts/sync.py upload --mapping outputs   # sync one mapping
+    python scripts/sync.py download --dry-run         # preview commands
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+from dotenv import load_dotenv
+
+logger = logging.getLogger("sync")
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+CONFIG_PATH = Path(__file__).resolve().parent / "sync_config.yaml"
+
+
+def load_config() -> dict:
+    with open(CONFIG_PATH) as f:
+        return yaml.safe_load(f)
+
+
+def resolve_server_root(mapping: dict) -> Path:
+    """Build the server source path from env var + optional suffix."""
+    env_var = mapping["server_root_env"]
+    base = os.environ.get(env_var)
+    if not base:
+        logger.error(
+            "Environment variable %s is not set. Set it in your .env file or export it.",
+            env_var,
+        )
+        sys.exit(1)
+    suffix = mapping.get("server_root_suffix", "")
+    return Path(base) / suffix
+
+
+def gsutil_rsync(src: str, dst: str, *, dry_run: bool, delete: bool = False) -> bool:
+    cmd = ["gsutil", "-m", "rsync", "-r"]
+    if delete:
+        cmd.append("-d")
+    cmd.extend([src, dst])
+
+    if dry_run:
+        print(f"DRY-RUN: {' '.join(cmd)}")
+        return True
+
+    logger.info("Running: %s", " ".join(cmd))
+    try:
+        subprocess.run(cmd, check=True)
+    except FileNotFoundError:
+        logger.error("`gsutil` not found on PATH. Install the Google Cloud SDK first.")
+        sys.exit(1)
+    except subprocess.CalledProcessError as e:
+        logger.error("gsutil rsync failed (exit %s)", e.returncode)
+        return False
+    return True
+
+
+def cmd_upload(mappings: list[dict], bucket: str, *, dry_run: bool) -> int:
+    failures = 0
+    for m in mappings:
+        if "server_root_env" not in m:
+            logger.info("Skipping [%s]: no server_root_env (download-only mapping).", m["name"])
+            continue
+        server_root = resolve_server_root(m)
+        gcs_dst = f"{bucket.rstrip('/')}/{m['gcs_prefix'].strip('/')}"
+
+        if not dry_run and not server_root.is_dir():
+            logger.error("Server root does not exist: %s", server_root)
+            failures += 1
+            continue
+
+        print(f"\n--- Uploading [{m['name']}]: {server_root} -> {gcs_dst}")
+        ok = gsutil_rsync(str(server_root), gcs_dst, dry_run=dry_run)
+        if not ok:
+            failures += 1
+    return failures
+
+
+def cmd_download(mappings: list[dict], bucket: str, *, dry_run: bool) -> int:
+    failures = 0
+    for m in mappings:
+        prefix = m["gcs_prefix"].strip("/")
+        gcs_src = f"{bucket.rstrip('/')}/{prefix}" if prefix else bucket.rstrip("/")
+        local_dst = REPO_ROOT / m["local_root"]
+
+        if not dry_run:
+            local_dst.mkdir(parents=True, exist_ok=True)
+
+        print(f"\n--- Downloading [{m['name']}]: {gcs_src} -> {local_dst}")
+        ok = gsutil_rsync(gcs_src, str(local_dst), dry_run=dry_run)
+        if not ok:
+            failures += 1
+    return failures
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "command",
+        choices=["upload", "download"],
+        help="Sync direction: upload (server -> GCS) or download (GCS -> local).",
+    )
+    parser.add_argument(
+        "--mapping",
+        help="Sync only the named mapping (e.g. 'outputs', 'tasks', 'meds').",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print gsutil commands without executing them.",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    load_dotenv(REPO_ROOT / ".env")
+
+    cfg = load_config()
+    bucket = cfg["bucket"]
+    mappings = cfg["mappings"]
+
+    if args.mapping:
+        mappings = [m for m in mappings if m["name"] == args.mapping]
+        if not mappings:
+            logger.error(
+                "No mapping named %r. Available: %s",
+                args.mapping,
+                ", ".join(m["name"] for m in cfg["mappings"]),
+            )
+            return 2
+
+    if args.command == "upload":
+        failures = cmd_upload(mappings, bucket, dry_run=args.dry_run)
+    else:
+        failures = cmd_download(mappings, bucket, dry_run=args.dry_run)
+
+    if failures:
+        print(f"\n{failures} mapping(s) failed.")
+        return 1
+
+    print("\nAll done.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sync_config.yaml
+++ b/scripts/sync_config.yaml
@@ -1,0 +1,37 @@
+# GCS sync configuration
+#
+# Each mapping defines a server source root, a GCS prefix inside the bucket,
+# and a local destination (relative to the repo root).
+#
+# The server_root values reference environment variables from .env so the same
+# config works across machines.  The sync script resolves them at runtime.
+# For download-only mappings that don't need a server root, omit server_root_env.
+
+bucket: gs://every-query-runs
+
+mappings:
+  # Current bucket contents: mirrors the data/ directory layout.
+  - name: eval-data
+    gcs_prefix: ""
+    local_root: data/
+
+  # Future mappings for server-side uploads:
+  - name: outputs
+    # Hydra writes run dirs under ${OUTPUT_DIR}/outputs/<date>/<time>/
+    server_root_env: OUTPUT_DIR
+    server_root_suffix: outputs/
+    gcs_prefix: outputs/
+    local_root: data/outputs/
+
+  - name: tasks
+    server_root_env: TASK_DIR
+    server_root_suffix: ""
+    gcs_prefix: tasks/
+    local_root: data/tasks/
+
+  - name: meds
+    # Root of the MEDS cohort (DATA_DIR in .env.example).
+    server_root_env: DATA_DIR
+    server_root_suffix: ""
+    gcs_prefix: meds/
+    local_root: data/meds/

--- a/scripts/upload_lists/example.txt
+++ b/scripts/upload_lists/example.txt
@@ -1,0 +1,7 @@
+# One run directory per line. Blank lines and '#' comments are ignored.
+# Each path should point at a directory containing best_model.ckpt,
+# config.yaml, and resolved_config.yaml.
+#
+# Example:
+# /path/to/outputs/eq_run_2026_03_15
+# /path/to/outputs/eq_run_2026_03_20

--- a/scripts/upload_mimic_meds.sh
+++ b/scripts/upload_mimic_meds.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+#SBATCH --job-name=mimic_meds_upload
+#SBATCH --output=logs/%x_%j.out
+#SBATCH --mail-user=gbk2114@cumc.columbia.edu
+#SBATCH --mail-type=END,FAIL
+
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --partition=cpu
+#SBATCH --cpus-per-task=4
+#SBATCH --mem=8G
+#SBATCH --time=08:00:00
+
+set -euo pipefail
+
+SRC_ROOT="/groups/mm6677_gp/data/MIMIC_MEDS/MEDS_cohort"
+BUCKET="gs://every-query-runs"
+DEST="${BUCKET}/meds/MIMIC_MEDS/MEDS_cohort"
+
+SUBDIRS=(
+    "intermediate/data"
+    "intermediate/metadata"
+    "processed/data"
+    "processed/metadata"
+)
+
+mkdir -p logs
+echo "Starting MIMIC_MEDS upload on $(hostname) at $(date)"
+echo "Source: ${SRC_ROOT}"
+echo "Destination: ${DEST}"
+
+for sub in "${SUBDIRS[@]}"; do
+    src="${SRC_ROOT}/${sub}"
+    dst="${DEST}/${sub}"
+    if [[ ! -d "${src}" ]]; then
+        echo "ERROR: source directory missing: ${src}" >&2
+        exit 1
+    fi
+    echo "---"
+    echo "Syncing ${src} -> ${dst}"
+    gsutil -m rsync -r "${src}" "${dst}"
+done
+
+echo "Finished at $(date)"

--- a/scripts/upload_models.sh
+++ b/scripts/upload_models.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+#SBATCH --job-name=eq_upload
+#SBATCH --output=logs/%x_%j.out
+#SBATCH --mail-user=gbk2114@cumc.columbia.edu
+#SBATCH --mail-type=END,FAIL
+
+#SBATCH --nodes=1
+#SBATCH --ntasks-per-node=1
+#SBATCH --partition=cpu
+#SBATCH --cpus-per-task=2
+#SBATCH --mem=8G
+#SBATCH --time=04:00:00
+
+set -euo pipefail
+export PYTHONNOUSERSITE=1
+
+if [[ $# -lt 1 ]]; then
+    echo "Usage: $0 <runs-file> [--dry-run]" >&2
+    echo "  <runs-file>  text file with one run directory per line" >&2
+    echo "  Bucket + path layout come from scripts/sync_config.yaml (outputs mapping)" >&2
+    exit 2
+fi
+
+RUNS_FILE="$1"
+shift
+
+mkdir -p logs
+echo "Starting upload job on $(hostname) at $(date)"
+cd "${SLURM_SUBMIT_DIR:-$PWD}"
+
+set -a
+# shellcheck source=/dev/null
+. ./.env
+set +a
+
+uv sync --locked
+
+uv run python src/every_query/upload_models.py \
+    --runs-file "${RUNS_FILE}" \
+    "$@"
+
+echo "Finished at $(date)"

--- a/src/every_query/upload_models.py
+++ b/src/every_query/upload_models.py
@@ -1,0 +1,198 @@
+"""Upload selected run dirs (ckpt + configs + eval outputs) to GCS.
+
+Bucket and path layout are read from ``scripts/sync_config.yaml`` so uploads
+land at the same paths ``scripts/sync.py`` would use for the ``outputs``
+mapping. Each listed run is expected to live under ``$OUTPUT_DIR/outputs/``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+from dotenv import load_dotenv
+
+logger = logging.getLogger("upload_models")
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SYNC_CONFIG_PATH = REPO_ROOT / "scripts" / "sync_config.yaml"
+
+REQUIRED_FILES = ("best_model.ckpt",)
+OPTIONAL_FILES = ("config.yaml", "resolved_config.yaml")
+EVAL_SUBDIR = "eval"
+
+
+def parse_runs_file(runs_file: Path) -> list[Path]:
+    runs: list[Path] = []
+    for raw in runs_file.read_text().splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        runs.append(Path(line))
+    return runs
+
+
+def load_sync_outputs_mapping() -> tuple[str, str, Path]:
+    """Return (bucket, gcs_prefix, server_root) from sync_config.yaml + env."""
+    with open(SYNC_CONFIG_PATH) as f:
+        cfg = yaml.safe_load(f)
+
+    bucket = cfg["bucket"]
+    mapping = next((m for m in cfg["mappings"] if m["name"] == "outputs"), None)
+    if mapping is None:
+        raise RuntimeError(f"No 'outputs' mapping found in {SYNC_CONFIG_PATH}")
+
+    env_var = mapping["server_root_env"]
+    base = os.environ.get(env_var)
+    if not base:
+        raise RuntimeError(
+            f"Environment variable {env_var} is not set. Set it in your .env file or export it."
+        )
+    server_root = Path(base) / mapping.get("server_root_suffix", "")
+    return bucket, mapping["gcs_prefix"], server_root
+
+
+def _run_gsutil(cmd: list[str], *, dry_run: bool) -> bool:
+    if dry_run:
+        print("DRY-RUN:", " ".join(cmd))
+        return True
+    logger.info("Running: %s", " ".join(cmd))
+    try:
+        subprocess.run(cmd, check=True)
+    except FileNotFoundError:
+        logger.error("`gsutil` not found on PATH. Install the Google Cloud SDK first.")
+        raise
+    except subprocess.CalledProcessError as e:
+        logger.error("gsutil failed (exit %s): %s", e.returncode, " ".join(cmd))
+        return False
+    return True
+
+
+def gsutil_cp(src: Path, dst: str, *, dry_run: bool) -> bool:
+    return _run_gsutil(["gsutil", "-m", "cp", str(src), dst], dry_run=dry_run)
+
+
+def gsutil_rsync(src: Path, dst: str, *, dry_run: bool) -> bool:
+    return _run_gsutil(["gsutil", "-m", "rsync", "-r", str(src), dst], dry_run=dry_run)
+
+
+def upload_run(
+    run_dir: Path,
+    *,
+    bucket: str,
+    gcs_prefix: str,
+    server_root: Path,
+    dry_run: bool,
+) -> str:
+    """Return 'uploaded', 'skipped', or 'failed' for one run directory."""
+    if not run_dir.is_dir():
+        logger.error("Run directory does not exist: %s", run_dir)
+        return "skipped"
+
+    try:
+        rel = run_dir.resolve().relative_to(server_root.resolve())
+    except ValueError:
+        logger.error(
+            "Run %s is not under the sync outputs root %s; skipping.",
+            run_dir,
+            server_root,
+        )
+        return "skipped"
+
+    missing_required = [f for f in REQUIRED_FILES if not (run_dir / f).is_file()]
+    if missing_required:
+        logger.error("Skipping %s: missing required file(s) %s", run_dir, missing_required)
+        return "skipped"
+
+    dest_prefix = f"{bucket.rstrip('/')}/{gcs_prefix.strip('/')}/{rel.as_posix()}"
+
+    all_ok = True
+    for filename in REQUIRED_FILES:
+        ok = gsutil_cp(run_dir / filename, f"{dest_prefix}/{filename}", dry_run=dry_run)
+        all_ok = all_ok and ok
+
+    for filename in OPTIONAL_FILES:
+        src = run_dir / filename
+        if not src.is_file():
+            logger.warning("Optional file missing, skipping: %s", src)
+            continue
+        ok = gsutil_cp(src, f"{dest_prefix}/{filename}", dry_run=dry_run)
+        all_ok = all_ok and ok
+
+    eval_dir = run_dir / EVAL_SUBDIR
+    if eval_dir.is_dir() and any(eval_dir.iterdir()):
+        ok = gsutil_rsync(eval_dir, f"{dest_prefix}/{EVAL_SUBDIR}", dry_run=dry_run)
+        all_ok = all_ok and ok
+    else:
+        logger.warning("No eval outputs to upload for %s (missing or empty %s/)", run_dir, EVAL_SUBDIR)
+
+    return "uploaded" if all_ok else "failed"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--runs-file",
+        type=Path,
+        required=True,
+        help="Text file with one run directory path per line. '#' comments and blank lines are ignored.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the gsutil commands that would run without executing them.",
+    )
+    args = parser.parse_args()
+
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(message)s")
+    load_dotenv(REPO_ROOT / ".env")
+
+    if not args.runs_file.is_file():
+        logger.error("--runs-file does not exist: %s", args.runs_file)
+        return 2
+
+    try:
+        bucket, gcs_prefix, server_root = load_sync_outputs_mapping()
+    except (RuntimeError, FileNotFoundError, KeyError) as e:
+        logger.error("Failed to load sync config: %s", e)
+        return 2
+
+    if not bucket.startswith("gs://"):
+        logger.error("bucket in sync_config.yaml must start with gs:// (got %r)", bucket)
+        return 2
+
+    run_dirs = parse_runs_file(args.runs_file)
+    if not run_dirs:
+        logger.error("No run directories parsed from %s", args.runs_file)
+        return 2
+
+    counts = {"uploaded": 0, "skipped": 0, "failed": 0}
+    failures: list[Path] = []
+    for run in run_dirs:
+        result = upload_run(
+            run,
+            bucket=bucket,
+            gcs_prefix=gcs_prefix,
+            server_root=server_root,
+            dry_run=args.dry_run,
+        )
+        counts[result] += 1
+        if result == "failed":
+            failures.append(run)
+
+    print(f"\nDone. uploaded={counts['uploaded']} skipped={counts['skipped']} failed={counts['failed']}")
+    if failures:
+        print("Failed runs:")
+        for run in failures:
+            print(f"  {run}")
+
+    return 0 if counts["failed"] == 0 else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary
- Add bidirectional GCS sync script (`scripts/sync.py` + `scripts/sync_config.yaml`) for syncing data, tasks, model outputs, and MEDS cohorts between server, GCS, and local machines
- Add `src/every_query/upload_models.py` for selectively uploading run directories (checkpoints, configs, eval outputs) to GCS, with a corresponding SLURM batch script
- Add `scripts/upload_mimic_meds.sh` for uploading MIMIC MEDS cohort data to GCS

## Test plan
- [ ] Verify `python scripts/sync.py upload --dry-run` prints expected gsutil commands
- [ ] Verify `python scripts/sync.py download --dry-run` prints expected gsutil commands
- [ ] Verify `uv run python src/every_query/upload_models.py --runs-file scripts/upload_lists/example.txt --dry-run` works with a populated runs file
- [ ] Confirm existing tests still pass on CI