### PR TITLE
fix: mark query.codes as ??? in config.yaml (replaces #88, refs #64)

### DIFF
--- a/src/every_query/config.yaml
+++ b/src/every_query/config.yaml
@@ -1,6 +1,5 @@
 defaults:
   - _self_
-  - train_codes: 10000_ID__8db2be6fadf8
 
 output_dir: ${oc.env:OUTPUT_DIR}/${run_id:}/
 do_overwrite: true
@@ -8,7 +7,11 @@ do_resume: false
 seed: 140799
 
 query:
-  codes: ${train_codes.codes}
+  # Required: the list of query codes to train on.  Pass either
+  #   - inline on the CLI: EQ_train query.codes=[A,B,C]
+  #   - via a user config: EQ_train --config-dir=$MY_CFG --config-name=my_train_config
+  # (where my_train_config.yaml sets query.codes).  See #64.
+  codes: ???
 
 datamodule:
   _target_: meds_torchdata.extensions.lightning_datamodule.Datamodule
@@ -63,8 +66,8 @@ trainer:
     prefix: "" # a string to put at the beginning of metric keys
     entity: ${oc.env:WANDB_ENTITY}
     config:
-      query_codes: ${train_codes.codes}
-      num_query_codes: ${list_len:${train_codes.codes}}
+      query_codes: ${query.codes}
+      num_query_codes: ${list_len:${query.codes}}
   callbacks:
     _target_: __main__.values_as_list
     learning_rate_monitor:

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -6,11 +6,11 @@ proves the ``[project.scripts]`` entry resolved, the package config
 directory resolved via ``importlib.resources.files()``, and module-level
 imports don't blow up in a fresh interpreter.
 
-Three endpoints (``EQ_train``, ``EQ_evaluate``, ``EQ_gen_eval_tasks``) compose a
-``{train,eval}_codes`` default group whose canonical file is generated out-of-band
-(see ``src/every_query/sample_codes/``) and is not checked in.  For those we point
-Hydra at a throwaway ``--config-dir`` that supplies an empty-codes smoke variant,
-which preserves the rest of the compose path.
+``EQ_train`` declares ``query.codes: ???`` (mandatory) in its shipped config so users
+are forced to supply codes explicitly.  The smoke tests override the marker with an
+empty list via ``query.codes=[]``.  The two eval endpoints still compose an
+``eval_codes`` group (will be restructured as part of Phase 2 of #54); for those we
+point Hydra at a throwaway ``--config-dir`` supplying an empty-codes smoke variant.
 
 Child-process coverage is picked up automatically via
 ``[tool.coverage.run] patch = ["subprocess"]`` in ``pyproject.toml`` — no
@@ -31,7 +31,7 @@ _VENV_BIN = str(Path(sys.executable).parent)
 # (console_script, extra_args) — extras inject a smoke code-group for configs
 # whose defaults pull an out-of-tree YAML.
 _ENTRYPOINTS: list[tuple[str, list[str]]] = [
-    ("EQ_train", ["train_codes=smoke"]),
+    ("EQ_train", ["query.codes=[]"]),
     ("EQ_evaluate", ["eval_codes=smoke"]),
     ("EQ_generate_tasks", []),
     ("EQ_gen_eval_index", []),
@@ -42,10 +42,8 @@ _ENTRYPOINTS: list[tuple[str, list[str]]] = [
 
 @pytest.fixture(scope="module")
 def smoke_config_dir(tmp_path_factory) -> Path:
-    """Temp Hydra search dir supplying empty ``train_codes`` / ``eval_codes``."""
+    """Temp Hydra search dir supplying an empty ``eval_codes`` compose group."""
     d = tmp_path_factory.mktemp("eq_smoke_cfg")
-    (d / "train_codes").mkdir()
-    (d / "train_codes" / "smoke.yaml").write_text("codes: []\n")
     (d / "eval_codes").mkdir()
     (d / "eval_codes" / "smoke.yaml").write_text("id: []\nood: []\n")
     return d


### PR DESCRIPTION
## Summary

Narrower replacement for [PR #88](https://github.com/payalchandak/EveryQuery/pull/88) after @mmcdermott's feedback there. Uses `query.codes: ???` (Hydra's mandatory-value marker) instead of the `+train_codes=…` compose-group override, and scopes down to `config.yaml` only — the eval-suite configs are intentionally left for Phase 2 of #54 to restructure.

Refs #64.

## Changes

**`src/every_query/config.yaml`:**
- Drop `defaults: - train_codes: 10000_ID__8db2be6fadf8` (gitignored default that broke `EQ_train --help` on a fresh clone).
- `query.codes: ???` — Hydra errors loudly with "missing mandatory value" if the user forgets to pass them.
- `${train_codes.codes}` interpolations under `trainer.logger.config` (wandb metadata) repointed at `${query.codes}`, which is now the single source of truth.

**`tests/test_cli_smoke.py`:**
- `EQ_train` smoke override becomes `query.codes=[]` (inline, no `+` ceremony).
- `smoke_config_dir` fixture no longer writes a `train_codes/smoke.yaml` — only `eval_codes/` remains (still needed for the two eval endpoints, which will go away in Phase 2).

## What's deliberately not here

- `eval_config.yaml` and `gen_tasks_config.yaml` still carry their `eval_codes` compose group. Converting those to `???` is awkward because ID/OOD code splits are naturally bundled into a single named YAML. Per Phase 2 of the [#54 refactor plan](https://github.com/payalchandak/EveryQuery/issues/54#issuecomment-4271122440), the eval pipeline is getting consolidated into a new `EQ_evaluate` that will redefine the input shape entirely (#83). Touching those configs in this PR would be churn.

## Why this replaces #88

[@mmcdermott on PR #88](https://github.com/payalchandak/EveryQuery/pull/88#issuecomment-TBD) flagged two points:
1. *"Any argument we're expecting users to pass should be in the config. If it is mandatory, it should have a `???` value. We don't want users to need the `+...` syntax, basically ever, if possible."* — addressed by switching to `query.codes: ???`.
2. *"Really, this looks like a bigger architectural problem, where we're maybe trying to make a small fix when this will be redundant with larger changes in the planned refactor."* — addressed by scoping down to `config.yaml` only and deferring the eval configs to Phase 2 where they're getting rewritten anyway.

## Test plan

- [x] `pytest tests/ src/` — 190 passed.
- [x] `pre-commit run --all-files` — clean.
- [x] `EQ_train --help` works on a fresh clone without any override.
- [x] Running `EQ_train` without `query.codes` fails loudly with Hydra's mandatory-value error.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
