### PR TITLE
refactor: move derive_seed to utils.seeds (closes #52)

### DIFF
--- a/src/every_query/sample_tasks.py
+++ b/src/every_query/sample_tasks.py
@@ -27,7 +27,6 @@ Design decisions (see issue #33):
   the whole ``index_df`` against the events table, regardless of how many distinct codes are present.
 """
 
-import hashlib
 import json
 import logging
 import os
@@ -41,6 +40,8 @@ import numpy as np
 import polars as pl
 from omegaconf import DictConfig
 
+from every_query.utils.seeds import derive_seed
+
 logger = logging.getLogger(__name__)
 
 
@@ -50,34 +51,6 @@ class TaskSpec:
 
     code: str
     duration_days: int
-
-
-# ---------------------------------------------------------------------------
-# Seed derivation
-# ---------------------------------------------------------------------------
-
-
-def derive_seed(*parts: int | str) -> int:
-    """Stable 31-bit int seed derived from a tuple of ints/strings via blake2b.
-
-    Python's builtin ``hash`` is not stable across processes, so hydra multirun workers would draw
-    inconsistent samples.  Blake2b is cross-process stable and fast enough to be irrelevant at this scale.
-
-    Examples:
-        >>> derive_seed(1, "tasks", 0) == derive_seed(1, "tasks", 0)
-        True
-        >>> derive_seed(1, "tasks", 0) != derive_seed(1, "tasks", 1)
-        True
-        >>> derive_seed(1, "contexts", "shard_a", 0) != derive_seed(1, "contexts", "shard_b", 0)
-        True
-        >>> 0 <= derive_seed(1, "tasks", 0) < 2**31
-        True
-    """
-    h = hashlib.blake2b(digest_size=8)
-    for p in parts:
-        h.update(str(p).encode("utf-8"))
-        h.update(b"\x1f")  # unit separator to avoid prefix collisions
-    return int.from_bytes(h.digest(), "big") & 0x7FFFFFFF
 
 
 # ---------------------------------------------------------------------------

--- a/src/every_query/utils/seeds.py
+++ b/src/every_query/utils/seeds.py
@@ -1,0 +1,31 @@
+"""Deterministic, cross-process-stable seed derivation helpers."""
+
+import hashlib
+
+
+def derive_seed(*parts: int | str) -> int:
+    """Stable 31-bit int seed derived from a tuple of ints/strings via blake2b.
+
+    Python's builtin ``hash`` is not stable across processes (uses a random per-interpreter salt),
+    so Hydra multirun workers would draw inconsistent samples if their seeds depended on
+    ``hash((seed, "tasks", shard_id))``.  Blake2b is cross-process stable and fast enough to be
+    irrelevant at this scale.
+
+    The ``0x7FFFFFFF`` mask keeps the result inside NumPy's legal 31-bit seed range so the return
+    value can be passed directly to ``np.random.default_rng(...)`` without further narrowing.
+
+    Examples:
+        >>> derive_seed(1, "tasks", 0) == derive_seed(1, "tasks", 0)
+        True
+        >>> derive_seed(1, "tasks", 0) != derive_seed(1, "tasks", 1)
+        True
+        >>> derive_seed(1, "contexts", "shard_a", 0) != derive_seed(1, "contexts", "shard_b", 0)
+        True
+        >>> 0 <= derive_seed(1, "tasks", 0) < 2**31
+        True
+    """
+    h = hashlib.blake2b(digest_size=8)
+    for p in parts:
+        h.update(str(p).encode("utf-8"))
+        h.update(b"\x1f")  # unit separator to avoid prefix collisions
+    return int.from_bytes(h.digest(), "big") & 0x7FFFFFFF

--- a/tests/test_sample_tasks.py
+++ b/tests/test_sample_tasks.py
@@ -29,12 +29,12 @@ from every_query.sample_tasks import (
     TaskSpec,
     build_index_df,
     compute_max_time_per_subject,
-    derive_seed,
     evaluate_index_df,
     run_worker,
     sample_contexts,
     sample_tasks,
 )
+from every_query.utils.seeds import derive_seed
 
 # ---------------------------------------------------------------------------
 # Shared synthetic fixtures


### PR DESCRIPTION
## Summary

Moves `derive_seed` from `every_query.sample_tasks` to `every_query.utils.seeds`. It's a general-purpose blake2b-based "tuple of (int|str) → stable 31-bit int" helper, not task-sampling-specific — other modules that need cross-process-stable seeding (context sampling, data splitting, eval-time index generation) can now import it without a misleading dep on `sample_tasks`.

Closes #52.

## Why not use something from stdlib/numpy instead?

Considered and ruled out:
- Python's `hash()` — not cross-process stable (random per-interpreter salt), which defeats the whole point (Hydra multirun workers would draw inconsistent samples).
- `numpy.random.SeedSequence` — the modern canonical entropy-spawning API, but it takes an *integer* entropy input, so you'd still need a function like `derive_seed` to turn a `(seed, "tasks", shard_id)` tuple into that int.
- `xxhash` / `mmh3` — would work but adding a dep for an 8-line helper is overkill.

The blake2b tuple-hash is the right pattern for this use case.

## Import-path change

Before:
```python
from every_query.sample_tasks import derive_seed
```

After:
```python
from every_query.utils.seeds import derive_seed
```

Follows the existing `every_query.utils.codes` pattern (full path, empty `utils/__init__.py`).

## Test plan

- [x] `pytest tests/ src/` — 232 passed (no regressions); `derive_seed`'s doctest runs from its new module home.
- [x] `pre-commit run --all-files` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
