### PR TITLE
fix(train): preserve config.yaml across do_overwrite re-runs (closes #31)

### DIFF
--- a/src/every_query/train.py
+++ b/src/every_query/train.py
@@ -230,12 +230,12 @@ def main(cfg: DictConfig) -> float | None:
             )
 
     # Ensure output_dir exists *after* any overwrite rmtree above, then write the config for this
-    # run.  On resume we keep the original run's config untouched so the resumed run stays
-    # bit-identical to the first.  On overwrite the previous rmtree wiped the old config; writing
-    # it here restores reproducibility for any downstream tool (e.g. ``eval.py`` loads
-    # ``resolved_config.yaml`` from the run dir).  Fixes #31.
+    # run.  On resume (without overwrite) we keep the original run's config untouched so the
+    # resumed run stays bit-identical to the first.  On overwrite the previous rmtree wiped the
+    # old config; writing it here restores reproducibility for any downstream tool (e.g.
+    # ``eval.py`` loads ``resolved_config.yaml`` from the run dir).  Fixes #31.
     os.makedirs(output_dir, exist_ok=True)
-    if not cfg.do_resume:
+    if not cfg.do_resume or cfg.do_overwrite:
         OmegaConf.save(cfg, output_dir / "config.yaml")
         save_resolved_config(cfg, output_dir / "resolved_config.yaml")
 

--- a/src/every_query/train.py
+++ b/src/every_query/train.py
@@ -213,7 +213,6 @@ def main(cfg: DictConfig) -> float | None:
     output_dir = Path(cfg.output_dir)
     if output_dir.is_file():
         raise NotADirectoryError(f"Output directory {output_dir} is a file, not a directory.")
-    os.makedirs(output_dir, exist_ok=True)
 
     cfg_path = output_dir / "config.yaml"
     ckpt_path = None
@@ -229,7 +228,14 @@ def main(cfg: DictConfig) -> float | None:
                 f"Output directory {output_dir} already exists and is populated. "
                 "Use `do_overwrite` or `do_resume` to proceed."
             )
-    else:
+
+    # Ensure output_dir exists *after* any overwrite rmtree above, then write the config for this
+    # run.  On resume we keep the original run's config untouched so the resumed run stays
+    # bit-identical to the first.  On overwrite the previous rmtree wiped the old config; writing
+    # it here restores reproducibility for any downstream tool (e.g. ``eval.py`` loads
+    # ``resolved_config.yaml`` from the run dir).  Fixes #31.
+    os.makedirs(output_dir, exist_ok=True)
+    if not cfg.do_resume:
         OmegaConf.save(cfg, output_dir / "config.yaml")
         save_resolved_config(cfg, output_dir / "resolved_config.yaml")
 

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -122,3 +122,42 @@ class TestTrainResume:
 
     def test_best_model_present_after_resume(self, resumed_output):
         assert (resumed_output / "best_model.ckpt").is_file()
+
+
+class TestTrainOverwriteReRun:
+    """Re-running ``EQ_train`` with ``do_overwrite=True`` into a populated output_dir must leave a readable
+    ``config.yaml`` + ``resolved_config.yaml`` behind.
+
+    Regression guard for #31: the
+    pre-fix code wiped the dir via ``shutil.rmtree`` but only re-saved the config on the fresh-dir
+    branch, so overwrite re-runs silently produced runs that downstream tools (notably
+    ``eval.py``, which loads ``resolved_config.yaml``) couldn't inspect.
+    """
+
+    @pytest.fixture(scope="class")
+    def overwrite_output(self, task_labels_dir, tensorized_cohort_dir, tmp_path_factory) -> Path:
+        output_dir = tmp_path_factory.mktemp("cli_overwrite")
+
+        first = _run_train_subprocess(task_labels_dir, tensorized_cohort_dir, output_dir)
+        assert first.returncode == 0, (
+            f"Initial training failed (rc={first.returncode}).\nstderr:\n{first.stderr}"
+        )
+        assert (output_dir / "config.yaml").is_file()
+
+        overwritten = _run_train_subprocess(
+            task_labels_dir,
+            tensorized_cohort_dir,
+            output_dir,
+            do_overwrite=True,
+            do_resume=False,
+        )
+        assert overwritten.returncode == 0, (
+            f"Overwrite re-run failed (rc={overwritten.returncode}).\nstderr:\n{overwritten.stderr}"
+        )
+        return output_dir
+
+    def test_config_yaml_present_after_overwrite(self, overwrite_output):
+        assert (overwrite_output / "config.yaml").is_file()
+
+    def test_resolved_config_yaml_present_after_overwrite(self, overwrite_output):
+        assert (overwrite_output / "resolved_config.yaml").is_file()

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -161,3 +161,43 @@ class TestTrainOverwriteReRun:
 
     def test_resolved_config_yaml_present_after_overwrite(self, overwrite_output):
         assert (overwrite_output / "resolved_config.yaml").is_file()
+
+
+class TestTrainOverwriteAndResumeBothTrue:
+    """When ``do_overwrite=True`` AND ``do_resume=True`` are set together, the warning at the top of ``main``
+    documents that *overwrite wins* and the directory is cleared.
+
+    Config-writing should
+    therefore also behave as if we were overwriting — not silently skipped the way a pure resume
+    would do.  Without the ``cfg.do_overwrite`` guard on the save, this combination produces an
+    output dir whose config.yaml was wiped and never rewritten.  Regression guard for the edge
+    case caught in Copilot's review of #31.
+    """
+
+    @pytest.fixture(scope="class")
+    def both_flags_output(self, task_labels_dir, tensorized_cohort_dir, tmp_path_factory) -> Path:
+        output_dir = tmp_path_factory.mktemp("cli_both_flags")
+
+        first = _run_train_subprocess(task_labels_dir, tensorized_cohort_dir, output_dir)
+        assert first.returncode == 0, (
+            f"Initial training failed (rc={first.returncode}).\nstderr:\n{first.stderr}"
+        )
+
+        # Both flags simultaneously — overwrite should win (the warning at the top of main() says so).
+        both = _run_train_subprocess(
+            task_labels_dir,
+            tensorized_cohort_dir,
+            output_dir,
+            do_overwrite=True,
+            do_resume=True,
+        )
+        assert both.returncode == 0, (
+            f"Run with do_overwrite=do_resume=True failed (rc={both.returncode}).\nstderr:\n{both.stderr}"
+        )
+        return output_dir
+
+    def test_config_yaml_present_after_both_flags(self, both_flags_output):
+        assert (both_flags_output / "config.yaml").is_file()
+
+    def test_resolved_config_yaml_present_after_both_flags(self, both_flags_output):
+        assert (both_flags_output / "resolved_config.yaml").is_file()


### PR DESCRIPTION
## Summary

`EQ_train` used to wipe `config.yaml` without re-saving it whenever `do_overwrite=True` ran against a populated output dir. Downstream tools (most visibly `eval.py`, which loads `resolved_config.yaml` from `model_run_dir`) would then fail or — worse — silently consume a stale config from a different run.

Closes #31.

## Fix

Move `os.makedirs(output_dir, exist_ok=True)` + the `OmegaConf.save` + `save_resolved_config` calls outside the `cfg_path.exists()` branch, so the config is always (re-)written after the output dir is known-good, unless `do_resume=True` (where we intentionally preserve the original run's config to keep the resume bit-identical).

## Test plan

- [x] New `TestTrainOverwriteReRun` in `tests/test_train_cli.py` runs `EQ_train` once, then again with `do_overwrite=True` into the same output_dir, asserts both `config.yaml` and `resolved_config.yaml` exist at the end.
- [x] `pytest tests/ src/` — 187 passed (was 185 + 2 new).
- [x] `pre-commit run --all-files` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
