### PR TITLE
chore: pin shfmt via shfmt-py in pre-commit mdformat hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -62,6 +62,12 @@ repos:
         # latest release at install time and silently produce different formatting
         # than stale local caches.  mdformat-shfmt in particular changes how it
         # indents bash inside fenced code blocks between versions.
+        #
+        # `shfmt-py` bundles the `shfmt` Go binary into the hook's venv bin dir so
+        # mdformat-shfmt finds it via subprocess.run(["shfmt"]).  Without this,
+        # mdformat-shfmt silently no-ops on machines lacking a system shfmt while
+        # CI (Ubuntu runners have shfmt via apt) actively reformats — producing
+        # local-pass / CI-fail drift on any markdown file with bash fenced blocks.
         additional_dependencies:
           - mdformat-ruff==0.1.3
           - mdformat-gfm==1.0.0
@@ -73,6 +79,7 @@ repos:
           - mdformat-shfmt==0.2.0
           - mdformat-mkdocs==5.1.4
           - mdformat-toc==0.5.0
+          - shfmt-py==3.12.0.2
 
   # word spelling linter
   - repo: https://github.com/codespell-project/codespell


### PR DESCRIPTION
## Summary

Follow-up to #70. That PR pinned the `mdformat` plugin versions but didn't fix the actual source of the local-pass / CI-fail drift that bit #69.

## The drift, for future me

`mdformat-shfmt`'s plugin shells out to a system `shfmt` binary:

```python
# mdformat_shfmt/__init__.py
for cmd in (["shfmt"], ["docker", "run", "..."], ["podman", "run", "..."]):
    try:
        result = subprocess.run(cmd, ...)
        break
    except FileNotFoundError:
        pass
else:
    raise Exception("No shfmt executable found")
```

Ubuntu CI runners have `shfmt` via apt. Dev laptops usually don't. When shfmt is missing, `mdformat_shfmt` raises → mdformat catches it → warning → bash block unchanged. Local passes; CI (with shfmt present) actively reformats; the `code-quality` job fails with a format diff on any markdown file containing a bash fenced block. #69 hit this after #70 pinned plugin versions — pinning didn't help because the binary wasn't part of the plugin.

## Fix

`shfmt-py` (https://pypi.org/project/shfmt-py/) is a PyPI wheel that bundles the shfmt Go binary and installs it into the consuming venv's `bin/`. Adding it to the `mdformat` hook's `additional_dependencies` guarantees the binary is in the hook's isolated venv wherever pre-commit runs — no system install required, no Docker fallback, no silent no-ops.

```diff
         additional_dependencies:
           - mdformat-ruff==0.1.3
           ...
           - mdformat-shfmt==0.2.0
           - mdformat-mkdocs==5.1.4
           - mdformat-toc==0.5.0
+          - shfmt-py==3.12.0.2
```

## Verification

After `pre-commit clean && pre-commit install-hooks`, the hook env has shfmt:

```
$ ls ~/.cache/pre-commit/*/py_env-python3.12/bin/shfmt
/home/mmd/.cache/pre-commit/repo7t4827bo/py_env-python3.12/bin/shfmt
$ ~/.cache/pre-commit/repo7t4827bo/py_env-python3.12/bin/shfmt --version
v3.12.0
```

`pre-commit run --all-files` passes (20+ hooks green) including `mdformat` on the post-#69 README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)