### PR TITLE
chore: pin mdformat plugins in pre-commit config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -58,17 +58,21 @@ repos:
     hooks:
       - id: mdformat
         args: ["--number"]
+        # Pin every plugin — otherwise fresh pre-commit envs (e.g. CI) resolve the
+        # latest release at install time and silently produce different formatting
+        # than stale local caches.  mdformat-shfmt in particular changes how it
+        # indents bash inside fenced code blocks between versions.
         additional_dependencies:
-          - mdformat-ruff
-          - mdformat-gfm
-          - mdformat-gfm-alerts
-          - mdformat-tables
-          - mdformat_frontmatter
-          - mdformat-black
-          - mdformat-config
-          - mdformat-shfmt
-          - mdformat-mkdocs
-          - mdformat-toc
+          - mdformat-ruff==0.1.3
+          - mdformat-gfm==1.0.0
+          - mdformat-gfm-alerts==2.0.0
+          - mdformat-tables==1.0.0
+          - mdformat_frontmatter==2.0.10
+          - mdformat-black==0.1.1
+          - mdformat-config==0.2.1
+          - mdformat-shfmt==0.2.0
+          - mdformat-mkdocs==5.1.4
+          - mdformat-toc==0.5.0
 
   # word spelling linter
   - repo: https://github.com/codespell-project/codespell


### PR DESCRIPTION
## Summary

Fixes a latent flakiness that just surfaced on #69.

The top-level pre-commit hooks had \`rev:\` tags pinned, but mdformat's \`additional_dependencies\` were unpinned. Every fresh pre-commit env (every CI run — CI has no cache) resolved whatever was latest on PyPI at install time, while local caches stuck with older versions. On #69 this produced:

- Local: mdformat-shfmt left 4-space bash-block indentation alone (with a warning it couldn't format).
- CI: mdformat-shfmt reformatted the same blocks with tabs.

Result: CI's code-quality job failed on a file that pre-commit passed cleanly locally.

## What changed

Pinned every plugin in the mdformat \`additional_dependencies\` list to the version I currently have installed (verified via \`pre-commit clean && pre-commit install-hooks\` then inspecting \`~/.cache/pre-commit/.../site-packages/*.dist-info\`). Added a one-paragraph comment explaining why.

```diff
+        # Pin every plugin — otherwise fresh pre-commit envs (e.g. CI) resolve the
+        # latest release at install time and silently produce different formatting
+        # than stale local caches.  mdformat-shfmt in particular changes how it
+        # indents bash inside fenced code blocks between versions.
         additional_dependencies:
-          - mdformat-ruff
-          - mdformat-gfm
-          ...
+          - mdformat-ruff==0.1.3
+          - mdformat-gfm==1.0.0
+          ...
```

## Test plan

- [x] \`pre-commit clean && pre-commit run --all-files\` passes locally (all 20+ hooks green) with the pinned versions.
- [ ] CI green.

After merge, #69 gets rebased onto \`dev\` and re-run through pre-commit so the bash-block formatting matches what CI will now produce deterministically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)