### PR TITLE
feat: register EQ_aces_to_eq + EQ_process_composite entry points (closes #62)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,8 @@ EQ_generate_tasks = "every_query.generate_tasks.sample_tasks:main"
 EQ_gen_eval_index = "every_query.evaluate.gen_index_times:main"
 EQ_gen_eval_tasks = "every_query.evaluate.gen_task:main"
 EQ_select_model = "every_query.evaluate.select_model:main"
+EQ_aces_to_eq = "every_query.predict.external_tasks.aces_to_eq:main"
+EQ_process_composite = "every_query.predict.external_tasks.process_composite:main"
 
 [tool.coverage.run]
 # Measure coverage for EQ_* CLIs launched via subprocess in tests/test_cli_smoke.py.

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -45,7 +45,7 @@ _ENTRYPOINTS: list[tuple[str, list[str]]] = [
 
 @pytest.fixture(scope="module")
 def smoke_config_dir(tmp_path_factory) -> Path:
-    """Temp Hydra search dir supplying empty ``train_codes`` / ``eval_codes``."""
+    """Temp Hydra search dir supplying stub ``train_codes``, ``eval_codes``, and ``query_codes`` groups."""
     d = tmp_path_factory.mktemp("eq_smoke_cfg")
     (d / "train_codes").mkdir()
     (d / "train_codes" / "smoke.yaml").write_text("codes: []\n")

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -38,6 +38,8 @@ _ENTRYPOINTS: list[tuple[str, list[str]]] = [
     ("EQ_gen_eval_index", []),
     ("EQ_gen_eval_tasks", ["eval_codes=smoke"]),
     ("EQ_select_model", []),
+    ("EQ_aces_to_eq", ["query_codes=smoke"]),
+    ("EQ_process_composite", []),
 ]
 
 
@@ -49,6 +51,8 @@ def smoke_config_dir(tmp_path_factory) -> Path:
     (d / "train_codes" / "smoke.yaml").write_text("codes: []\n")
     (d / "eval_codes").mkdir()
     (d / "eval_codes" / "smoke.yaml").write_text("id: []\nood: []\n")
+    (d / "query_codes").mkdir()
+    (d / "query_codes" / "smoke.yaml").write_text("- A\n- B\n")
     return d
 
 

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -6,11 +6,12 @@ proves the ``[project.scripts]`` entry resolved, the package config
 directory resolved via ``importlib.resources.files()``, and module-level
 imports don't blow up in a fresh interpreter.
 
-Three endpoints (``EQ_train``, ``EQ_evaluate``, ``EQ_gen_eval_tasks``) compose a
-``{train,eval}_codes`` default group whose canonical file is generated out-of-band
-(see ``src/every_query/paper_experiments/sample_codes/``) and is not checked in.  For those we point
-Hydra at a throwaway ``--config-dir`` that supplies an empty-codes smoke variant,
-which preserves the rest of the compose path.
+Several endpoints compose a default code-group whose canonical file is generated
+out-of-band (see ``src/every_query/paper_experiments/sample_codes/``) and is not
+checked in: ``EQ_train`` / ``EQ_gen_eval_tasks`` use ``train_codes``, ``EQ_evaluate``
+uses ``eval_codes``, and ``EQ_aces_to_eq`` uses ``query_codes``.  For those we point
+Hydra at a throwaway ``--config-dir`` that supplies a stub smoke variant, which
+preserves the rest of the compose path.
 
 Child-process coverage is picked up automatically via
 ``[tool.coverage.run] patch = ["subprocess"]`` in ``pyproject.toml`` — no


### PR DESCRIPTION
## Summary

File moves landed in #90 — this PR registers the two Hydra mains as console scripts so they're directly invocable post-install.

Closes #62.

## What lands

- `pyproject.toml`: adds
  ```toml
  EQ_aces_to_eq        = "every_query.predict.external_tasks.aces_to_eq:main"
  EQ_process_composite = "every_query.predict.external_tasks.process_composite:main"
  ```
- `tests/test_cli_smoke.py`: parametrize list gains both entries. The `aces_to_eq` config defaults on a `query_codes` compose-group, so the smoke-config-dir fixture now also writes a `query_codes/smoke.yaml` stub alongside the existing `train_codes` / `eval_codes` stubs.

## Why not `get_per_code_from_composite` too

[@gkondas on #62](https://github.com/payalchandak/EveryQuery/issues/62#issuecomment-4269309300) only mentioned `aces_to_eq` and `process_composite`. `get_per_code_from_composite` is a helper used *after* composite aggregation to evaluate each code individually; the primary surface is the two registered here. If it needs an entry point later, it's a one-line addition.

## Test plan

- [x] `pytest tests/test_cli_smoke.py` — 9 passed (7 existing + 2 new).
- [x] `EQ_aces_to_eq --help` and `EQ_process_composite --help` both exit 0 after `uv sync`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
