### PR TITLE
Scaffold paper_experiments/ submodule (closes #84)

### DIFF
--- a/src/every_query/paper_experiments/README.md
+++ b/src/every_query/paper_experiments/README.md
@@ -1,0 +1,31 @@
+# `paper_experiments/`
+
+Home for code that reproduces the specific experiments we run for the EveryQuery paper — things external users would never do in normal model usage, but we need to produce figures, ablations, and generalization claims.
+
+> [!IMPORTANT]
+> This is a **research-intent** split, not a packaging one. Code here is still shipped on PyPI, still tested, still pre-commit-linted, still importable as `every_query.paper_experiments.*`. The separation is about *purpose*, so the normal-usage pipeline stays obvious.
+
+## What belongs here
+
+Concrete examples of paper-experiments code:
+
+- **ID-vs-OOD code-list generation.** Sampling the code universe into "in-distribution" and "out-of-distribution" splits to assess the model's generalization to never-queried codes. External users would simply train on all codes of interest — holding codes out is a research claim, not a deployment pattern.
+- **Duration-ablation sweeps.** Evaluating the same model against the same tasks at many horizon lengths to characterize how probability calibration changes with `duration_days`. Not something a downstream user would run for a single deployment decision.
+- **Cross-model leaderboards.** Pairwise win-rate ranking across multiple trained variants to produce comparison tables for the paper.
+- **Figure/plot code.** Matplotlib / seaborn scripts that turn the outputs of the above into paper-ready PNGs/PDFs.
+
+## What does **not** belong here
+
+Anything on the normal-usage path: `preprocessing/`, `prepare_tasks/`, `pretrain/`, `predict/`, `evaluate/`. Those submodules are what any external user touches when running EveryQuery on their own cohort, and they should stay obviously separate from paper-only tooling.
+
+Cluster-specific operator tooling (SLURM submit wrappers, GCS upload scripts) also doesn't live here — that category already left the repo in [#77](https://github.com/payalchandak/EveryQuery/pull/77).
+
+## Optional dependencies
+
+If a specific experiment needs heavyweight plotting deps (matplotlib, seaborn, plotly), those go under `[project.optional-dependencies].paper` in `pyproject.toml` rather than polluting the core install. Parked until we see the real dep footprint.
+
+## Related
+
+- Parent refactor umbrella: [#54](https://github.com/payalchandak/EveryQuery/issues/54)
+- Planned `sample_codes/` move into here: [#85](https://github.com/payalchandak/EveryQuery/issues/85)
+- Plan context for this split: [refactor plan v3](https://github.com/payalchandak/EveryQuery/issues/54#issuecomment-4271122440)

--- a/src/every_query/paper_experiments/__init__.py
+++ b/src/every_query/paper_experiments/__init__.py
@@ -1,0 +1,4 @@
+"""Paper-experiments submodule.
+
+See ``README.md`` for what belongs here versus the normal-usage pipeline.
+"""


### PR DESCRIPTION
## Summary

Stands up `src/every_query/paper_experiments/` as an empty submodule with a README explaining its purpose. No code moves in this PR.

Closes #84. Prerequisite for #85 (move `sample_codes/` in) and for any `eval_suite/` operations classified as paper-experiments in #82 (inventory).

## Why a dedicated submodule

Research-intent split: things external users would never do in normal model usage (ID/OOD generalization studies, duration ablations, cross-model leaderboards, figure code) vs. the normal `preprocess → prepare-tasks → pretrain → predict → evaluate` flow. Same CI / pre-commit / tests / PyPI coverage as any other submodule — this is an organizational move only.

Full framing on [refactor plan v3](https://github.com/payalchandak/EveryQuery/issues/54#issuecomment-4271122440).

## What lands

- `src/every_query/paper_experiments/__init__.py` (minimal docstring)
- `src/every_query/paper_experiments/README.md` (what belongs here vs. normal pipeline, optional-deps story, related-issue links)

## What does not land

- No existing code moves in — `sample_codes/` migration is tracked in #85.
- No new `[project.optional-dependencies].paper` group — deferred until we see actual plotting-dep needs.

## Test plan

- [x] `pytest tests/ src/` — 185 passed (unchanged).
- [x] `pre-commit run --all-files` — clean.
- [x] `python -c "import every_query.paper_experiments"` resolves (the submodule is on the install path via `[tool.setuptools.packages.find] where=["src"]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
