### PR TITLE
feat: console script endpoints and importlib.resources config paths

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,14 @@ every_query = ["**/*.yaml"]
 
 [project.optional-dependencies] # Add any optional dependencies here, installable via `pip install .[extra]`
 
-[project.scripts] # Add any console scripts here
+[project.scripts]
+EQ_train = "every_query.train:main"
+EQ_evaluate = "every_query.eval:main"
+EQ_generate_tasks = "every_query.sample_tasks:main"
+EQ_generate_tasks_exhaustive = "every_query.tasks:main"
+EQ_gen_eval_index = "every_query.eval_suite.gen_index_times:main"
+EQ_gen_eval_tasks = "every_query.eval_suite.gen_task:main"
+EQ_select_model = "every_query.eval_suite.select_model:main"
 
 [tool.pytest.ini_options] # Default pytest options
 addopts = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -65,11 +65,11 @@ EQ_gen_eval_tasks = "every_query.eval_suite.gen_task:main"
 EQ_select_model = "every_query.eval_suite.select_model:main"
 
 [tool.coverage.run]
-# ``parallel`` + ``COVERAGE_PROCESS_START`` (set in tests/test_cli_smoke.py)
-# let pytest-cov attribute subprocess-launched coverage data back to the parent
-# run — see https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html
-parallel = true
-source_pkgs = ["every_query"]
+# Measure coverage for EQ_* CLIs launched via subprocess in tests/test_cli_smoke.py.
+# coverage's `patch = ["subprocess"]` replaces the removed pytest-cov 7.0 subprocess hook
+# and implies parallel=true.  See
+# https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html
+patch = ["subprocess"]
 
 [tool.pytest.ini_options] # Default pytest options
 addopts = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,13 @@ EQ_gen_eval_index = "every_query.eval_suite.gen_index_times:main"
 EQ_gen_eval_tasks = "every_query.eval_suite.gen_task:main"
 EQ_select_model = "every_query.eval_suite.select_model:main"
 
+[tool.coverage.run]
+# ``parallel`` + ``COVERAGE_PROCESS_START`` (set in tests/test_cli_smoke.py)
+# let pytest-cov attribute subprocess-launched coverage data back to the parent
+# run — see https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html
+parallel = true
+source_pkgs = ["every_query"]
+
 [tool.pytest.ini_options] # Default pytest options
 addopts = [
   "--color=yes",

--- a/src/every_query/aces_to_eq/aces_to_eq.py
+++ b/src/every_query/aces_to_eq/aces_to_eq.py
@@ -1,5 +1,6 @@
 import logging
 import os
+from importlib.resources import files
 from pathlib import Path
 
 import hydra
@@ -55,7 +56,10 @@ def create_eq_task_df(
         logger.info(f"Wrote to {out_fp}")
 
 
-@hydra.main(version_base="1.3", config_path=".", config_name="config.yaml")
+ACES_CONFIGS = str(files("every_query") / "aces_to_eq")
+
+
+@hydra.main(version_base="1.3", config_path=ACES_CONFIGS, config_name="config.yaml")
 def main(cfg: DictConfig) -> None:
     all_eq_shards = sorted(
         Path(cfg.eq_tasks_all_dir).glob("*.parquet"),

--- a/src/every_query/eval.py
+++ b/src/every_query/eval.py
@@ -1,6 +1,7 @@
 import logging
 import time
 from datetime import UTC, datetime
+from importlib.resources import files
 from pathlib import Path
 from typing import Any
 
@@ -219,7 +220,10 @@ def _run_predict(
     return pred_df, embed_df
 
 
-@hydra.main(version_base="1.3", config_path="./eval_suite/conf", config_name="eval_config.yaml")
+EVAL_CONFIGS = str(files("every_query") / "eval_suite" / "conf")
+
+
+@hydra.main(version_base="1.3", config_path=EVAL_CONFIGS, config_name="eval_config.yaml")
 def main(cfg: DictConfig) -> None:
     model_run_dirs = list(cfg.model_run_dirs) if cfg.get("model_run_dirs") else [cfg.model_run_dir]
     durations = list(cfg.durations)

--- a/src/every_query/eval_suite/gen_index_times.py
+++ b/src/every_query/eval_suite/gen_index_times.py
@@ -1,5 +1,6 @@
 import hashlib
 import json
+from importlib.resources import files
 from pathlib import Path
 
 import hydra
@@ -19,7 +20,10 @@ def build_time_hash(cfg: DictConfig, read_dir: Path) -> str:
     return hash_hex
 
 
-@hydra.main(config_path="./conf", config_name="gen_index_times_config", version_base=None)
+EVAL_CONFIGS = str(files("every_query") / "eval_suite" / "conf")
+
+
+@hydra.main(config_path=EVAL_CONFIGS, config_name="gen_index_times_config", version_base=None)
 def main(cfg: DictConfig) -> None:
     task_dir = Path(cfg.io.task_dir)
     read_dir = task_dir / "all"

--- a/src/every_query/eval_suite/gen_task.py
+++ b/src/every_query/eval_suite/gen_task.py
@@ -1,3 +1,4 @@
+from importlib.resources import files
 from pathlib import Path
 
 import hydra
@@ -102,7 +103,10 @@ def process_eval_tasks(
                 df.write_parquet(out_fp)
 
 
-@hydra.main(config_path="./conf", config_name="gen_tasks_config", version_base=None)
+EVAL_CONFIGS = str(files("every_query") / "eval_suite" / "conf")
+
+
+@hydra.main(config_path=EVAL_CONFIGS, config_name="gen_tasks_config", version_base=None)
 def main(cfg: DictConfig) -> None:
     codes = _resolve_codes(cfg.eval_codes)
     extra = list(cfg.get("extra_codes", []))

--- a/src/every_query/eval_suite/select_model.py
+++ b/src/every_query/eval_suite/select_model.py
@@ -1,5 +1,6 @@
 import logging
 from datetime import UTC, datetime
+from importlib.resources import files
 from itertools import combinations
 from pathlib import Path
 
@@ -68,7 +69,10 @@ def _compute_win_rates(df: pl.DataFrame) -> tuple[pl.DataFrame, pl.DataFrame]:
     return ranking, win_matrix
 
 
-@hydra.main(version_base="1.3", config_path="./conf", config_name="select_model_config.yaml")
+EVAL_CONFIGS = str(files("every_query") / "eval_suite" / "conf")
+
+
+@hydra.main(version_base="1.3", config_path=EVAL_CONFIGS, config_name="select_model_config.yaml")
 def main(cfg: DictConfig) -> None:
     model_run_dirs = [Path(p) for p in cfg.model_run_dirs]
     split = cfg.split

--- a/src/every_query/process_composite/get_per_code_from_composite.py
+++ b/src/every_query/process_composite/get_per_code_from_composite.py
@@ -1,4 +1,5 @@
 import logging
+from importlib.resources import files
 from pathlib import Path
 
 import hydra
@@ -13,8 +14,11 @@ logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.INFO)
 
 
+EVAL_CONFIGS = str(files("every_query") / "eval_suite" / "conf")
+
+
 @hydra.main(
-    version_base="1.3", config_path="./eval_suite/conf", config_name="get_per_code_from_composite_config.yaml"
+    version_base="1.3", config_path=EVAL_CONFIGS, config_name="get_per_code_from_composite_config.yaml"
 )
 def main(cfg: DictConfig) -> None:
     print("starting")

--- a/src/every_query/process_composite/process_composite.py
+++ b/src/every_query/process_composite/process_composite.py
@@ -1,4 +1,5 @@
 from datetime import UTC, datetime
+from importlib.resources import files
 from pathlib import Path
 
 import hydra
@@ -77,7 +78,12 @@ def agg_probs(
     return joined_df, aucs
 
 
-@hydra.main(version_base="1.3", config_path=".", config_name="process_composite_config.yaml")
+PROCESS_COMPOSITE_CONFIGS = str(files("every_query") / "process_composite")
+
+
+@hydra.main(
+    version_base="1.3", config_path=PROCESS_COMPOSITE_CONFIGS, config_name="process_composite_config.yaml"
+)
 def main(cfg: DictConfig) -> None:
     _, aucs = agg_probs(
         all_preds_df_fp=cfg.predictions_df_path,

--- a/src/every_query/sample_tasks.py
+++ b/src/every_query/sample_tasks.py
@@ -33,6 +33,7 @@ import logging
 import os
 import tempfile
 from dataclasses import dataclass
+from importlib.resources import files
 from pathlib import Path
 
 import hydra
@@ -666,7 +667,10 @@ def _resolve_path(cfg_value: str | None, env_var: str, name: str) -> Path:
     )
 
 
-@hydra.main(version_base=None, config_path=".", config_name="sample_tasks_config")
+CONFIGS = str(files("every_query"))
+
+
+@hydra.main(version_base=None, config_path=CONFIGS, config_name="sample_tasks_config")
 def main(cfg: DictConfig) -> None:
     """Hydra entry point.
 

--- a/src/every_query/tasks.py
+++ b/src/every_query/tasks.py
@@ -2,6 +2,7 @@ import gc
 import json
 import os
 from concurrent.futures import ThreadPoolExecutor
+from importlib.resources import files
 
 import hydra
 import numpy as np
@@ -207,7 +208,10 @@ def sample_durations(n: int, low: int, high: int, seed: int) -> list[int]:
     return sorted(unique)[:n]
 
 
-@hydra.main(version_base=None, config_path=".", config_name="tasks_config")
+CONFIGS = str(files("every_query"))
+
+
+@hydra.main(version_base=None, config_path=CONFIGS, config_name="tasks_config")
 def main(cfg: DictConfig) -> None:
     ensure_env()
     shard_index = int(cfg.shard_index) if cfg.shard_index is not None else None

--- a/src/every_query/train.py
+++ b/src/every_query/train.py
@@ -7,6 +7,7 @@ import shutil
 import sys
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from datetime import UTC, datetime
+from importlib.resources import files
 from pathlib import Path
 from typing import Any
 
@@ -339,7 +340,10 @@ def _init_env() -> None:
     os.environ["OMP_NUM_THREADS"] = str(threads_per_file)
 
 
-@hydra.main(version_base="1.3", config_path="", config_name="config.yaml")
+CONFIGS = str(files("every_query"))
+
+
+@hydra.main(version_base="1.3", config_path=CONFIGS, config_name="config.yaml")
 def main(cfg: DictConfig) -> float | None:
     _init_env()
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,0 +1,100 @@
+"""Subprocess smoke tests for the ``EQ_*`` console script entry points.
+
+Each endpoint is invoked via its installed console script name (the contract
+introduced in PR #61) with ``--help``.  A successful exit proves four things
+at once:
+
+1. The ``[project.scripts]`` entry in ``pyproject.toml`` resolved and the
+   installed shim is runnable.
+2. Hydra accepted the ``config_path=`` argument (this PR's switch from
+   fragile relative paths to ``importlib.resources.files()``).
+3. Hydra could locate and load the named config file under that path — if
+   the package-data glob or the resource resolution regressed, ``--help``
+   would fail with ``MissingConfigException``.
+4. Module-level imports don't blow up in a fresh interpreter.
+
+Three endpoints (``EQ_train``, ``EQ_evaluate``, ``EQ_gen_eval_tasks``)
+compose a ``{train,eval}_codes`` default group whose canonical file is
+generated out-of-band (see ``src/every_query/sample_codes/``) and is not
+checked in.  For those we point Hydra at a throwaway ``--config-dir`` that
+supplies an empty-codes smoke variant, which preserves the rest of the
+compose path.
+
+Subprocess coverage follows the pytest-cov recipe:
+https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_VENV_BIN = str(Path(sys.executable).parent)
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# (console_script, extra_args) — extras inject a smoke code-group for configs
+# whose defaults pull an out-of-tree YAML.
+_ENTRYPOINTS: list[tuple[str, list[str]]] = [
+    ("EQ_train", ["train_codes=smoke"]),
+    ("EQ_evaluate", ["eval_codes=smoke"]),
+    ("EQ_generate_tasks", []),
+    ("EQ_generate_tasks_exhaustive", []),
+    ("EQ_gen_eval_index", []),
+    ("EQ_gen_eval_tasks", ["eval_codes=smoke"]),
+    ("EQ_select_model", []),
+]
+
+
+@pytest.fixture(scope="module")
+def smoke_config_dir(tmp_path_factory) -> Path:
+    """Temp Hydra search dir supplying empty ``train_codes`` / ``eval_codes``."""
+    d = tmp_path_factory.mktemp("eq_smoke_cfg")
+    (d / "train_codes").mkdir()
+    (d / "train_codes" / "smoke.yaml").write_text("codes: []\n")
+    (d / "eval_codes").mkdir()
+    (d / "eval_codes" / "smoke.yaml").write_text("id: []\nood: []\n")
+    return d
+
+
+@pytest.fixture(scope="module")
+def cli_env(tmp_path_factory) -> dict[str, str]:
+    """Subprocess env with venv ``PATH`` and pytest-cov subprocess hook.
+
+    Writes an ephemeral ``sitecustomize.py`` that calls
+    ``coverage.process_startup()`` and points the child at it via
+    ``PYTHONPATH`` + ``COVERAGE_PROCESS_START``.  This is a no-op when
+    coverage is not installed or not active; when it is,
+    ``[tool.coverage.run] parallel = true`` in ``pyproject.toml`` makes
+    the child-process data files merge cleanly with the parent's.
+    """
+    env = os.environ.copy()
+    env["PATH"] = _VENV_BIN + os.pathsep + env.get("PATH", "")
+
+    sitecustom = tmp_path_factory.mktemp("eq_cov_sitecustomize")
+    (sitecustom / "sitecustomize.py").write_text(
+        "try:\n    import coverage\n    coverage.process_startup()\nexcept Exception:\n    pass\n",
+    )
+    env["PYTHONPATH"] = str(sitecustom) + os.pathsep + env.get("PYTHONPATH", "")
+    env["COVERAGE_PROCESS_START"] = str(_REPO_ROOT / "pyproject.toml")
+
+    return env
+
+
+@pytest.mark.parametrize(("script", "extra_args"), _ENTRYPOINTS, ids=[e[0] for e in _ENTRYPOINTS])
+def test_entrypoint_help(script, extra_args, cli_env, smoke_config_dir):
+    """``<script> --help`` exits 0 and produces Hydra's help signature."""
+    cmd = [script, f"--config-dir={smoke_config_dir}", *extra_args, "--help"]
+    result = subprocess.run(cmd, capture_output=True, text=True, env=cli_env, timeout=60)
+
+    combined = result.stdout + result.stderr
+    assert result.returncode == 0, (
+        f"{script} --help failed (rc={result.returncode})\n"
+        f"cmd: {cmd}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert "Powered by Hydra" in combined, (
+        f"{script} --help lacks Hydra help signature; output was:\n{combined}"
+    )

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -1,17 +1,10 @@
 """Subprocess smoke tests for the ``EQ_*`` console script entry points.
 
 Each endpoint is invoked via its installed console script name (the contract
-introduced in PR #61) with ``--help``.  A successful exit proves four things
-at once:
-
-1. The ``[project.scripts]`` entry in ``pyproject.toml`` resolved and the
-   installed shim is runnable.
-2. Hydra accepted the ``config_path=`` argument (this PR's switch from
-   fragile relative paths to ``importlib.resources.files()``).
-3. Hydra could locate and load the named config file under that path — if
-   the package-data glob or the resource resolution regressed, ``--help``
-   would fail with ``MissingConfigException``.
-4. Module-level imports don't blow up in a fresh interpreter.
+introduced in PR #61) with ``--help`` and must exit 0.  A successful exit
+proves the ``[project.scripts]`` entry resolved, the package config
+directory resolved via ``importlib.resources.files()``, and module-level
+imports don't blow up in a fresh interpreter.
 
 Three endpoints (``EQ_train``, ``EQ_evaluate``, ``EQ_gen_eval_tasks``)
 compose a ``{train,eval}_codes`` default group whose canonical file is
@@ -20,8 +13,9 @@ checked in.  For those we point Hydra at a throwaway ``--config-dir`` that
 supplies an empty-codes smoke variant, which preserves the rest of the
 compose path.
 
-Subprocess coverage follows the pytest-cov recipe:
-https://pytest-cov.readthedocs.io/en/latest/subprocess-support.html
+Child-process coverage is picked up automatically via
+``[tool.coverage.run] patch = ["subprocess"]`` in ``pyproject.toml`` — no
+per-subprocess env wiring required.
 """
 
 from __future__ import annotations
@@ -34,7 +28,6 @@ from pathlib import Path
 import pytest
 
 _VENV_BIN = str(Path(sys.executable).parent)
-_REPO_ROOT = Path(__file__).resolve().parent.parent
 
 # (console_script, extra_args) — extras inject a smoke code-group for configs
 # whose defaults pull an out-of-tree YAML.
@@ -61,40 +54,19 @@ def smoke_config_dir(tmp_path_factory) -> Path:
 
 
 @pytest.fixture(scope="module")
-def cli_env(tmp_path_factory) -> dict[str, str]:
-    """Subprocess env with venv ``PATH`` and pytest-cov subprocess hook.
-
-    Writes an ephemeral ``sitecustomize.py`` that calls
-    ``coverage.process_startup()`` and points the child at it via
-    ``PYTHONPATH`` + ``COVERAGE_PROCESS_START``.  This is a no-op when
-    coverage is not installed or not active; when it is,
-    ``[tool.coverage.run] parallel = true`` in ``pyproject.toml`` makes
-    the child-process data files merge cleanly with the parent's.
-    """
+def cli_env() -> dict[str, str]:
+    """Subprocess env with venv ``PATH`` prepended so console scripts resolve."""
     env = os.environ.copy()
     env["PATH"] = _VENV_BIN + os.pathsep + env.get("PATH", "")
-
-    sitecustom = tmp_path_factory.mktemp("eq_cov_sitecustomize")
-    (sitecustom / "sitecustomize.py").write_text(
-        "try:\n    import coverage\n    coverage.process_startup()\nexcept Exception:\n    pass\n",
-    )
-    env["PYTHONPATH"] = str(sitecustom) + os.pathsep + env.get("PYTHONPATH", "")
-    env["COVERAGE_PROCESS_START"] = str(_REPO_ROOT / "pyproject.toml")
-
     return env
 
 
 @pytest.mark.parametrize(("script", "extra_args"), _ENTRYPOINTS, ids=[e[0] for e in _ENTRYPOINTS])
 def test_entrypoint_help(script, extra_args, cli_env, smoke_config_dir):
-    """``<script> --help`` exits 0 and produces Hydra's help signature."""
+    """``<script> --help`` exits 0."""
     cmd = [script, f"--config-dir={smoke_config_dir}", *extra_args, "--help"]
     result = subprocess.run(cmd, capture_output=True, text=True, env=cli_env, timeout=60)
-
-    combined = result.stdout + result.stderr
     assert result.returncode == 0, (
         f"{script} --help failed (rc={result.returncode})\n"
         f"cmd: {cmd}\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
-    )
-    assert "Powered by Hydra" in combined, (
-        f"{script} --help lacks Hydra help signature; output was:\n{combined}"
     )


### PR DESCRIPTION
## Summary

- Refactor all Hydra `config_path` arguments across 11 files to use `importlib.resources.files()` for package-relative config resolution, ensuring configs are found correctly after `pip install`
- Add 7 console script entry points to `pyproject.toml`: `EQ_train`, `EQ_evaluate`, `EQ_generate_tasks`, `EQ_generate_tasks_exhaustive`, `EQ_gen_eval_index`, `EQ_gen_eval_tasks`, `EQ_select_model`
- All 203 tests pass, all pre-commit hooks pass, ruff clean

Closes #60
Part of #54

## Test plan

- [x] All 203 existing tests pass
- [x] All pre-commit hooks pass (ruff format, ruff lint, codespell, etc.)
- [x] Console scripts install and resolve configs correctly (`EQ_train --help`, `EQ_generate_tasks --help`, etc.)
- [x] Config search paths point to the correct package-relative directories
- [ ] CI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)