### PR TITLE
test(eval): doctest _collect_codes with None buckets (closes #32)

### DIFF
--- a/src/every_query/eval.py
+++ b/src/every_query/eval.py
@@ -71,7 +71,43 @@ def _model_name(model_run_dir: str) -> str:
 
 
 def _collect_codes(cfg: DictConfig) -> tuple[list[str], dict[str, str]]:
-    """Combine id/ood/manual codes into a flat list plus a code→bucket map."""
+    """Combine id/ood/manual codes into a flat list plus a code→bucket map.
+
+    Any of ``id_codes``, ``ood_codes``, ``manual_codes`` may be ``None`` or omitted —
+    `None` is treated as an empty list (regression guard for #32, where
+    ``code in cfg.ood_codes`` crashed with ``TypeError: argument of type 'NoneType' is not
+    iterable`` for eval configs that legitimately had no OOD bucket).
+
+    Examples:
+        >>> from omegaconf import OmegaConf
+        >>> codes, bucket = _collect_codes(OmegaConf.create(
+        ...     {"id_codes": ["A", "B"], "ood_codes": ["X"], "manual_codes": ["M"]}
+        ... ))
+        >>> codes
+        ['A', 'B', 'X', 'M']
+        >>> bucket == {"A": "id", "B": "id", "X": "ood", "M": "manual"}
+        True
+
+        ``None`` for any bucket is silently treated as empty:
+
+        >>> codes, bucket = _collect_codes(OmegaConf.create(
+        ...     {"id_codes": ["A"], "ood_codes": None, "manual_codes": None}
+        ... ))
+        >>> codes
+        ['A']
+        >>> bucket
+        {'A': 'id'}
+
+        Duplicates across buckets keep the first-seen bucket label:
+
+        >>> codes, bucket = _collect_codes(OmegaConf.create(
+        ...     {"id_codes": ["A"], "ood_codes": ["A", "B"], "manual_codes": None}
+        ... ))
+        >>> codes
+        ['A', 'B']
+        >>> bucket == {"A": "id", "B": "ood"}
+        True
+    """
     codes: list[str] = []
     bucket: dict[str, str] = {}
     for c in cfg.id_codes or []:

--- a/src/every_query/eval.py
+++ b/src/every_query/eval.py
@@ -73,10 +73,15 @@ def _model_name(model_run_dir: str) -> str:
 def _collect_codes(cfg: DictConfig) -> tuple[list[str], dict[str, str]]:
     """Combine id/ood/manual codes into a flat list plus a code→bucket map.
 
-    Any of ``id_codes``, ``ood_codes``, ``manual_codes`` may be ``None`` or omitted —
-    `None` is treated as an empty list (regression guard for #32, where
-    ``code in cfg.ood_codes`` crashed with ``TypeError: argument of type 'NoneType' is not
-    iterable`` for eval configs that legitimately had no OOD bucket).
+    Any of ``id_codes``, ``ood_codes``, ``manual_codes`` may be ``None`` — ``None`` is treated as
+    an empty list (regression guard for #32, where ``code in cfg.ood_codes`` crashed with
+    ``TypeError: argument of type 'NoneType' is not iterable`` for eval configs that legitimately
+    had no OOD bucket).
+
+    Note: a key that is entirely *missing* from the ``DictConfig`` (as opposed to present with
+    value ``None``) raises ``ConfigAttributeError`` at the ``cfg.<key>`` access.  Hydra callers
+    typically end up with ``None`` rather than a missing key because the shipped config files
+    declare all three fields, so in practice the ``or []`` guard is sufficient.
 
     Examples:
         >>> from omegaconf import OmegaConf
@@ -88,7 +93,7 @@ def _collect_codes(cfg: DictConfig) -> tuple[list[str], dict[str, str]]:
         >>> bucket == {"A": "id", "B": "id", "X": "ood", "M": "manual"}
         True
 
-        ``None`` for any bucket is silently treated as empty:
+        Each of the three buckets is independently guarded against ``None``:
 
         >>> codes, bucket = _collect_codes(OmegaConf.create(
         ...     {"id_codes": ["A"], "ood_codes": None, "manual_codes": None}
@@ -97,6 +102,14 @@ def _collect_codes(cfg: DictConfig) -> tuple[list[str], dict[str, str]]:
         ['A']
         >>> bucket
         {'A': 'id'}
+
+        >>> codes, bucket = _collect_codes(OmegaConf.create(
+        ...     {"id_codes": None, "ood_codes": ["X"], "manual_codes": None}
+        ... ))
+        >>> codes
+        ['X']
+        >>> bucket
+        {'X': 'ood'}
 
         Duplicates across buckets keep the first-seen bucket label:
 


### PR DESCRIPTION
## Summary

Issue #32 reported that `_run_test`'s `code in cfg.ood_codes` could crash with `TypeError: argument of type 'NoneType' is not iterable` when an eval config legitimately had no OOD bucket. An earlier refactor (the one that introduced `_collect_codes`) already fixed the use sites by switching to `cfg.X_codes or []`. This PR locks that behavior in with a doctest.

Closes #32.

## What changed

- Added a doctest block to `_collect_codes` covering: (a) all three buckets populated, (b) `ood_codes` / `manual_codes = None`, (c) duplicates across buckets (first-seen bucket label wins).

No functional change. This is a regression guard so a future refactor can't silently drop the `or []` defaults.

## Test plan

- [x] `pytest src/every_query/eval.py` — 1 passed (the new doctest).
- [x] Full suite still green.
- [x] `pre-commit run --all-files` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
