### PR TITLE
feat(data): TaskQuerySchema — cross-stage contract for task-query rows (closes #80)

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -317,7 +317,8 @@ def task_labels_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
                     "prediction_time": _PRED_TIMES[subj],
                     "boolean_value": bv,
                     "query": query_code,
-                    "duration_days": 30,
+                    # Float to match ``TaskQuerySchema.duration_days`` (``pa.float32``).
+                    "duration_days": 30.0,
                 }
             )
 
@@ -327,7 +328,7 @@ def task_labels_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
                 "subject_id": pl.Int64,
                 "boolean_value": pl.Boolean,
                 "query": pl.Utf8,
-                "duration_days": pl.Int64,
+                "duration_days": pl.Float32,
             }
         )
         df.write_parquet(split_dir / "0.parquet")
@@ -369,7 +370,7 @@ def demo_dataset(
             "subject_id": pl.Int64,
             "boolean_value": pl.Boolean,
             "query": pl.Utf8,
-            "duration_days": pl.Float64,
+            "duration_days": pl.Float32,  # matches TaskQuerySchema
         }
     )
     df.write_parquet(collated_dir / "0.parquet")

--- a/conftest.py
+++ b/conftest.py
@@ -289,7 +289,7 @@ def task_labels_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
         {task_labels_dir}/{split}/{shard}.parquet
 
-    Columns: ``subject_id, prediction_time, boolean_value, occurs, code, duration_days``.
+    Columns: ``subject_id, prediction_time, boolean_value, occurs, query, duration_days``.
     """
     task_dir = tmp_path_factory.mktemp("eq_task_labels")
 
@@ -305,7 +305,7 @@ def task_labels_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
                     "prediction_time": _PRED_TIMES[subj],
                     "boolean_value": i % 2 == 0,
                     "occurs": i % 3 != 0,
-                    "code": query_code,
+                    "query": query_code,
                     "duration_days": 30,
                 }
             )
@@ -316,7 +316,7 @@ def task_labels_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
                 "subject_id": pl.Int64,
                 "boolean_value": pl.Boolean,
                 "occurs": pl.Boolean,
-                "code": pl.Utf8,
+                "query": pl.Utf8,
                 "duration_days": pl.Int64,
             }
         )
@@ -342,7 +342,7 @@ def demo_dataset(
                 "prediction_time": _PRED_TIMES[subj],
                 "boolean_value": i % 2 == 0,
                 "occurs": i % 3 != 0,
-                "code": query_code,
+                "query": query_code,
                 "duration_days": 30.0,
             }
         )
@@ -353,7 +353,7 @@ def demo_dataset(
             "subject_id": pl.Int64,
             "boolean_value": pl.Boolean,
             "occurs": pl.Boolean,
-            "code": pl.Utf8,
+            "query": pl.Utf8,
             "duration_days": pl.Float64,
         }
     )

--- a/conftest.py
+++ b/conftest.py
@@ -289,7 +289,7 @@ def task_labels_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
         {task_labels_dir}/{split}/{shard}.parquet
 
-    Columns: ``subject_id, prediction_time, boolean_value, occurs, query, duration_days``.
+    Columns: ``subject_id, prediction_time, boolean_value, occurs, code, duration_days``.
     """
     task_dir = tmp_path_factory.mktemp("eq_task_labels")
 
@@ -305,7 +305,7 @@ def task_labels_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
                     "prediction_time": _PRED_TIMES[subj],
                     "boolean_value": i % 2 == 0,
                     "occurs": i % 3 != 0,
-                    "query": query_code,
+                    "code": query_code,
                     "duration_days": 30,
                 }
             )
@@ -316,7 +316,7 @@ def task_labels_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
                 "subject_id": pl.Int64,
                 "boolean_value": pl.Boolean,
                 "occurs": pl.Boolean,
-                "query": pl.Utf8,
+                "code": pl.Utf8,
                 "duration_days": pl.Int64,
             }
         )
@@ -342,7 +342,7 @@ def demo_dataset(
                 "prediction_time": _PRED_TIMES[subj],
                 "boolean_value": i % 2 == 0,
                 "occurs": i % 3 != 0,
-                "query": query_code,
+                "code": query_code,
                 "duration_days": 30.0,
             }
         )
@@ -353,7 +353,7 @@ def demo_dataset(
             "subject_id": pl.Int64,
             "boolean_value": pl.Boolean,
             "occurs": pl.Boolean,
-            "query": pl.Utf8,
+            "code": pl.Utf8,
             "duration_days": pl.Float64,
         }
     )

--- a/conftest.py
+++ b/conftest.py
@@ -289,7 +289,9 @@ def task_labels_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
         {task_labels_dir}/{split}/{shard}.parquet
 
-    Columns: ``subject_id, prediction_time, boolean_value, occurs, query, duration_days``.
+    Columns: ``subject_id, prediction_time, boolean_value, query, duration_days``.
+    Conforms to ``TaskQuerySchema`` — ``boolean_value`` is nullable (null=censored,
+    True=event occurred, False=no event and not censored).
     """
     task_dir = tmp_path_factory.mktemp("eq_task_labels")
 
@@ -299,12 +301,21 @@ def task_labels_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
 
         rows = []
         for i, (subj, query_code) in enumerate((s, q) for s in subjects for q in _QUERY_CODES):
+            # Alternate the three-valued state so downstream tests see each:
+            #   i % 3 == 0 → censored  (null)
+            #   i % 3 == 1 → occurred  (True)
+            #   i % 3 == 2 → no event  (False)
+            if i % 3 == 0:
+                bv = None
+            elif i % 3 == 1:
+                bv = True
+            else:
+                bv = False
             rows.append(
                 {
                     "subject_id": subj,
                     "prediction_time": _PRED_TIMES[subj],
-                    "boolean_value": i % 2 == 0,
-                    "occurs": i % 3 != 0,
+                    "boolean_value": bv,
                     "query": query_code,
                     "duration_days": 30,
                 }
@@ -315,7 +326,6 @@ def task_labels_dir(tmp_path_factory: pytest.TempPathFactory) -> Path:
                 "prediction_time": pl.Datetime("us"),
                 "subject_id": pl.Int64,
                 "boolean_value": pl.Boolean,
-                "occurs": pl.Boolean,
                 "query": pl.Utf8,
                 "duration_days": pl.Int64,
             }
@@ -336,12 +346,18 @@ def demo_dataset(
 
     rows = []
     for i, (subj, query_code) in enumerate((s, q) for s in _TRAIN_SUBJECTS for q in _QUERY_CODES):
+        # Three-valued nullable boolean_value per TaskQuerySchema.
+        if i % 3 == 0:
+            bv = None
+        elif i % 3 == 1:
+            bv = True
+        else:
+            bv = False
         rows.append(
             {
                 "subject_id": subj,
                 "prediction_time": _PRED_TIMES[subj],
-                "boolean_value": i % 2 == 0,
-                "occurs": i % 3 != 0,
+                "boolean_value": bv,
                 "query": query_code,
                 "duration_days": 30.0,
             }
@@ -352,7 +368,6 @@ def demo_dataset(
             "prediction_time": pl.Datetime("us"),
             "subject_id": pl.Int64,
             "boolean_value": pl.Boolean,
-            "occurs": pl.Boolean,
             "query": pl.Utf8,
             "duration_days": pl.Float64,
         }

--- a/src/every_query/data/README.md
+++ b/src/every_query/data/README.md
@@ -10,8 +10,7 @@ from the model architecture.
     `Dataset` implementation that maps tensorized MEDS shards + a task-labels parquet into the
     query-aware batches the model consumes. Shared between the `train/` stage (training loop)
     and the future `predict/` stage (inference).
-- **`schema.py`** — `TaskQuerySchema`. Cross-stage contract for the `(subject_id,
-    prediction_time, code, duration_days)` rows produced by `generate_tasks/` and consumed
+- **`schema.py`** — `TaskQuerySchema`. Cross-stage contract for the `(subject_id, prediction_time, code, duration_days)` rows produced by `generate_tasks/` and consumed
     by `predict/` + `evaluate/`. Extends MEDS `LabelSchema` so inference and evaluation share
     the same row shape — labels live on the inherited `boolean_value` column when present.
     Initial scope (#80) is narrow: flat single code + continuous duration. Extensions come
@@ -28,7 +27,7 @@ Hydra `_target_` strings in configs use the fully-qualified path
 
 ## Why `data/` is separate from `model/`
 
-The data layer evolves on a different schedule than the model architecture.  The task-query
+The data layer evolves on a different schedule than the model architecture. The task-query
 schema (#80) lives here, separate from the `nn.Module`, so schema changes diff only `data/`
 and its two call-site edges (`generate_tasks/` output wiring + `train/` dataloader wiring).
 

--- a/src/every_query/data/README.md
+++ b/src/every_query/data/README.md
@@ -10,11 +10,11 @@ from the model architecture.
     `Dataset` implementation that maps tensorized MEDS shards + a task-labels parquet into the
     query-aware batches the model consumes. Shared between the `train/` stage (training loop)
     and the future `predict/` stage (inference).
-- **`schema.py`** — `TaskQuerySchema`. Cross-stage contract for the `(subject_id, prediction_time, code, duration_days)` rows produced by `generate_tasks/` and consumed
+- **`schema.py`** — `TaskQuerySchema`. Cross-stage contract for the `(subject_id, prediction_time, query, duration_days)` rows produced by `generate_tasks/` and consumed
     by `predict/` + `evaluate/`. Extends MEDS `LabelSchema` so inference and evaluation share
     the same row shape — labels live on the inherited `boolean_value` column when present.
-    Initial scope (#80) is narrow: flat single code + continuous duration. Extensions come
-    later as the pipeline matures.
+    Initial scope (#80) is narrow: flat single query code + continuous duration. Extensions
+    come later as the pipeline matures.
 
 Call through the package so stage submodules don't need to know the file layout:
 

--- a/src/every_query/data/README.md
+++ b/src/every_query/data/README.md
@@ -10,6 +10,12 @@ from the model architecture.
     `Dataset` implementation that maps tensorized MEDS shards + a task-labels parquet into the
     query-aware batches the model consumes. Shared between the `train/` stage (training loop)
     and the future `predict/` stage (inference).
+- **`schema.py`** — `TaskQuerySchema`. Cross-stage contract for the `(subject_id,
+    prediction_time, code, duration_days)` rows produced by `generate_tasks/` and consumed
+    by `predict/` + `evaluate/`. Extends MEDS `LabelSchema` so inference and evaluation share
+    the same row shape — labels live on the inherited `boolean_value` column when present.
+    Initial scope (#80) is narrow: flat single code + continuous duration. Extensions come
+    later as the pipeline matures.
 
 Call through the package so stage submodules don't need to know the file layout:
 
@@ -22,10 +28,8 @@ Hydra `_target_` strings in configs use the fully-qualified path
 
 ## Why `data/` is separate from `model/`
 
-The data layer evolves on a different schedule than the model architecture.
-Issue [#80](https://github.com/payalchandak/EveryQuery/issues/80) will reshape what
-`EveryQueryBatch` carries — likely toward a MEDS `LabelSchema`-derived shape — with no touch
-to the `nn.Module`. Keeping them in distinct submodules means a schema PR diffs only `data/`
+The data layer evolves on a different schedule than the model architecture.  The task-query
+schema (#80) lives here, separate from the `nn.Module`, so schema changes diff only `data/`
 and its two call-site edges (`generate_tasks/` output wiring + `train/` dataloader wiring).
 
 ## Pipeline position

--- a/src/every_query/data/__init__.py
+++ b/src/every_query/data/__init__.py
@@ -8,11 +8,12 @@ so stage submodules do not need to know the internal file layout::
 """
 
 from every_query.data.dataset import EveryQueryBatch, EveryQueryPytorchDataset, QueryData
-from every_query.data.schema import TaskQuerySchema
+from every_query.data.schema import TaskQuerySchema, empty_task_query_df
 
 __all__ = [
     "EveryQueryBatch",
     "EveryQueryPytorchDataset",
     "QueryData",
     "TaskQuerySchema",
+    "empty_task_query_df",
 ]

--- a/src/every_query/data/__init__.py
+++ b/src/every_query/data/__init__.py
@@ -8,9 +8,11 @@ so stage submodules do not need to know the internal file layout::
 """
 
 from every_query.data.dataset import EveryQueryBatch, EveryQueryPytorchDataset, QueryData
+from every_query.data.schema import TaskQuerySchema
 
 __all__ = [
     "EveryQueryBatch",
     "EveryQueryPytorchDataset",
     "QueryData",
+    "TaskQuerySchema",
 ]

--- a/src/every_query/data/dataset.py
+++ b/src/every_query/data/dataset.py
@@ -305,9 +305,9 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
         if "occurs" in label_names:
             group_cols.append("occurs")
             out_cols.append("occurs")
-        if "query" in label_names:
-            group_cols.append("query")
-            out_cols.append("query")
+        if "code" in label_names:
+            group_cols.append("code")
+            out_cols.append("code")
         if "duration_days" in label_names:
             group_cols.append("duration_days")
             out_cols.append("duration_days")
@@ -332,12 +332,17 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
                 .alias(LabelSchema.prediction_time_name)
             )
 
-        # Extra task annotations
+        # Extra task annotations.  Parquet column name is ``code`` (matches
+        # ``TaskQuerySchema`` in ``every_query.data.schema``); the Python attribute is kept
+        # as ``self.query`` / ``self.has_query`` because the batch-level counterpart
+        # ``EveryQueryBatch.query`` already occupies that name — and the inherited
+        # ``EveryQueryBatch.code`` is the event-sequence-level code tensor, not the query
+        # code.  Renaming either would collide.
         self.has_occurs: bool = "occurs" in self.schema_df.collect_schema().names()
-        self.has_query: bool = "query" in self.schema_df.collect_schema().names()
+        self.has_query: bool = "code" in self.schema_df.collect_schema().names()
         self.has_duration_days: bool = "duration_days" in self.schema_df.collect_schema().names()
         self.occurs = self.schema_df["occurs"] if self.has_occurs else None
-        self.query = self.schema_df["query"] if self.has_query else None
+        self.query = self.schema_df["code"] if self.has_query else None
         self.duration_days = self.schema_df["duration_days"] if self.has_duration_days else None
         # Load code vocabulary mapping (string code -> integer vocab index) for encoding queries
         try:
@@ -364,7 +369,7 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
         def read_df(fp: Path) -> pl.DataFrame:
             schema = pq.read_schema(fp)
             extras = []
-            for extra_col in [self.LABEL_COL, "occurs", "query", "duration_days"]:
+            for extra_col in [self.LABEL_COL, "occurs", "code", "duration_days"]:
                 if extra_col in schema.names:
                     extras.append(extra_col)
             label_cols = [*required_cols, *extras]

--- a/src/every_query/data/dataset.py
+++ b/src/every_query/data/dataset.py
@@ -332,10 +332,41 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
                 .alias(LabelSchema.prediction_time_name)
             )
 
+        # Split the collapsed nullable ``boolean_value`` label into the separate
+        # ``(censor, occurs)`` pair the model's loss code consumes.
+        #
+        # On-disk schema (TaskQuerySchema in every_query.data.schema):
+        #     boolean_value: nullable bool
+        #         null  → censored (observation ended before we could see the outcome)
+        #         True  → event occurred in the duration window
+        #         False → no event in the window, and not censored
+        #
+        # Batch-level API (EveryQueryBatch):
+        #     censor: bool          ← boolean_value.is_null()
+        #     occurs: bool/long     ← boolean_value.fill_null(False) (masked on censored rows)
+        #
+        # Done here (after super().__init__() has already read the label parquet into
+        # self.schema_df) so the downstream getitem / collate path sees non-null tensors
+        # — torch's bool→tensor conversion doesn't tolerate nulls.
+        schema_cols = self.schema_df.collect_schema().names()
+        if "boolean_value" in schema_cols:
+            raw = pl.col("boolean_value")
+            self.schema_df = self.schema_df.with_columns(
+                raw.is_null().alias("boolean_value"),
+                raw.fill_null(False).alias("occurs"),
+            )
+            schema_cols = self.schema_df.collect_schema().names()
+            # Super cached the pre-collapse ``boolean_value`` Series into ``self.labels``
+            # at its ``__init__`` time; re-point it at the post-processed (non-null,
+            # censor-indicator) column so ``_seeded_getitem`` and ``collate`` see the
+            # correct values.
+            if getattr(self, "has_task_labels", False):
+                self.labels = self.schema_df["boolean_value"]
+
         # Extra task annotations
-        self.has_occurs: bool = "occurs" in self.schema_df.collect_schema().names()
-        self.has_query: bool = "query" in self.schema_df.collect_schema().names()
-        self.has_duration_days: bool = "duration_days" in self.schema_df.collect_schema().names()
+        self.has_occurs: bool = "occurs" in schema_cols
+        self.has_query: bool = "query" in schema_cols
+        self.has_duration_days: bool = "duration_days" in schema_cols
         self.occurs = self.schema_df["occurs"] if self.has_occurs else None
         self.query = self.schema_df["query"] if self.has_query else None
         self.duration_days = self.schema_df["duration_days"] if self.has_duration_days else None
@@ -364,6 +395,10 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
         def read_df(fp: Path) -> pl.DataFrame:
             schema = pq.read_schema(fp)
             extras = []
+            # "occurs" is not an on-disk column after the nullable-label collapse; it's
+            # derived in __init__ from boolean_value.is_null().  Keep it in the list for
+            # backward compatibility with any legacy label parquets that still carry it
+            # explicitly — harmless if absent.
             for extra_col in [self.LABEL_COL, "occurs", "query", "duration_days"]:
                 if extra_col in schema.names:
                     extras.append(extra_col)

--- a/src/every_query/data/dataset.py
+++ b/src/every_query/data/dataset.py
@@ -305,9 +305,9 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
         if "occurs" in label_names:
             group_cols.append("occurs")
             out_cols.append("occurs")
-        if "code" in label_names:
-            group_cols.append("code")
-            out_cols.append("code")
+        if "query" in label_names:
+            group_cols.append("query")
+            out_cols.append("query")
         if "duration_days" in label_names:
             group_cols.append("duration_days")
             out_cols.append("duration_days")
@@ -332,17 +332,12 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
                 .alias(LabelSchema.prediction_time_name)
             )
 
-        # Extra task annotations.  Parquet column name is ``code`` (matches
-        # ``TaskQuerySchema`` in ``every_query.data.schema``); the Python attribute is kept
-        # as ``self.query`` / ``self.has_query`` because the batch-level counterpart
-        # ``EveryQueryBatch.query`` already occupies that name — and the inherited
-        # ``EveryQueryBatch.code`` is the event-sequence-level code tensor, not the query
-        # code.  Renaming either would collide.
+        # Extra task annotations
         self.has_occurs: bool = "occurs" in self.schema_df.collect_schema().names()
-        self.has_query: bool = "code" in self.schema_df.collect_schema().names()
+        self.has_query: bool = "query" in self.schema_df.collect_schema().names()
         self.has_duration_days: bool = "duration_days" in self.schema_df.collect_schema().names()
         self.occurs = self.schema_df["occurs"] if self.has_occurs else None
-        self.query = self.schema_df["code"] if self.has_query else None
+        self.query = self.schema_df["query"] if self.has_query else None
         self.duration_days = self.schema_df["duration_days"] if self.has_duration_days else None
         # Load code vocabulary mapping (string code -> integer vocab index) for encoding queries
         try:
@@ -369,7 +364,7 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
         def read_df(fp: Path) -> pl.DataFrame:
             schema = pq.read_schema(fp)
             extras = []
-            for extra_col in [self.LABEL_COL, "occurs", "code", "duration_days"]:
+            for extra_col in [self.LABEL_COL, "occurs", "query", "duration_days"]:
                 if extra_col in schema.names:
                     extras.append(extra_col)
             label_cols = [*required_cols, *extras]

--- a/src/every_query/data/dataset.py
+++ b/src/every_query/data/dataset.py
@@ -332,24 +332,32 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
                 .alias(LabelSchema.prediction_time_name)
             )
 
-        # Split the collapsed nullable ``boolean_value`` label into the separate
-        # ``(censor, occurs)`` pair the model's loss code consumes.
+        # Derive the ``(censor, occurs)`` pair the model's loss code consumes, from
+        # whichever on-disk label shape the parquet has.  Two shapes are supported:
         #
-        # On-disk schema (TaskQuerySchema in every_query.data.schema):
-        #     boolean_value: nullable bool
-        #         null  → censored (observation ended before we could see the outcome)
-        #         True  → event occurred in the duration window
-        #         False → no event in the window, and not censored
+        # 1. **Collapsed (new, ``TaskQuerySchema``-shaped)** — the parquet has a single
+        #    nullable ``boolean_value`` column:
+        #        null  → censored (observation ended before we could see the outcome)
+        #        True  → event occurred in the duration window
+        #        False → no event in the window, and not censored
+        #    We split it into ``boolean_value = is_null()`` (censor indicator) and
+        #    ``occurs = fill_null(False)``.
         #
-        # Batch-level API (EveryQueryBatch):
-        #     censor: bool          ← boolean_value.is_null()
-        #     occurs: bool/long     ← boolean_value.fill_null(False) (masked on censored rows)
+        # 2. **Legacy two-column** — the parquet has both ``boolean_value`` (meaning
+        #    "censored") AND an explicit ``occurs`` column.  We leave both alone;
+        #    super's ``self.labels`` cache is already the censor indicator.
         #
-        # Done here (after super().__init__() has already read the label parquet into
-        # self.schema_df) so the downstream getitem / collate path sees non-null tensors
-        # — torch's bool→tensor conversion doesn't tolerate nulls.
+        # Detection: presence of an explicit ``occurs`` column marks the legacy shape
+        # — the collapsed shape never emits it (see ``evaluate_index_df``).  This
+        # preserves backward compat with any label parquets produced by pre-#96
+        # pipelines still on disk.
+        #
+        # Done after super().__init__() has read the label parquet into self.schema_df
+        # so the downstream getitem / collate path sees non-null tensors (torch's
+        # bool→tensor conversion doesn't tolerate nulls).
         schema_cols = self.schema_df.collect_schema().names()
-        if "boolean_value" in schema_cols:
+        is_legacy_two_col = "occurs" in schema_cols
+        if "boolean_value" in schema_cols and not is_legacy_two_col:
             raw = pl.col("boolean_value")
             self.schema_df = self.schema_df.with_columns(
                 raw.is_null().alias("boolean_value"),

--- a/src/every_query/data/schema.py
+++ b/src/every_query/data/schema.py
@@ -24,7 +24,7 @@ evolve.
 """
 
 import pyarrow as pa
-from flexible_schema import Required
+from flexible_schema import Optional, Required
 from meds import LabelSchema
 
 
@@ -38,9 +38,15 @@ class TaskQuerySchema(LabelSchema):
     both inference input (no label) and evaluation input (label filled in) without a branch.
 
     Attributes:
-        query: The MEDS code the query asks about.  Named ``query`` rather than ``code`` to
-            match the column name already used throughout the sampler / dataset / batch
-            layer (``EveryQueryBatch.code`` is the distinct event-sequence-token tensor).
+        query: The MEDS code the query asks about.  Stored as ``pa.large_string``
+            (polars' ``Utf8`` serializes to ``large_string`` when a DataFrame is
+            converted to arrow, so this matches producer output natively and
+            ``TaskQuerySchema.align()`` works without type coercion; also matches
+            MEDS's own ``DataSchema.code`` convention which uses ``large_string``
+            for the same 2 GB-offset reason).  Named ``query`` rather than ``code``
+            to match the column name already used throughout the sampler / dataset /
+            batch layer (``EveryQueryBatch.code`` is the distinct event-sequence-token
+            tensor).
         duration_days: The horizon, in days (continuous — ``float32``) within which the
             ``query`` code must occur for the query to be positive.  Allowing fractional
             days keeps the contract flexible for future finer-grained horizons.
@@ -84,3 +90,9 @@ class TaskQuerySchema(LabelSchema):
 
     query: Required(pa.large_string(), nullable=False)
     duration_days: Required(pa.float32(), nullable=False)
+    # Override ``boolean_value`` from ``LabelSchema`` (which declares it
+    # ``Optional(bool, nullable=NONE)``) to allow nulls — the EveryQuery task-label
+    # convention is to use null as the "censored" sentinel (closes #122).  The column
+    # stays optional at the schema level so inference-only inputs (no ground truth)
+    # continue to validate.
+    boolean_value: Optional(pa.bool_(), nullable=True)

--- a/src/every_query/data/schema.py
+++ b/src/every_query/data/schema.py
@@ -1,0 +1,77 @@
+"""Cross-stage schema for EveryQuery task-query rows.
+
+``TaskQuerySchema`` is the contract shared between ``generate_tasks/`` (producer) and the
+future ``predict/`` + ``evaluate/`` stages (consumers).  Each row specifies: *"for
+subject_id at prediction_time, will ``code`` occur within ``duration_days``?"*
+
+Extends the MEDS ``LabelSchema`` — so it inherits ``subject_id``, ``prediction_time``, and
+the optional label columns (``boolean_value``, ``integer_value``, etc.) — and adds the two
+required query fields ``code`` and ``duration_days``.  Mirrors the pattern
+``meds-evaluation``'s `PredictionSchema
+<https://github.com/kamilest/meds-evaluation/blob/main/src/meds_evaluation/schema.py>`_ uses.
+
+Initial scope (per #80) is intentionally narrow: a flat single code + a continuous (float)
+duration.  Extensions — compound ANY/ALL queries, structured task payloads — are out of
+scope for the initial schema and will be added as the inference / evaluation pipelines
+evolve.
+"""
+
+import pyarrow as pa
+from flexible_schema import Required
+from meds import LabelSchema
+
+
+class TaskQuerySchema(LabelSchema):
+    """An EveryQuery task-query row: a MEDS prediction-time label plus the query that defines it.
+
+    Each row is a single ``(subject_id, prediction_time, code, duration_days)`` tuple with
+    optional label columns inherited from ``LabelSchema``.  When the ground-truth label is
+    present it lives on the inherited ``boolean_value`` column — *"did ``code`` occur for
+    ``subject_id`` within ``duration_days`` of ``prediction_time``?"* — so the schema serves
+    both inference input (no label) and evaluation input (label filled in) without a branch.
+
+    Attributes:
+        code: The MEDS code the query asks about.
+        duration_days: The horizon, in days (continuous — ``float32``) within which ``code``
+            must occur for the query to be positive.  Allowing fractional days keeps the
+            contract flexible for future finer-grained horizons.
+
+    Examples:
+        A row with just the query (inference input) validates:
+
+        >>> from datetime import datetime
+        >>> import pyarrow as pa
+        >>> data = pa.Table.from_pylist([
+        ...     {"subject_id": 1, "prediction_time": datetime(2023, 1, 1),
+        ...      "code": "ICD//I10", "duration_days": 30.0},
+        ... ])
+        >>> aligned = TaskQuerySchema.align(data)
+        >>> [f.name for f in aligned.schema]
+        ['subject_id', 'prediction_time', 'code', 'duration_days']
+
+        A row with the inherited ``boolean_value`` label filled in (evaluation input) also
+        validates:
+
+        >>> data = pa.Table.from_pylist([
+        ...     {"subject_id": 1, "prediction_time": datetime(2023, 1, 1),
+        ...      "code": "ICD//I10", "duration_days": 30.0, "boolean_value": True},
+        ...     {"subject_id": 2, "prediction_time": datetime(2023, 1, 1),
+        ...      "code": "ICD//I10", "duration_days": 30.0, "boolean_value": False},
+        ... ])
+        >>> aligned = TaskQuerySchema.align(data)
+        >>> set(f.name for f in aligned.schema) >= {
+        ...     "subject_id", "prediction_time", "code", "duration_days", "boolean_value"
+        ... }
+        True
+
+        Fractional durations are supported:
+
+        >>> data = pa.Table.from_pylist([
+        ...     {"subject_id": 1, "prediction_time": datetime(2023, 1, 1),
+        ...      "code": "ICD//I10", "duration_days": 0.5},
+        ... ])
+        >>> _ = TaskQuerySchema.align(data)
+    """
+
+    code: Required(pa.large_string(), nullable=False)
+    duration_days: Required(pa.float32(), nullable=False)

--- a/src/every_query/data/schema.py
+++ b/src/every_query/data/schema.py
@@ -23,6 +23,7 @@ scope for the initial schema and will be added as the inference / evaluation pip
 evolve.
 """
 
+import polars as pl
 import pyarrow as pa
 from flexible_schema import Optional, Required
 from meds import LabelSchema
@@ -96,3 +97,43 @@ class TaskQuerySchema(LabelSchema):
     # stays optional at the schema level so inference-only inputs (no ground truth)
     # continue to validate.
     boolean_value: Optional(pa.bool_(), nullable=True)
+
+
+def empty_task_query_df() -> pl.DataFrame:
+    """Build an empty polars DataFrame shaped like ``TaskQuerySchema``'s required columns plus the inherited
+    ``boolean_value`` (the collapsed label column).
+
+    Only the required columns + ``boolean_value`` are included — not every
+    ``LabelSchema`` optional column — because (a) that's what the sampler's empty-input
+    fast path needs, and (b) a polars-arrow round-trip coerces ``pa.string`` →
+    ``pa.large_string`` on the inherited ``categorical_value`` column, so a schema-
+    complete empty frame would fail ``TaskQuerySchema.validate`` after the round-trip
+    unless we bypassed polars entirely.  Keeping the shape focused on what downstream
+    writers actually emit avoids that type-drift landmine.
+
+    Callers use this at the empty-input fast path (e.g., ``evaluate_index_df`` when no
+    tasks were sampled) so the produced parquet still aligns to the schema via
+    ``TaskQuerySchema.align`` at the write boundary.
+
+    Examples:
+        >>> df = empty_task_query_df()
+        >>> df.height
+        0
+        >>> set(df.columns) == {
+        ...     TaskQuerySchema.subject_id_name,
+        ...     TaskQuerySchema.prediction_time_name,
+        ...     TaskQuerySchema.query_name,
+        ...     TaskQuerySchema.duration_days_name,
+        ...     TaskQuerySchema.boolean_value_name,
+        ... }
+        True
+    """
+    return pl.DataFrame(
+        schema={
+            TaskQuerySchema.subject_id_name: pl.Int64,
+            TaskQuerySchema.prediction_time_name: pl.Datetime("us"),
+            TaskQuerySchema.query_name: pl.Utf8,
+            TaskQuerySchema.duration_days_name: pl.Float32,
+            TaskQuerySchema.boolean_value_name: pl.Boolean,
+        }
+    )

--- a/src/every_query/data/schema.py
+++ b/src/every_query/data/schema.py
@@ -2,13 +2,20 @@
 
 ``TaskQuerySchema`` is the contract shared between ``generate_tasks/`` (producer) and the
 future ``predict/`` + ``evaluate/`` stages (consumers).  Each row specifies: *"for
-subject_id at prediction_time, will ``code`` occur within ``duration_days``?"*
+subject_id at prediction_time, will ``query`` occur within ``duration_days``?"*
 
 Extends the MEDS ``LabelSchema`` — so it inherits ``subject_id``, ``prediction_time``, and
 the optional label columns (``boolean_value``, ``integer_value``, etc.) — and adds the two
-required query fields ``code`` and ``duration_days``.  Mirrors the pattern
+required query fields ``query`` and ``duration_days``.  Mirrors the pattern
 ``meds-evaluation``'s `PredictionSchema
 <https://github.com/kamilest/meds-evaluation/blob/main/src/meds_evaluation/schema.py>`_ uses.
+
+The ``query`` column holds the MEDS code the query asks about.  The field is named
+``query`` (not ``code``) to match the existing column name used by ``sample_tasks``
+output, ``EveryQueryPytorchDataset``, and the ``EveryQueryBatch.query`` tensor —
+renaming to ``code`` would (a) collide with the inherited ``EveryQueryBatch.code``
+sequence-token tensor, which is a different thing semantically, and (b) churn every
+downstream consumer for no functional win.
 
 Initial scope (per #80) is intentionally narrow: a flat single code + a continuous (float)
 duration.  Extensions — compound ANY/ALL queries, structured task payloads — are out of
@@ -24,17 +31,19 @@ from meds import LabelSchema
 class TaskQuerySchema(LabelSchema):
     """An EveryQuery task-query row: a MEDS prediction-time label plus the query that defines it.
 
-    Each row is a single ``(subject_id, prediction_time, code, duration_days)`` tuple with
+    Each row is a single ``(subject_id, prediction_time, query, duration_days)`` tuple with
     optional label columns inherited from ``LabelSchema``.  When the ground-truth label is
-    present it lives on the inherited ``boolean_value`` column — *"did ``code`` occur for
+    present it lives on the inherited ``boolean_value`` column — *"did ``query`` occur for
     ``subject_id`` within ``duration_days`` of ``prediction_time``?"* — so the schema serves
     both inference input (no label) and evaluation input (label filled in) without a branch.
 
     Attributes:
-        code: The MEDS code the query asks about.
-        duration_days: The horizon, in days (continuous — ``float32``) within which ``code``
-            must occur for the query to be positive.  Allowing fractional days keeps the
-            contract flexible for future finer-grained horizons.
+        query: The MEDS code the query asks about.  Named ``query`` rather than ``code`` to
+            match the column name already used throughout the sampler / dataset / batch
+            layer (``EveryQueryBatch.code`` is the distinct event-sequence-token tensor).
+        duration_days: The horizon, in days (continuous — ``float32``) within which the
+            ``query`` code must occur for the query to be positive.  Allowing fractional
+            days keeps the contract flexible for future finer-grained horizons.
 
     Examples:
         A row with just the query (inference input) validates:
@@ -43,24 +52,24 @@ class TaskQuerySchema(LabelSchema):
         >>> import pyarrow as pa
         >>> data = pa.Table.from_pylist([
         ...     {"subject_id": 1, "prediction_time": datetime(2023, 1, 1),
-        ...      "code": "ICD//I10", "duration_days": 30.0},
+        ...      "query": "ICD//I10", "duration_days": 30.0},
         ... ])
         >>> aligned = TaskQuerySchema.align(data)
         >>> [f.name for f in aligned.schema]
-        ['subject_id', 'prediction_time', 'code', 'duration_days']
+        ['subject_id', 'prediction_time', 'query', 'duration_days']
 
         A row with the inherited ``boolean_value`` label filled in (evaluation input) also
         validates:
 
         >>> data = pa.Table.from_pylist([
         ...     {"subject_id": 1, "prediction_time": datetime(2023, 1, 1),
-        ...      "code": "ICD//I10", "duration_days": 30.0, "boolean_value": True},
+        ...      "query": "ICD//I10", "duration_days": 30.0, "boolean_value": True},
         ...     {"subject_id": 2, "prediction_time": datetime(2023, 1, 1),
-        ...      "code": "ICD//I10", "duration_days": 30.0, "boolean_value": False},
+        ...      "query": "ICD//I10", "duration_days": 30.0, "boolean_value": False},
         ... ])
         >>> aligned = TaskQuerySchema.align(data)
         >>> set(f.name for f in aligned.schema) >= {
-        ...     "subject_id", "prediction_time", "code", "duration_days", "boolean_value"
+        ...     "subject_id", "prediction_time", "query", "duration_days", "boolean_value"
         ... }
         True
 
@@ -68,10 +77,10 @@ class TaskQuerySchema(LabelSchema):
 
         >>> data = pa.Table.from_pylist([
         ...     {"subject_id": 1, "prediction_time": datetime(2023, 1, 1),
-        ...      "code": "ICD//I10", "duration_days": 0.5},
+        ...      "query": "ICD//I10", "duration_days": 0.5},
         ... ])
         >>> _ = TaskQuerySchema.align(data)
     """
 
-    code: Required(pa.large_string(), nullable=False)
+    query: Required(pa.large_string(), nullable=False)
     duration_days: Required(pa.float32(), nullable=False)

--- a/src/every_query/evaluate/gen_task.py
+++ b/src/every_query/evaluate/gen_task.py
@@ -86,14 +86,14 @@ def process_eval_tasks(
                     )
                     .rename({"censored": "boolean_value", code: "occurs"})
                     .with_columns(
-                        pl.lit(code).alias("query"),
+                        pl.lit(code).alias("code"),
                         pl.lit(duration).alias("duration_days"),
                     )
                     .select(
                         "subject_id",
                         "prediction_time",
                         "boolean_value",
-                        "query",
+                        "code",
                         "occurs",
                         "duration_days",
                     )

--- a/src/every_query/evaluate/gen_task.py
+++ b/src/every_query/evaluate/gen_task.py
@@ -78,14 +78,26 @@ def process_eval_tasks(
                     print(f"WARNING: code {code} not in shard {task_fp.name} for duration={duration}")
                     continue
 
+                # Collapsed nullable boolean_value per TaskQuerySchema:
+                #   null  → censored
+                #   True  → event occurred (input `<code>=True`)
+                #   False → no event, not censored
+                # Filter step drops rows whose underlying per-code value was null in the
+                # wide input AND weren't censored (a null per-code cell means the matrix
+                # didn't have a value for this (subject, prediction_time) pair — distinct
+                # from "censored" which is the meaningful null).
+                boolean_value = (
+                    pl.when(pl.col("censored")).then(pl.lit(None, dtype=pl.Boolean)).otherwise(pl.col(code))
+                )
                 df = (
                     index_df.join(
                         shard_task_df.select(["subject_id", "prediction_time", "censored", code]),
                         on=["subject_id", "prediction_time"],
                         how="inner",
                     )
-                    .rename({"censored": "boolean_value", code: "occurs"})
+                    .filter(pl.col("censored") | pl.col(code).is_not_null())
                     .with_columns(
+                        boolean_value.alias("boolean_value"),
                         pl.lit(code).alias("query"),
                         pl.lit(duration).alias("duration_days"),
                     )
@@ -94,10 +106,8 @@ def process_eval_tasks(
                         "prediction_time",
                         "boolean_value",
                         "query",
-                        "occurs",
                         "duration_days",
                     )
-                    .filter(pl.col("occurs").is_not_null())
                 )
 
                 df.write_parquet(out_fp)

--- a/src/every_query/evaluate/gen_task.py
+++ b/src/every_query/evaluate/gen_task.py
@@ -86,14 +86,14 @@ def process_eval_tasks(
                     )
                     .rename({"censored": "boolean_value", code: "occurs"})
                     .with_columns(
-                        pl.lit(code).alias("code"),
+                        pl.lit(code).alias("query"),
                         pl.lit(duration).alias("duration_days"),
                     )
                     .select(
                         "subject_id",
                         "prediction_time",
                         "boolean_value",
-                        "code",
+                        "query",
                         "occurs",
                         "duration_days",
                     )

--- a/src/every_query/evaluate/gen_task.py
+++ b/src/every_query/evaluate/gen_task.py
@@ -99,7 +99,9 @@ def process_eval_tasks(
                     .with_columns(
                         boolean_value.alias("boolean_value"),
                         pl.lit(code).alias("query"),
-                        pl.lit(duration).alias("duration_days"),
+                        # Float32 to match ``TaskQuerySchema.duration_days`` so the
+                        # output aligns to the schema natively.
+                        pl.lit(duration).cast(pl.Float32).alias("duration_days"),
                     )
                     .select(
                         "subject_id",

--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -39,8 +39,10 @@ from pathlib import Path
 import hydra
 import numpy as np
 import polars as pl
+import pyarrow as pa
 from omegaconf import DictConfig
 
+from every_query.data.schema import TaskQuerySchema
 from every_query.utils.seeds import derive_seed
 
 logger = logging.getLogger(__name__)
@@ -202,7 +204,10 @@ def build_index_df(
                 "subject_id": sid_dtype,
                 "prediction_time": pt_dtype,
                 "query": pl.Utf8,
-                "duration_days": pl.Int64,
+                # ``Float32`` matches ``TaskQuerySchema.duration_days`` (``pa.float32``);
+                # emitting Float32 directly means downstream ``TaskQuerySchema.align()``
+                # calls don't need to coerce types at the write boundary.
+                "duration_days": pl.Float32,
             }
         )
 
@@ -225,10 +230,12 @@ def build_index_df(
         np.repeat([t.code for t in tasks], contexts_per_task),
         dtype=pl.Utf8,
     )
+    # Float32 matches TaskQuerySchema's duration_days type so the final labeled output
+    # aligns to the schema without a type-coercion step at the write boundary.
     duration_col = pl.Series(
         "duration_days",
-        np.repeat([t.duration_days for t in tasks], contexts_per_task).astype(np.int64),
-        dtype=pl.Int64,
+        np.repeat([t.duration_days for t in tasks], contexts_per_task).astype(np.float32),
+        dtype=pl.Float32,
     )
 
     return contexts.with_columns(task_ids, query_col, duration_col).select(
@@ -276,15 +283,17 @@ def evaluate_index_df(
         DataFrame with columns ``(subject_id, prediction_time, boolean_value, query,
         duration_days)``.  ``boolean_value`` is nullable (``null`` = censored).
     """
-    out_schema = {
-        "subject_id": index_df.schema.get("subject_id", pl.Int64),
-        "prediction_time": index_df.schema.get("prediction_time", pl.Datetime("us")),
-        "boolean_value": pl.Boolean,
-        "query": pl.Utf8,
-        "duration_days": pl.Int64,
-    }
+    # Empty-input fast-path: build an empty TaskQuerySchema-conformant table via the
+    # schema itself (rather than hand-rolling a matching polars schema dict).  The
+    # downstream consumer only cares that the column set + dtypes match the schema;
+    # using TaskQuerySchema.schema() directly eliminates the drift risk of keeping two
+    # parallel type lists in sync.
     if index_df.height == 0:
-        return pl.DataFrame(schema=out_schema)
+        arrow_schema = TaskQuerySchema.schema()
+        empty_table = pa.Table.from_pylist([], schema=arrow_schema)
+        return pl.from_arrow(empty_table).select(
+            "subject_id", "prediction_time", "boolean_value", "query", "duration_days"
+        )
 
     # Left side: index rows with a +1µs-shifted prediction_time for the strict-> asof key.
     left = index_df.with_columns(
@@ -483,6 +492,13 @@ def run_worker(
     labeled = evaluate_index_df(index_df, events_df, max_time_df)
     # Downstream MEDS dataloader does not use task_id; it is intentionally absent from the
     # published schema.
+    #
+    # Validate the output against TaskQuerySchema at the write boundary.  The column set
+    # and types should already conform (evaluate_index_df emits schema-shaped output and
+    # duration_days is Float32 from build_index_df), so this is a guardrail against silent
+    # upstream drift rather than a coercion step — if ``align`` has to do any work we
+    # treat that as a bug in the producer, not something the write path papers over.
+    TaskQuerySchema.validate(labeled.to_arrow())
     _atomic_write_parquet(labeled, labels_fp)
     logger.info("Wrote %d labeled rows to %s", labeled.height, labels_fp)
     return labels_fp

--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -25,7 +25,7 @@ Design decisions (see issue #33):
 - **Censoring**: computed from ``max_time`` per subject (one groupby up-front per shard). Censored
   rows get ``boolean_value=True`` and ``occurs=False`` regardless of whether the event actually
   fired in the window.
-- **Single-pass evaluation**: one ``join_asof(strategy="forward", by=["subject_id","query"])`` across
+- **Single-pass evaluation**: one ``join_asof(strategy="forward", by=["subject_id","code"])`` across
   the whole ``index_df`` against the events table, regardless of how many distinct codes are present.
 """
 
@@ -191,7 +191,7 @@ def build_index_df(
     independently per task.
 
     Returns:
-        ``DataFrame`` with columns ``(task_id, subject_id, prediction_time, query, duration_days)``.
+        ``DataFrame`` with columns ``(task_id, subject_id, prediction_time, code, duration_days)``.
     """
     n_tasks = len(tasks)
 
@@ -201,7 +201,7 @@ def build_index_df(
                 "task_id": pl.Int64,
                 "subject_id": sid_dtype,
                 "prediction_time": pt_dtype,
-                "query": pl.Utf8,
+                "code": pl.Utf8,
                 "duration_days": pl.Int64,
             }
         )
@@ -220,8 +220,8 @@ def build_index_df(
         "task_id",
         np.repeat(np.arange(n_tasks, dtype=np.int64), contexts_per_task),
     )
-    query_col = pl.Series(
-        "query",
+    code_col = pl.Series(
+        "code",
         np.repeat([t.code for t in tasks], contexts_per_task),
         dtype=pl.Utf8,
     )
@@ -231,8 +231,8 @@ def build_index_df(
         dtype=pl.Int64,
     )
 
-    return contexts.with_columns(task_ids, query_col, duration_col).select(
-        "task_id", "subject_id", "prediction_time", "query", "duration_days"
+    return contexts.with_columns(task_ids, code_col, duration_col).select(
+        "task_id", "subject_id", "prediction_time", "code", "duration_days"
     )
 
 
@@ -262,22 +262,28 @@ def evaluate_index_df(
     stored at microsecond precision, which turns ``strategy="forward"``'s ``>=`` into a strict ``>``.
 
     Args:
-        index_df: Output of ``build_index_df``. Must have columns ``subject_id``, ``prediction_time``,
-            ``query``, ``duration_days``. If ``task_id`` is present it is ignored and dropped from
-            the output.
+        index_df: Output of ``build_index_df``.  Must have columns ``subject_id``,
+            ``prediction_time``, ``code``, ``duration_days`` — the ``code`` column names
+            the MEDS code the query is asking about, matching the ``TaskQuerySchema``
+            contract in ``every_query.data.schema``.  If ``task_id`` is present it is
+            ignored and dropped from the output.
         events_df: Shard events with columns ``subject_id``, ``time``, ``code``.
         max_time_per_subject: Output of ``compute_max_time_per_subject``.
 
     Returns:
-        DataFrame with columns ``(subject_id, prediction_time, boolean_value, occurs, query,
-        duration_days)``.
+        DataFrame with columns ``(subject_id, prediction_time, boolean_value, occurs,
+        code, duration_days)``.  Conforms to ``TaskQuerySchema`` on the required columns
+        (``subject_id``, ``prediction_time``, ``code``, ``duration_days``) plus the
+        inherited ``boolean_value``; the extra ``occurs`` column is EQ-specific and
+        currently sits alongside the schema (collapsing ``boolean_value`` / ``occurs``
+        into a single nullable label is tracked in #122).
     """
     out_schema = {
         "subject_id": index_df.schema.get("subject_id", pl.Int64),
         "prediction_time": index_df.schema.get("prediction_time", pl.Datetime("us")),
         "boolean_value": pl.Boolean,
         "occurs": pl.Boolean,
-        "query": pl.Utf8,
+        "code": pl.Utf8,
         "duration_days": pl.Int64,
     }
     if index_df.height == 0:
@@ -286,18 +292,15 @@ def evaluate_index_df(
     # Left side: index rows with a +1µs-shifted prediction_time for the strict-> asof key.
     left = index_df.with_columns(
         (pl.col("prediction_time") + pl.duration(microseconds=1)).alias("_pt_shifted")
-    ).sort(["subject_id", "query", "_pt_shifted"])
+    ).sort(["subject_id", "code", "_pt_shifted"])
 
-    # Right side: events renamed so the join-by column name matches the left.
-    right = (
-        events_df.rename({"code": "query"})
-        .select(["subject_id", "query", "time"])
-        .sort(["subject_id", "query", "time"])
-    )
+    # Right side: events restricted to the columns needed for the asof join.  Both sides
+    # now share the ``code`` column name so no rename is needed.
+    right = events_df.select(["subject_id", "code", "time"]).sort(["subject_id", "code", "time"])
 
     joined = left.join_asof(
         right,
-        by=["subject_id", "query"],
+        by=["subject_id", "code"],
         left_on="_pt_shifted",
         right_on="time",
         strategy="forward",
@@ -330,7 +333,7 @@ def evaluate_index_df(
             pl.col("_censored").alias("boolean_value"),
             (pl.col("_censored").not_() & event_in_window).alias("occurs"),
         )
-        .select("subject_id", "prediction_time", "boolean_value", "occurs", "query", "duration_days")
+        .select("subject_id", "prediction_time", "boolean_value", "occurs", "code", "duration_days")
     )
 
 
@@ -345,8 +348,8 @@ def _read_event_shard(file_path: str | Path) -> pl.DataFrame:
     The parquet schema is normalized explicitly so the returned frame is type-stable regardless
     of how the source shard encoded strings or timestamps:
 
-    - ``code`` is cast to ``pl.Utf8`` so it compares against the ``query`` column of ``index_df``
-      (also ``Utf8``) in ``evaluate_index_df``'s ``join_asof(by=["subject_id","query"])``.  Mixed
+    - ``code`` is cast to ``pl.Utf8`` so it compares against the ``code`` column of ``index_df``
+      (also ``Utf8``) in ``evaluate_index_df``'s ``join_asof(by=["subject_id","code"])``.  Mixed
       ``Categorical``/``Utf8`` or ``<integer vocab index>``/``Utf8`` joins would either raise or
       silently produce zero matches.  Upstream stages may store codes as categoricals or integer
       vocab indices; casting to ``Utf8`` here avoids coupling to either representation.

--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -250,13 +250,17 @@ def evaluate_index_df(
     events_df: pl.DataFrame,
     max_time_per_subject: pl.DataFrame,
 ) -> pl.DataFrame:
-    """Label an index DataFrame with ``(boolean_value, occurs)`` via a single ``join_asof``.
+    """Label an index DataFrame with the single nullable ``boolean_value`` column via a single ``join_asof``.
 
-    Semantics:
-        - ``censored = (prediction_time + duration_days) > max_time[subject_id]``
-        - ``occurs = (not censored) AND (next event with matching code falls strictly within
-          (prediction_time, prediction_time + duration_days))``
-        - ``boolean_value = censored``
+    Three-valued semantics (matches ``TaskQuerySchema`` + ``LabelSchema``'s nullable
+    ``boolean_value``):
+
+        - ``boolean_value = null``: censored — ``(prediction_time + duration_days) >
+          max_time[subject_id]``; observation ended before we could see whether the event
+          fired.
+        - ``boolean_value = True``: not censored and an event with matching ``query`` code
+          fell strictly within ``(prediction_time, prediction_time + duration_days)``.
+        - ``boolean_value = False``: not censored and no such event fell within the window.
 
     The ``>`` on event time is enforced by shifting the asof key by ``+1µs`` since datetimes are
     stored at microsecond precision, which turns ``strategy="forward"``'s ``>=`` into a strict ``>``.
@@ -269,14 +273,13 @@ def evaluate_index_df(
         max_time_per_subject: Output of ``compute_max_time_per_subject``.
 
     Returns:
-        DataFrame with columns ``(subject_id, prediction_time, boolean_value, occurs, query,
-        duration_days)``.
+        DataFrame with columns ``(subject_id, prediction_time, boolean_value, query,
+        duration_days)``.  ``boolean_value`` is nullable (``null`` = censored).
     """
     out_schema = {
         "subject_id": index_df.schema.get("subject_id", pl.Int64),
         "prediction_time": index_df.schema.get("prediction_time", pl.Datetime("us")),
         "boolean_value": pl.Boolean,
-        "occurs": pl.Boolean,
         "query": pl.Utf8,
         "duration_days": pl.Int64,
     }
@@ -306,15 +309,15 @@ def evaluate_index_df(
 
     # Rows whose subject is not present in max_time_per_subject (typically a pre-seeded or
     # hand-edited index_df referencing subjects outside this shard) come out of the left join
-    # with max_time=null.  A naïve comparison would produce null booleans, which would break
-    # downstream torch conversion.  Policy: treat unknown-subject rows as fully censored
-    # (boolean_value=True, occurs=False) — the same outcome a real "no future data observed"
-    # row would produce.  We log a warning so the condition is visible.
+    # with max_time=null.  A naïve comparison would produce null booleans, which is the
+    # correct "censored" signal under the collapsed label semantics — so we just log a
+    # warning for visibility and let the `(window_end > max_time).fill_null(True)` below
+    # resolve the missing-subject case to censored.
     n_unknown = joined.filter(pl.col("max_time").is_null()).height
     if n_unknown > 0:
         logger.warning(
             "%d index_df row(s) reference subjects not present in events_df; "
-            "they will be labeled as censored (boolean_value=True, occurs=False).",
+            "they will be labeled as censored (boolean_value=null).",
             n_unknown,
         )
 
@@ -324,13 +327,11 @@ def evaluate_index_df(
     censored = (window_end > pl.col("max_time")).fill_null(True)
     event_in_window = pl.col("time").is_not_null() & (pl.col("time") < window_end)
 
-    return (
-        joined.with_columns(censored.alias("_censored"))
-        .with_columns(
-            pl.col("_censored").alias("boolean_value"),
-            (pl.col("_censored").not_() & event_in_window).alias("occurs"),
-        )
-        .select("subject_id", "prediction_time", "boolean_value", "occurs", "query", "duration_days")
+    # Collapsed nullable label: null when censored, else True/False from event_in_window.
+    boolean_value = pl.when(censored).then(pl.lit(None, dtype=pl.Boolean)).otherwise(event_in_window)
+
+    return joined.with_columns(boolean_value.alias("boolean_value")).select(
+        "subject_id", "prediction_time", "boolean_value", "query", "duration_days"
     )
 
 

--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -39,10 +39,10 @@ from pathlib import Path
 import hydra
 import numpy as np
 import polars as pl
-import pyarrow as pa
+from meds import DataSchema
 from omegaconf import DictConfig
 
-from every_query.data.schema import TaskQuerySchema
+from every_query.data.schema import TaskQuerySchema, empty_task_query_df
 from every_query.utils.seeds import derive_seed
 
 logger = logging.getLogger(__name__)
@@ -197,22 +197,33 @@ def build_index_df(
     """
     n_tasks = len(tasks)
 
+    # ``task_id`` is intermediate-only (ignored by ``evaluate_index_df``) so it's not on
+    # TaskQuerySchema; everything else comes from the schema's exported ``_name`` attrs.
+    task_id_col = "task_id"
+    index_cols = [
+        task_id_col,
+        TaskQuerySchema.subject_id_name,
+        TaskQuerySchema.prediction_time_name,
+        TaskQuerySchema.query_name,
+        TaskQuerySchema.duration_days_name,
+    ]
+
     def _empty(pt_dtype: pl.DataType, sid_dtype: pl.DataType) -> pl.DataFrame:
         return pl.DataFrame(
             schema={
-                "task_id": pl.Int64,
-                "subject_id": sid_dtype,
-                "prediction_time": pt_dtype,
-                "query": pl.Utf8,
+                task_id_col: pl.Int64,
+                TaskQuerySchema.subject_id_name: sid_dtype,
+                TaskQuerySchema.prediction_time_name: pt_dtype,
+                TaskQuerySchema.query_name: pl.Utf8,
                 # ``Float32`` matches ``TaskQuerySchema.duration_days`` (``pa.float32``);
                 # emitting Float32 directly means downstream ``TaskQuerySchema.align()``
                 # calls don't need to coerce types at the write boundary.
-                "duration_days": pl.Float32,
+                TaskQuerySchema.duration_days_name: pl.Float32,
             }
         )
 
-    pt_dtype = contexts.schema.get("prediction_time", pl.Datetime("us"))
-    sid_dtype = contexts.schema.get("subject_id", pl.Int64)
+    pt_dtype = contexts.schema.get(TaskQuerySchema.prediction_time_name, pl.Datetime("us"))
+    sid_dtype = contexts.schema.get(TaskQuerySchema.subject_id_name, pl.Int64)
 
     if n_tasks == 0 or contexts.height == 0:
         return _empty(pt_dtype, sid_dtype)
@@ -222,25 +233,23 @@ def build_index_df(
     contexts_per_task = contexts.height // n_tasks
 
     task_ids = pl.Series(
-        "task_id",
+        task_id_col,
         np.repeat(np.arange(n_tasks, dtype=np.int64), contexts_per_task),
     )
     query_col = pl.Series(
-        "query",
+        TaskQuerySchema.query_name,
         np.repeat([t.code for t in tasks], contexts_per_task),
         dtype=pl.Utf8,
     )
     # Float32 matches TaskQuerySchema's duration_days type so the final labeled output
     # aligns to the schema without a type-coercion step at the write boundary.
     duration_col = pl.Series(
-        "duration_days",
+        TaskQuerySchema.duration_days_name,
         np.repeat([t.duration_days for t in tasks], contexts_per_task).astype(np.float32),
         dtype=pl.Float32,
     )
 
-    return contexts.with_columns(task_ids, query_col, duration_col).select(
-        "task_id", "subject_id", "prediction_time", "query", "duration_days"
-    )
+    return contexts.with_columns(task_ids, query_col, duration_col).select(index_cols)
 
 
 def compute_max_time_per_subject(events_df: pl.DataFrame) -> pl.DataFrame:
@@ -249,7 +258,9 @@ def compute_max_time_per_subject(events_df: pl.DataFrame) -> pl.DataFrame:
     Used once per shard to turn the per-row censoring check into an O(1) lookup inside
     ``evaluate_index_df``.
     """
-    return events_df.group_by("subject_id").agg(pl.col("time").max().alias("max_time"))
+    return events_df.group_by(DataSchema.subject_id_name).agg(
+        pl.col(DataSchema.time_name).max().alias("max_time")
+    )
 
 
 def evaluate_index_df(
@@ -283,38 +294,46 @@ def evaluate_index_df(
         DataFrame with columns ``(subject_id, prediction_time, boolean_value, query,
         duration_days)``.  ``boolean_value`` is nullable (``null`` = censored).
     """
-    # Empty-input fast-path: build an empty TaskQuerySchema-conformant table via the
-    # schema itself (rather than hand-rolling a matching polars schema dict).  The
-    # downstream consumer only cares that the column set + dtypes match the schema;
-    # using TaskQuerySchema.schema() directly eliminates the drift risk of keeping two
-    # parallel type lists in sync.
+    # Output column set lives on ``TaskQuerySchema`` — the 4 required columns plus the
+    # inherited (optional) ``boolean_value`` for the collapsed label.  Defining it once
+    # here avoids drift between the empty-path shape, the non-empty-path projection, and
+    # the ``run_worker`` write-boundary validation.
+    out_cols = [
+        TaskQuerySchema.subject_id_name,
+        TaskQuerySchema.prediction_time_name,
+        TaskQuerySchema.boolean_value_name,
+        TaskQuerySchema.query_name,
+        TaskQuerySchema.duration_days_name,
+    ]
+
+    # Empty-input fast-path: use the schema-driven empty builder in ``every_query.data``
+    # rather than hand-rolling a matching polars schema dict — same column set, same
+    # dtypes, guaranteed to pass ``TaskQuerySchema.align()`` downstream.
     if index_df.height == 0:
-        arrow_schema = TaskQuerySchema.schema()
-        empty_table = pa.Table.from_pylist([], schema=arrow_schema)
-        return pl.from_arrow(empty_table).select(
-            "subject_id", "prediction_time", "boolean_value", "query", "duration_days"
-        )
+        return empty_task_query_df().select(out_cols)
 
     # Left side: index rows with a +1µs-shifted prediction_time for the strict-> asof key.
     left = index_df.with_columns(
-        (pl.col("prediction_time") + pl.duration(microseconds=1)).alias("_pt_shifted")
-    ).sort(["subject_id", "query", "_pt_shifted"])
+        (pl.col(TaskQuerySchema.prediction_time_name) + pl.duration(microseconds=1)).alias("_pt_shifted")
+    ).sort([TaskQuerySchema.subject_id_name, TaskQuerySchema.query_name, "_pt_shifted"])
 
-    # Right side: events renamed so the join-by column name matches the left.
+    # Right side: events renamed so the join-by column name matches the left.  The events
+    # frame uses ``DataSchema.code_name`` for the code column; we rename it to the
+    # TaskQuerySchema ``query`` column so the asof ``by=`` key aligns on both sides.
     right = (
-        events_df.rename({"code": "query"})
-        .select(["subject_id", "query", "time"])
-        .sort(["subject_id", "query", "time"])
+        events_df.rename({DataSchema.code_name: TaskQuerySchema.query_name})
+        .select([TaskQuerySchema.subject_id_name, TaskQuerySchema.query_name, DataSchema.time_name])
+        .sort([TaskQuerySchema.subject_id_name, TaskQuerySchema.query_name, DataSchema.time_name])
     )
 
     joined = left.join_asof(
         right,
-        by=["subject_id", "query"],
+        by=[TaskQuerySchema.subject_id_name, TaskQuerySchema.query_name],
         left_on="_pt_shifted",
-        right_on="time",
+        right_on=DataSchema.time_name,
         strategy="forward",
     )
-    joined = joined.join(max_time_per_subject, on="subject_id", how="left")
+    joined = joined.join(max_time_per_subject, on=TaskQuerySchema.subject_id_name, how="left")
 
     # Rows whose subject is not present in max_time_per_subject (typically a pre-seeded or
     # hand-edited index_df referencing subjects outside this shard) come out of the left join
@@ -330,18 +349,16 @@ def evaluate_index_df(
             n_unknown,
         )
 
-    duration_expr = pl.duration(days=pl.col("duration_days"))
-    window_end = pl.col("prediction_time") + duration_expr
+    duration_expr = pl.duration(days=pl.col(TaskQuerySchema.duration_days_name))
+    window_end = pl.col(TaskQuerySchema.prediction_time_name) + duration_expr
     # `(window_end > max_time).fill_null(True)` resolves the missing-subject case to censored.
     censored = (window_end > pl.col("max_time")).fill_null(True)
-    event_in_window = pl.col("time").is_not_null() & (pl.col("time") < window_end)
+    event_in_window = pl.col(DataSchema.time_name).is_not_null() & (pl.col(DataSchema.time_name) < window_end)
 
     # Collapsed nullable label: null when censored, else True/False from event_in_window.
     boolean_value = pl.when(censored).then(pl.lit(None, dtype=pl.Boolean)).otherwise(event_in_window)
 
-    return joined.with_columns(boolean_value.alias("boolean_value")).select(
-        "subject_id", "prediction_time", "boolean_value", "query", "duration_days"
-    )
+    return joined.with_columns(boolean_value.alias(TaskQuerySchema.boolean_value_name)).select(out_cols)
 
 
 # ---------------------------------------------------------------------------
@@ -493,13 +510,14 @@ def run_worker(
     # Downstream MEDS dataloader does not use task_id; it is intentionally absent from the
     # published schema.
     #
-    # Validate the output against TaskQuerySchema at the write boundary.  The column set
-    # and types should already conform (evaluate_index_df emits schema-shaped output and
-    # duration_days is Float32 from build_index_df), so this is a guardrail against silent
-    # upstream drift rather than a coercion step — if ``align`` has to do any work we
-    # treat that as a bug in the producer, not something the write path papers over.
-    TaskQuerySchema.validate(labeled.to_arrow())
-    _atomic_write_parquet(labeled, labels_fp)
+    # Align the output against TaskQuerySchema at the write boundary.  ``align`` is
+    # preferred over ``validate`` here because it (a) reorders columns into the schema's
+    # canonical order and (b) casts mistyped columns to the declared dtypes — so even if
+    # an upstream edit silently changes one type (e.g., reverting ``build_index_df`` to
+    # emit ``Int64`` durations), the on-disk parquet still conforms.  Missing or extra
+    # columns remain hard errors (``align`` re-raises on those).
+    aligned = TaskQuerySchema.align(labeled.to_arrow())
+    _atomic_write_parquet(pl.from_arrow(aligned), labels_fp)
     logger.info("Wrote %d labeled rows to %s", labeled.height, labels_fp)
     return labels_fp
 

--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -25,7 +25,7 @@ Design decisions (see issue #33):
 - **Censoring**: computed from ``max_time`` per subject (one groupby up-front per shard). Censored
   rows get ``boolean_value=True`` and ``occurs=False`` regardless of whether the event actually
   fired in the window.
-- **Single-pass evaluation**: one ``join_asof(strategy="forward", by=["subject_id","code"])`` across
+- **Single-pass evaluation**: one ``join_asof(strategy="forward", by=["subject_id","query"])`` across
   the whole ``index_df`` against the events table, regardless of how many distinct codes are present.
 """
 
@@ -191,7 +191,7 @@ def build_index_df(
     independently per task.
 
     Returns:
-        ``DataFrame`` with columns ``(task_id, subject_id, prediction_time, code, duration_days)``.
+        ``DataFrame`` with columns ``(task_id, subject_id, prediction_time, query, duration_days)``.
     """
     n_tasks = len(tasks)
 
@@ -201,7 +201,7 @@ def build_index_df(
                 "task_id": pl.Int64,
                 "subject_id": sid_dtype,
                 "prediction_time": pt_dtype,
-                "code": pl.Utf8,
+                "query": pl.Utf8,
                 "duration_days": pl.Int64,
             }
         )
@@ -220,8 +220,8 @@ def build_index_df(
         "task_id",
         np.repeat(np.arange(n_tasks, dtype=np.int64), contexts_per_task),
     )
-    code_col = pl.Series(
-        "code",
+    query_col = pl.Series(
+        "query",
         np.repeat([t.code for t in tasks], contexts_per_task),
         dtype=pl.Utf8,
     )
@@ -231,8 +231,8 @@ def build_index_df(
         dtype=pl.Int64,
     )
 
-    return contexts.with_columns(task_ids, code_col, duration_col).select(
-        "task_id", "subject_id", "prediction_time", "code", "duration_days"
+    return contexts.with_columns(task_ids, query_col, duration_col).select(
+        "task_id", "subject_id", "prediction_time", "query", "duration_days"
     )
 
 
@@ -262,28 +262,22 @@ def evaluate_index_df(
     stored at microsecond precision, which turns ``strategy="forward"``'s ``>=`` into a strict ``>``.
 
     Args:
-        index_df: Output of ``build_index_df``.  Must have columns ``subject_id``,
-            ``prediction_time``, ``code``, ``duration_days`` — the ``code`` column names
-            the MEDS code the query is asking about, matching the ``TaskQuerySchema``
-            contract in ``every_query.data.schema``.  If ``task_id`` is present it is
-            ignored and dropped from the output.
+        index_df: Output of ``build_index_df``. Must have columns ``subject_id``, ``prediction_time``,
+            ``query``, ``duration_days``. If ``task_id`` is present it is ignored and dropped from
+            the output.
         events_df: Shard events with columns ``subject_id``, ``time``, ``code``.
         max_time_per_subject: Output of ``compute_max_time_per_subject``.
 
     Returns:
-        DataFrame with columns ``(subject_id, prediction_time, boolean_value, occurs,
-        code, duration_days)``.  Conforms to ``TaskQuerySchema`` on the required columns
-        (``subject_id``, ``prediction_time``, ``code``, ``duration_days``) plus the
-        inherited ``boolean_value``; the extra ``occurs`` column is EQ-specific and
-        currently sits alongside the schema (collapsing ``boolean_value`` / ``occurs``
-        into a single nullable label is tracked in #122).
+        DataFrame with columns ``(subject_id, prediction_time, boolean_value, occurs, query,
+        duration_days)``.
     """
     out_schema = {
         "subject_id": index_df.schema.get("subject_id", pl.Int64),
         "prediction_time": index_df.schema.get("prediction_time", pl.Datetime("us")),
         "boolean_value": pl.Boolean,
         "occurs": pl.Boolean,
-        "code": pl.Utf8,
+        "query": pl.Utf8,
         "duration_days": pl.Int64,
     }
     if index_df.height == 0:
@@ -292,15 +286,18 @@ def evaluate_index_df(
     # Left side: index rows with a +1µs-shifted prediction_time for the strict-> asof key.
     left = index_df.with_columns(
         (pl.col("prediction_time") + pl.duration(microseconds=1)).alias("_pt_shifted")
-    ).sort(["subject_id", "code", "_pt_shifted"])
+    ).sort(["subject_id", "query", "_pt_shifted"])
 
-    # Right side: events restricted to the columns needed for the asof join.  Both sides
-    # now share the ``code`` column name so no rename is needed.
-    right = events_df.select(["subject_id", "code", "time"]).sort(["subject_id", "code", "time"])
+    # Right side: events renamed so the join-by column name matches the left.
+    right = (
+        events_df.rename({"code": "query"})
+        .select(["subject_id", "query", "time"])
+        .sort(["subject_id", "query", "time"])
+    )
 
     joined = left.join_asof(
         right,
-        by=["subject_id", "code"],
+        by=["subject_id", "query"],
         left_on="_pt_shifted",
         right_on="time",
         strategy="forward",
@@ -333,7 +330,7 @@ def evaluate_index_df(
             pl.col("_censored").alias("boolean_value"),
             (pl.col("_censored").not_() & event_in_window).alias("occurs"),
         )
-        .select("subject_id", "prediction_time", "boolean_value", "occurs", "code", "duration_days")
+        .select("subject_id", "prediction_time", "boolean_value", "occurs", "query", "duration_days")
     )
 
 
@@ -348,8 +345,8 @@ def _read_event_shard(file_path: str | Path) -> pl.DataFrame:
     The parquet schema is normalized explicitly so the returned frame is type-stable regardless
     of how the source shard encoded strings or timestamps:
 
-    - ``code`` is cast to ``pl.Utf8`` so it compares against the ``code`` column of ``index_df``
-      (also ``Utf8``) in ``evaluate_index_df``'s ``join_asof(by=["subject_id","code"])``.  Mixed
+    - ``code`` is cast to ``pl.Utf8`` so it compares against the ``query`` column of ``index_df``
+      (also ``Utf8``) in ``evaluate_index_df``'s ``join_asof(by=["subject_id","query"])``.  Mixed
       ``Categorical``/``Utf8`` or ``<integer vocab index>``/``Utf8`` joins would either raise or
       silently produce zero matches.  Upstream stages may store codes as categoricals or integer
       vocab indices; casting to ``Utf8`` here avoids coupling to either representation.

--- a/src/every_query/predict/external_tasks/aces_to_eq.py
+++ b/src/every_query/predict/external_tasks/aces_to_eq.py
@@ -42,14 +42,12 @@ def create_eq_task_df(
         output_dir = Path(output_root) / slug
         os.makedirs(output_dir, exist_ok=True)
 
-        # per-code EQ df (no unpivot; one file per input shard).  The ``code`` column
-        # names the MEDS code the query is about, matching the ``TaskQuerySchema``
-        # contract in ``every_query.data.schema``.
+        # per-code EQ df (no unpivot; one file per input shard)
         eq_df = (
             joined_df.select([*base_cols + code])
             .rename({code: "occurs", "censored": "boolean_value"})
-            .with_columns(pl.lit(code).alias("code"))
-            .select(["subject_id", "prediction_time", "code", "boolean_value", "occurs", "task_label"])
+            .with_columns(pl.lit(code).alias("query"))
+            .select(["subject_id", "prediction_time", "query", "boolean_value", "occurs", "task_label"])
         )
 
         out_fp = output_dir / shard_name  # same shard id as original

--- a/src/every_query/predict/external_tasks/aces_to_eq.py
+++ b/src/every_query/predict/external_tasks/aces_to_eq.py
@@ -42,12 +42,14 @@ def create_eq_task_df(
         output_dir = Path(output_root) / slug
         os.makedirs(output_dir, exist_ok=True)
 
-        # per-code EQ df (no unpivot; one file per input shard)
+        # per-code EQ df (no unpivot; one file per input shard).  The ``code`` column
+        # names the MEDS code the query is about, matching the ``TaskQuerySchema``
+        # contract in ``every_query.data.schema``.
         eq_df = (
             joined_df.select([*base_cols + code])
             .rename({code: "occurs", "censored": "boolean_value"})
-            .with_columns(pl.lit(code).alias("query"))
-            .select(["subject_id", "prediction_time", "query", "boolean_value", "occurs", "task_label"])
+            .with_columns(pl.lit(code).alias("code"))
+            .select(["subject_id", "prediction_time", "code", "boolean_value", "occurs", "task_label"])
         )
 
         out_fp = output_dir / shard_name  # same shard id as original

--- a/src/every_query/predict/external_tasks/aces_to_eq.py
+++ b/src/every_query/predict/external_tasks/aces_to_eq.py
@@ -8,6 +8,7 @@ import polars as pl
 from omegaconf import DictConfig
 from tqdm import tqdm
 
+from every_query.data.schema import TaskQuerySchema
 from every_query.utils.codes import code_slug
 
 logger = logging.getLogger(__name__)
@@ -19,8 +20,21 @@ def shard_id(p: Path) -> int:
 
 
 def create_eq_task_df(
-    eq_shard_fp: str, aces_shard_fp: str, codes: list[str], output_root: str, target_rows: int
+    eq_shard_fp: str,
+    aces_shard_fp: str,
+    codes: list[str],
+    output_root: str,
+    target_rows: int,
+    duration_days: float,
 ) -> int:
+    """Convert an ACES task shard + matching EQ all-tasks shard into per-code ``TaskQuerySchema``-conformant
+    parquets, one per code.
+
+    Args:
+        duration_days: Horizon in days to write into the ``duration_days`` column of the
+            output.  Constant across every row emitted by a single ACES conversion —
+            ACES-style tasks carry their window in the task config rather than per-row.
+    """
     # boolean value in aces_shard_df is the real label for the task that will be used for eval
     # Note: every query expected this to eventually be called the "occurs" column as boolean_value
     # is for censoring
@@ -37,6 +51,10 @@ def create_eq_task_df(
 
     base_cols = ["subject_id", "prediction_time", "task_label", "censored"]
 
+    # Output columns conform to TaskQuerySchema + one extra ``task_label`` column the
+    # external-tasks pipeline carries for its own bookkeeping.  TaskQuerySchema allows
+    # extra columns by default (``allow_extra_columns`` inherited from the Schema
+    # base), so the extra passes validation.
     for code in codes:
         slug = code_slug(code)
         output_dir = Path(output_root) / slug
@@ -50,16 +68,29 @@ def create_eq_task_df(
             pl.when(pl.col("censored")).then(pl.lit(None, dtype=pl.Boolean)).otherwise(pl.col(code))
         )
         eq_df = (
-            joined_df.select([*base_cols + code])
+            joined_df.select([*base_cols, code])
             .with_columns(
-                boolean_value.alias("boolean_value"),
-                pl.lit(code).alias("query"),
+                boolean_value.alias(TaskQuerySchema.boolean_value_name),
+                pl.lit(code).alias(TaskQuerySchema.query_name),
+                pl.lit(duration_days).cast(pl.Float32).alias(TaskQuerySchema.duration_days_name),
             )
-            .select(["subject_id", "prediction_time", "query", "boolean_value", "task_label"])
+            .select(
+                [
+                    TaskQuerySchema.subject_id_name,
+                    TaskQuerySchema.prediction_time_name,
+                    TaskQuerySchema.query_name,
+                    TaskQuerySchema.duration_days_name,
+                    TaskQuerySchema.boolean_value_name,
+                    "task_label",
+                ]
+            )
         )
 
+        # Align to TaskQuerySchema at the write boundary — same check the sampler does.
+        aligned = TaskQuerySchema.align(eq_df.to_arrow())
+
         out_fp = output_dir / shard_name  # same shard id as original
-        eq_df.write_parquet(out_fp)
+        pl.from_arrow(aligned).write_parquet(out_fp)
 
         logger.info(f"Wrote to {out_fp}")
 
@@ -88,6 +119,7 @@ def main(cfg: DictConfig) -> None:
             codes=cfg.queries,
             output_root=cfg.output_dir,
             target_rows=cfg.target_rows_per_shard,
+            duration_days=float(cfg.duration_days),
         )
 
 

--- a/src/every_query/predict/external_tasks/aces_to_eq.py
+++ b/src/every_query/predict/external_tasks/aces_to_eq.py
@@ -42,12 +42,20 @@ def create_eq_task_df(
         output_dir = Path(output_root) / slug
         os.makedirs(output_dir, exist_ok=True)
 
-        # per-code EQ df (no unpivot; one file per input shard)
+        # per-code EQ df conforming to TaskQuerySchema's nullable boolean_value:
+        #   null  → censored (input `censored=True`)
+        #   True  → event occurred (input `<code>=True`)
+        #   False → no event, not censored
+        boolean_value = (
+            pl.when(pl.col("censored")).then(pl.lit(None, dtype=pl.Boolean)).otherwise(pl.col(code))
+        )
         eq_df = (
             joined_df.select([*base_cols + code])
-            .rename({code: "occurs", "censored": "boolean_value"})
-            .with_columns(pl.lit(code).alias("query"))
-            .select(["subject_id", "prediction_time", "query", "boolean_value", "occurs", "task_label"])
+            .with_columns(
+                boolean_value.alias("boolean_value"),
+                pl.lit(code).alias("query"),
+            )
+            .select(["subject_id", "prediction_time", "query", "boolean_value", "task_label"])
         )
 
         out_fp = output_dir / shard_name  # same shard id as original

--- a/src/every_query/predict/external_tasks/configs/aces_to_eq.yaml
+++ b/src/every_query/predict/external_tasks/configs/aces_to_eq.yaml
@@ -6,6 +6,12 @@ target_rows_per_shard: 400
 task_name: readmiss_30d/
 queries: ${query_codes}
 
+# Horizon in days to stamp onto the output ``duration_days`` column of every row.
+# ACES-style tasks carry their window in the task config rather than per-row, so this
+# is a single constant per conversion run.  Override per invocation to match whichever
+# ACES task you're converting (``readmiss_30d`` → 30, ``mortality_1y`` → 365, etc.).
+duration_days: 30.0
+
 eq_tasks_all_dir: ${oc.env:TASK_DIR}/all/held_out
 # ACES_SHARDS_DIR lives outside TASK_DIR/OUTPUT_DIR — set it in .env if you use this pipeline.
 aces_shards_dir: ${oc.env:ACES_SHARDS_DIR}/${task_name}/held_out

--- a/tests/test_e2e_foundation.py
+++ b/tests/test_e2e_foundation.py
@@ -36,7 +36,7 @@ def test_generate_tasks_writes_both_splits(eq_sampled_tasks_dir: Path) -> None:
             "prediction_time",
             "boolean_value",
             "occurs",
-            "query",
+            "code",
             "duration_days",
         }, f"unexpected columns in {fps[0]}: {cols}"
 
@@ -56,7 +56,7 @@ def test_generate_tasks_out_dir_contains_only_label_parquets(eq_sampled_tasks_di
         "prediction_time",
         "boolean_value",
         "occurs",
-        "query",
+        "code",
         "duration_days",
     }
     for fp in eq_sampled_tasks_dir.rglob("*.parquet"):

--- a/tests/test_e2e_foundation.py
+++ b/tests/test_e2e_foundation.py
@@ -35,7 +35,6 @@ def test_generate_tasks_writes_both_splits(eq_sampled_tasks_dir: Path) -> None:
             "subject_id",
             "prediction_time",
             "boolean_value",
-            "occurs",
             "query",
             "duration_days",
         }, f"unexpected columns in {fps[0]}: {cols}"
@@ -55,7 +54,6 @@ def test_generate_tasks_out_dir_contains_only_label_parquets(eq_sampled_tasks_di
         "subject_id",
         "prediction_time",
         "boolean_value",
-        "occurs",
         "query",
         "duration_days",
     }

--- a/tests/test_e2e_foundation.py
+++ b/tests/test_e2e_foundation.py
@@ -36,7 +36,7 @@ def test_generate_tasks_writes_both_splits(eq_sampled_tasks_dir: Path) -> None:
             "prediction_time",
             "boolean_value",
             "occurs",
-            "code",
+            "query",
             "duration_days",
         }, f"unexpected columns in {fps[0]}: {cols}"
 
@@ -56,7 +56,7 @@ def test_generate_tasks_out_dir_contains_only_label_parquets(eq_sampled_tasks_di
         "prediction_time",
         "boolean_value",
         "occurs",
-        "code",
+        "query",
         "duration_days",
     }
     for fp in eq_sampled_tasks_dir.rglob("*.parquet"):

--- a/tests/test_eval_suite.py
+++ b/tests/test_eval_suite.py
@@ -7,6 +7,7 @@ import polars as pl
 import pytest
 from omegaconf import ListConfig, OmegaConf
 
+from every_query.data.schema import TaskQuerySchema
 from every_query.evaluate.eval import _model_name
 from every_query.evaluate.gen_task import _resolve_codes, process_eval_tasks
 from every_query.utils.codes import code_slug
@@ -129,31 +130,18 @@ class TestResolveCodes:
 
 
 class TestGenTaskOutputSchema:
-    def test_columns(self, tmp_path):
-        """Output conforms to TaskQuerySchema: subject_id, prediction_time, boolean_value,
-        query, duration_days — occurs/censored collapsed into the nullable boolean_value.
+    def test_conforms_to_task_query_schema(self, tmp_path):
+        """Output conforms to ``TaskQuerySchema`` — validated directly via the schema's ``validate()`` method
+        rather than a hand-rolled column-set check.
+
+        Fails with a field-level diff if the producer drifts (extra columns, missing required columns, wrong
+        dtypes).
         """
         index_dir, task_dir_base, out_root = _build_fixtures(tmp_path)
         process_eval_tasks(index_dir, task_dir_base, out_root, INDEX_HASH, CODES, DURATIONS, "held_out")
 
         df = _read_all_outputs(out_root, INDEX_HASH)
-        expected = {"subject_id", "prediction_time", "boolean_value", "query", "duration_days"}
-        assert set(df.columns) == expected
-
-    def test_non_censored_rows_are_non_null(self, tmp_path):
-        """Rows whose underlying per-code value was null in the wide task matrix (and weren't censored) must
-        be dropped, so every remaining non-censored row has a non-null ``boolean_value``.
-
-        Under the collapsed schema, null ``boolean_value``
-        means censored, not missing data.
-        """
-        index_dir, task_dir_base, out_root = _build_fixtures(tmp_path)
-        process_eval_tasks(index_dir, task_dir_base, out_root, INDEX_HASH, CODES, DURATIONS, "held_out")
-
-        df = _read_all_outputs(out_root, INDEX_HASH)
-        # Compute censored by structural meaning rather than reading a separate column.
-        non_null_rows = df.filter(pl.col("boolean_value").is_not_null())
-        assert non_null_rows["boolean_value"].null_count() == 0
+        TaskQuerySchema.validate(df.to_arrow())
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_eval_suite.py
+++ b/tests/test_eval_suite.py
@@ -130,20 +130,30 @@ class TestResolveCodes:
 
 class TestGenTaskOutputSchema:
     def test_columns(self, tmp_path):
+        """Output conforms to TaskQuerySchema: subject_id, prediction_time, boolean_value,
+        query, duration_days — occurs/censored collapsed into the nullable boolean_value.
+        """
         index_dir, task_dir_base, out_root = _build_fixtures(tmp_path)
         process_eval_tasks(index_dir, task_dir_base, out_root, INDEX_HASH, CODES, DURATIONS, "held_out")
 
         df = _read_all_outputs(out_root, INDEX_HASH)
-        expected = {"subject_id", "prediction_time", "boolean_value", "query", "occurs", "duration_days"}
+        expected = {"subject_id", "prediction_time", "boolean_value", "query", "duration_days"}
         assert set(df.columns) == expected
 
-    def test_no_null_occurs(self, tmp_path):
-        """Rows with null occurs should be filtered out."""
+    def test_non_censored_rows_are_non_null(self, tmp_path):
+        """Rows whose underlying per-code value was null in the wide task matrix (and weren't censored) must
+        be dropped, so every remaining non-censored row has a non-null ``boolean_value``.
+
+        Under the collapsed schema, null ``boolean_value``
+        means censored, not missing data.
+        """
         index_dir, task_dir_base, out_root = _build_fixtures(tmp_path)
         process_eval_tasks(index_dir, task_dir_base, out_root, INDEX_HASH, CODES, DURATIONS, "held_out")
 
         df = _read_all_outputs(out_root, INDEX_HASH)
-        assert df["occurs"].null_count() == 0
+        # Compute censored by structural meaning rather than reading a separate column.
+        non_null_rows = df.filter(pl.col("boolean_value").is_not_null())
+        assert non_null_rows["boolean_value"].null_count() == 0
 
 
 # ---------------------------------------------------------------------------
@@ -297,10 +307,16 @@ class TestGenTaskDirectoryStructure:
 
 class TestGenTaskCensorSource:
     def test_boolean_value_from_task_file_not_index(self, tmp_path):
-        """boolean_value should reflect the duration-specific censored column, not index times."""
+        """``boolean_value`` should reflect the duration-specific ``censored`` column, not the index times.
+
+        Under the collapsed ``TaskQuerySchema`` label:
+        null  → censored
+        True  → event occurred (per-code value = True, not censored)
+        False → no event, not censored (per-code value = False, not censored)
+        """
         base = datetime(2020, 1, 1)
 
-        # Index times (no censored column needed anymore — we only use subject_id, prediction_time)
+        # Index times (no censored column needed — we only use subject_id, prediction_time)
         index_df = pl.DataFrame(
             {
                 "subject_id": [1, 2],
@@ -343,13 +359,13 @@ class TestGenTaskCensorSource:
 
         all_df = _read_all_outputs(out_root, INDEX_HASH)
 
-        # At duration=30, subject 1 should be censored (True)
+        # At duration=30, subject 1 is censored → boolean_value is null.
         row_30_s1 = all_df.filter((pl.col("duration_days") == 30) & (pl.col("subject_id") == 1))
-        assert row_30_s1["boolean_value"][0] is True
+        assert row_30_s1["boolean_value"][0] is None
 
-        # At duration=90, subject 1 should NOT be censored (False)
+        # At duration=90, subject 1 is NOT censored and per-code value was True → True.
         row_90_s1 = all_df.filter((pl.col("duration_days") == 90) & (pl.col("subject_id") == 1))
-        assert row_90_s1["boolean_value"][0] is False
+        assert row_90_s1["boolean_value"][0] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_eval_suite.py
+++ b/tests/test_eval_suite.py
@@ -134,7 +134,7 @@ class TestGenTaskOutputSchema:
         process_eval_tasks(index_dir, task_dir_base, out_root, INDEX_HASH, CODES, DURATIONS, "held_out")
 
         df = _read_all_outputs(out_root, INDEX_HASH)
-        expected = {"subject_id", "prediction_time", "boolean_value", "query", "occurs", "duration_days"}
+        expected = {"subject_id", "prediction_time", "boolean_value", "code", "occurs", "duration_days"}
         assert set(df.columns) == expected
 
     def test_no_null_occurs(self, tmp_path):
@@ -177,8 +177,8 @@ class TestGenTaskDurations:
         process_eval_tasks(index_dir, task_dir_base, out1, INDEX_HASH, CODES, [30, 90, 180], "held_out")
         process_eval_tasks(index_dir, task_dir_base, out2, INDEX_HASH, CODES, [180, 30, 90], "held_out")
 
-        df1 = _read_all_outputs(out1, INDEX_HASH).sort("duration_days", "query", "subject_id")
-        df2 = _read_all_outputs(out2, INDEX_HASH).sort("duration_days", "query", "subject_id")
+        df1 = _read_all_outputs(out1, INDEX_HASH).sort("duration_days", "code", "subject_id")
+        df2 = _read_all_outputs(out2, INDEX_HASH).sort("duration_days", "code", "subject_id")
         assert df1.equals(df2)
 
     def test_same_prediction_times_across_durations(self, tmp_path):
@@ -223,7 +223,7 @@ class TestGenTaskCodes:
         process_eval_tasks(index_dir, task_dir_base, out_root, INDEX_HASH, CODES, DURATIONS, "held_out")
 
         df = _read_all_outputs(out_root, INDEX_HASH)
-        assert set(df["query"].unique().to_list()) == set(CODES)
+        assert set(df["code"].unique().to_list()) == set(CODES)
 
     def test_code_order_invariant(self, tmp_path):
         """Changing code order should produce identical output (when sorted)."""
@@ -236,8 +236,8 @@ class TestGenTaskCodes:
             index_dir, task_dir_base, out2, INDEX_HASH, list(reversed(CODES)), DURATIONS, "held_out"
         )
 
-        df1 = _read_all_outputs(out1, INDEX_HASH).sort("duration_days", "query", "subject_id")
-        df2 = _read_all_outputs(out2, INDEX_HASH).sort("duration_days", "query", "subject_id")
+        df1 = _read_all_outputs(out1, INDEX_HASH).sort("duration_days", "code", "subject_id")
+        df2 = _read_all_outputs(out2, INDEX_HASH).sort("duration_days", "code", "subject_id")
         assert df1.equals(df2)
 
     def test_missing_code_skipped(self, tmp_path):
@@ -250,8 +250,8 @@ class TestGenTaskCodes:
         )
 
         df = _read_all_outputs(out_root, INDEX_HASH)
-        assert "FAKE//MISSING" not in df["query"].unique().to_list()
-        assert set(CODES).issubset(set(df["query"].unique().to_list()))
+        assert "FAKE//MISSING" not in df["code"].unique().to_list()
+        assert set(CODES).issubset(set(df["code"].unique().to_list()))
 
 
 # ---------------------------------------------------------------------------
@@ -420,11 +420,11 @@ class TestGenTaskRowCounts:
         process_eval_tasks(index_dir, task_dir_base, out_root, INDEX_HASH, CODES, DURATIONS, "held_out")
 
         df = _read_all_outputs(out_root, INDEX_HASH)
-        counts = df.group_by("duration_days", "query").len()
+        counts = df.group_by("duration_days", "code").len()
 
         # With identical task data per duration, counts should be uniform across durations for each code
         for code in CODES:
-            code_counts = counts.filter(pl.col("query") == code)["len"].to_list()
+            code_counts = counts.filter(pl.col("code") == code)["len"].to_list()
             assert len(set(code_counts)) == 1, f"Row counts differ across durations for code={code}"
 
 

--- a/tests/test_eval_suite.py
+++ b/tests/test_eval_suite.py
@@ -134,7 +134,7 @@ class TestGenTaskOutputSchema:
         process_eval_tasks(index_dir, task_dir_base, out_root, INDEX_HASH, CODES, DURATIONS, "held_out")
 
         df = _read_all_outputs(out_root, INDEX_HASH)
-        expected = {"subject_id", "prediction_time", "boolean_value", "code", "occurs", "duration_days"}
+        expected = {"subject_id", "prediction_time", "boolean_value", "query", "occurs", "duration_days"}
         assert set(df.columns) == expected
 
     def test_no_null_occurs(self, tmp_path):
@@ -177,8 +177,8 @@ class TestGenTaskDurations:
         process_eval_tasks(index_dir, task_dir_base, out1, INDEX_HASH, CODES, [30, 90, 180], "held_out")
         process_eval_tasks(index_dir, task_dir_base, out2, INDEX_HASH, CODES, [180, 30, 90], "held_out")
 
-        df1 = _read_all_outputs(out1, INDEX_HASH).sort("duration_days", "code", "subject_id")
-        df2 = _read_all_outputs(out2, INDEX_HASH).sort("duration_days", "code", "subject_id")
+        df1 = _read_all_outputs(out1, INDEX_HASH).sort("duration_days", "query", "subject_id")
+        df2 = _read_all_outputs(out2, INDEX_HASH).sort("duration_days", "query", "subject_id")
         assert df1.equals(df2)
 
     def test_same_prediction_times_across_durations(self, tmp_path):
@@ -223,7 +223,7 @@ class TestGenTaskCodes:
         process_eval_tasks(index_dir, task_dir_base, out_root, INDEX_HASH, CODES, DURATIONS, "held_out")
 
         df = _read_all_outputs(out_root, INDEX_HASH)
-        assert set(df["code"].unique().to_list()) == set(CODES)
+        assert set(df["query"].unique().to_list()) == set(CODES)
 
     def test_code_order_invariant(self, tmp_path):
         """Changing code order should produce identical output (when sorted)."""
@@ -236,8 +236,8 @@ class TestGenTaskCodes:
             index_dir, task_dir_base, out2, INDEX_HASH, list(reversed(CODES)), DURATIONS, "held_out"
         )
 
-        df1 = _read_all_outputs(out1, INDEX_HASH).sort("duration_days", "code", "subject_id")
-        df2 = _read_all_outputs(out2, INDEX_HASH).sort("duration_days", "code", "subject_id")
+        df1 = _read_all_outputs(out1, INDEX_HASH).sort("duration_days", "query", "subject_id")
+        df2 = _read_all_outputs(out2, INDEX_HASH).sort("duration_days", "query", "subject_id")
         assert df1.equals(df2)
 
     def test_missing_code_skipped(self, tmp_path):
@@ -250,8 +250,8 @@ class TestGenTaskCodes:
         )
 
         df = _read_all_outputs(out_root, INDEX_HASH)
-        assert "FAKE//MISSING" not in df["code"].unique().to_list()
-        assert set(CODES).issubset(set(df["code"].unique().to_list()))
+        assert "FAKE//MISSING" not in df["query"].unique().to_list()
+        assert set(CODES).issubset(set(df["query"].unique().to_list()))
 
 
 # ---------------------------------------------------------------------------
@@ -420,11 +420,11 @@ class TestGenTaskRowCounts:
         process_eval_tasks(index_dir, task_dir_base, out_root, INDEX_HASH, CODES, DURATIONS, "held_out")
 
         df = _read_all_outputs(out_root, INDEX_HASH)
-        counts = df.group_by("duration_days", "code").len()
+        counts = df.group_by("duration_days", "query").len()
 
         # With identical task data per duration, counts should be uniform across durations for each code
         for code in CODES:
-            code_counts = counts.filter(pl.col("code") == code)["len"].to_list()
+            code_counts = counts.filter(pl.col("query") == code)["len"].to_list()
             assert len(set(code_counts)) == 1, f"Row counts differ across durations for code={code}"
 
 

--- a/tests/test_generate_tasks.py
+++ b/tests/test_generate_tasks.py
@@ -134,14 +134,14 @@ def test_labels_match_ground_truth(
             # 1µs-shifted join_asof key, so we mirror with a strict > comparison here.
             subj_events = events.filter(pl.col("subject_id") == subj)
             event_fires = not subj_events.filter(
-                (pl.col("code") == row["query"])
+                (pl.col("code") == row["code"])
                 & (pl.col("time") > row["prediction_time"])
                 & (pl.col("time") < window_end)
             ).is_empty()
             expected_occurs = (not expected_censored) and event_fires
 
             ctx = (
-                f"split={split}, subject_id={subj}, query={row['query']!r}, "
+                f"split={split}, subject_id={subj}, code={row['code']!r}, "
                 f"prediction_time={row['prediction_time']}, duration_days={row['duration_days']}, "
                 f"max_time={max_time}"
             )
@@ -203,7 +203,7 @@ def test_reproducible_with_same_seed(
 
     # Compare by row content (sorted) since file-byte equality is flaky across polars versions.
     # The invariant we care about: same seed → same labeled rows.
-    sort_cols = ["subject_id", "prediction_time", "query", "duration_days"]
+    sort_cols = ["subject_id", "prediction_time", "code", "duration_days"]
     a = fixture_labels.sort(sort_cols)
     b = rerun_labels.sort(sort_cols)
     assert a.equals(b), (

--- a/tests/test_generate_tasks.py
+++ b/tests/test_generate_tasks.py
@@ -120,13 +120,16 @@ def test_labels_match_ground_truth(
         # Walk every emitted row.  Simple Python — slow for millions of rows but fine for the
         # ~20-row fixture output, and the cost is bounded by CPU + parquet I/O, not test
         # complexity.  Favours readability + ground-truth correctness over vectorisation.
+        #
+        # Collapsed nullable boolean_value per TaskQuerySchema:
+        #   null  → censored (window_end > max_time OR subject absent from events_df)
+        #   True  → event occurred in (prediction_time, window_end)
+        #   False → no event in window and not censored
         for row in labels.iter_rows(named=True):
             subj = row["subject_id"]
             window_end = row["prediction_time"] + timedelta(days=row["duration_days"])
 
             max_time = max_time_per_subject.get(subj)
-            # Sampler policy (per evaluate_index_df docstring): unknown-subject rows resolve to
-            # censored=True.  None case handled via default.
             expected_censored = max_time is None or window_end > max_time
 
             # Ground-truth event_fires: any event of the matching code in
@@ -138,19 +141,18 @@ def test_labels_match_ground_truth(
                 & (pl.col("time") > row["prediction_time"])
                 & (pl.col("time") < window_end)
             ).is_empty()
-            expected_occurs = (not expected_censored) and event_fires
+
+            expected_boolean = None if expected_censored else event_fires
 
             ctx = (
                 f"split={split}, subject_id={subj}, query={row['query']!r}, "
                 f"prediction_time={row['prediction_time']}, duration_days={row['duration_days']}, "
                 f"max_time={max_time}"
             )
-            assert row["boolean_value"] == expected_censored, (
-                f"boolean_value (censored) mismatch: sampler={row['boolean_value']}, "
-                f"expected={expected_censored}.  {ctx}"
-            )
-            assert row["occurs"] == expected_occurs, (
-                f"occurs mismatch: sampler={row['occurs']}, expected={expected_occurs}.  {ctx}"
+            assert row["boolean_value"] == expected_boolean, (
+                f"boolean_value mismatch: sampler={row['boolean_value']!r}, "
+                f"expected={expected_boolean!r} (censored={expected_censored}, "
+                f"event_fires={event_fires}).  {ctx}"
             )
 
 

--- a/tests/test_generate_tasks.py
+++ b/tests/test_generate_tasks.py
@@ -134,14 +134,14 @@ def test_labels_match_ground_truth(
             # 1µs-shifted join_asof key, so we mirror with a strict > comparison here.
             subj_events = events.filter(pl.col("subject_id") == subj)
             event_fires = not subj_events.filter(
-                (pl.col("code") == row["code"])
+                (pl.col("code") == row["query"])
                 & (pl.col("time") > row["prediction_time"])
                 & (pl.col("time") < window_end)
             ).is_empty()
             expected_occurs = (not expected_censored) and event_fires
 
             ctx = (
-                f"split={split}, subject_id={subj}, code={row['code']!r}, "
+                f"split={split}, subject_id={subj}, query={row['query']!r}, "
                 f"prediction_time={row['prediction_time']}, duration_days={row['duration_days']}, "
                 f"max_time={max_time}"
             )
@@ -203,7 +203,7 @@ def test_reproducible_with_same_seed(
 
     # Compare by row content (sorted) since file-byte equality is flaky across polars versions.
     # The invariant we care about: same seed → same labeled rows.
-    sort_cols = ["subject_id", "prediction_time", "code", "duration_days"]
+    sort_cols = ["subject_id", "prediction_time", "query", "duration_days"]
     a = fixture_labels.sort(sort_cols)
     b = rerun_labels.sort(sort_cols)
     assert a.equals(b), (

--- a/tests/test_sample_tasks.py
+++ b/tests/test_sample_tasks.py
@@ -147,11 +147,11 @@ class TestPrimitives:
             "task_id",
             "subject_id",
             "prediction_time",
-            "query",
+            "code",
             "duration_days",
         }
         assert index_df["task_id"].to_list() == [0, 0, 1, 1, 2, 2]
-        assert index_df["query"].to_list() == ["X", "X", "Y", "Y", "Z", "Z"]
+        assert index_df["code"].to_list() == ["X", "X", "Y", "Y", "Z", "Z"]
         assert index_df["duration_days"].to_list() == [30, 30, 60, 60, 90, 90]
 
     def test_build_index_df_m_equals_one(self, synthetic_events):
@@ -210,7 +210,7 @@ class TestEvaluateIndexDfEdgeCases:
             {
                 "subject_id": [1],
                 "prediction_time": [datetime(2020, 1, 3)],
-                "query": ["A"],
+                "code": ["A"],
                 "duration_days": [10],
             }
         ).with_columns(pl.col("prediction_time").cast(pl.Datetime("us")))
@@ -246,7 +246,7 @@ class TestEvaluateIndexDfEdgeCases:
                 # Subject 1 is present; subject 2 is not.
                 "subject_id": [1, 2],
                 "prediction_time": [datetime(2020, 1, 1), datetime(2020, 1, 1)],
-                "query": ["A", "A"],
+                "code": ["A", "A"],
                 "duration_days": [10, 10],
             }
         ).with_columns(pl.col("prediction_time").cast(pl.Datetime("us")))
@@ -328,7 +328,7 @@ class TestReadEventShardDtypeNormalization:
             {
                 "subject_id": [1],
                 "prediction_time": [datetime(2020, 1, 1)],
-                "query": ["A"],
+                "code": ["A"],
                 "duration_days": [10],
             }
         ).with_columns(pl.col("prediction_time").cast(pl.Datetime("us")))
@@ -445,7 +445,7 @@ class TestRunWorkerPipeline:
             "prediction_time",
             "boolean_value",
             "occurs",
-            "query",
+            "code",
             "duration_days",
         }
 
@@ -547,7 +547,7 @@ class TestRunWorkerPipeline:
 
         def _task_multiset(fp):
             df = pl.read_parquet(fp)
-            return sorted(zip(df["query"].to_list(), df["duration_days"].to_list(), strict=True))
+            return sorted(zip(df["code"].to_list(), df["duration_days"].to_list(), strict=True))
 
         assert _task_multiset(labels_a_fp) != _task_multiset(labels_b_fp)
 
@@ -590,8 +590,8 @@ class TestRunWorkerPipeline:
         df_1 = pl.read_parquet(labels_1_fp)
 
         # Same tasks across input shards (task_seed depends only on task_shard).
-        tasks_0 = sorted(set(zip(df_0["query"].to_list(), df_0["duration_days"].to_list(), strict=True)))
-        tasks_1 = sorted(set(zip(df_1["query"].to_list(), df_1["duration_days"].to_list(), strict=True)))
+        tasks_0 = sorted(set(zip(df_0["code"].to_list(), df_0["duration_days"].to_list(), strict=True)))
+        tasks_1 = sorted(set(zip(df_1["code"].to_list(), df_1["duration_days"].to_list(), strict=True)))
         assert tasks_0 == tasks_1, "tasks should be identical across input_shards at fixed task_shard"
 
         # ... but the sampled context pairs must differ (context_seed depends on both axes).
@@ -678,7 +678,7 @@ class TestRunWorkerPipeline:
         assert labels_fp is not None
         labels = pl.read_parquet(labels_fp)
         # The queries in the output must all come from codes.parquet under codes_dir.
-        assert set(labels["query"].to_list()) <= set(synthetic_query_codes)
+        assert set(labels["code"].to_list()) <= set(synthetic_query_codes)
 
 
 # ---------------------------------------------------------------------------
@@ -782,7 +782,7 @@ class TestEndToEndWithDataset:
                 {
                     "subject_id": subj,
                     "prediction_time": _E2E_PRED_TIMES[subj],
-                    "query": q,
+                    "code": q,
                     "duration_days": 30,
                 }
                 for subj in _E2E_TRAIN_SUBJECTS
@@ -792,7 +792,7 @@ class TestEndToEndWithDataset:
             {
                 "subject_id": pl.Int64,
                 "prediction_time": pl.Datetime("us"),
-                "query": pl.Utf8,
+                "code": pl.Utf8,
                 "duration_days": pl.Int64,
             }
         )
@@ -806,7 +806,7 @@ class TestEndToEndWithDataset:
             "prediction_time",
             "boolean_value",
             "occurs",
-            "query",
+            "code",
             "duration_days",
         }
         assert labeled.schema["boolean_value"] == pl.Boolean

--- a/tests/test_sample_tasks.py
+++ b/tests/test_sample_tasks.py
@@ -147,11 +147,11 @@ class TestPrimitives:
             "task_id",
             "subject_id",
             "prediction_time",
-            "code",
+            "query",
             "duration_days",
         }
         assert index_df["task_id"].to_list() == [0, 0, 1, 1, 2, 2]
-        assert index_df["code"].to_list() == ["X", "X", "Y", "Y", "Z", "Z"]
+        assert index_df["query"].to_list() == ["X", "X", "Y", "Y", "Z", "Z"]
         assert index_df["duration_days"].to_list() == [30, 30, 60, 60, 90, 90]
 
     def test_build_index_df_m_equals_one(self, synthetic_events):
@@ -210,7 +210,7 @@ class TestEvaluateIndexDfEdgeCases:
             {
                 "subject_id": [1],
                 "prediction_time": [datetime(2020, 1, 3)],
-                "code": ["A"],
+                "query": ["A"],
                 "duration_days": [10],
             }
         ).with_columns(pl.col("prediction_time").cast(pl.Datetime("us")))
@@ -246,7 +246,7 @@ class TestEvaluateIndexDfEdgeCases:
                 # Subject 1 is present; subject 2 is not.
                 "subject_id": [1, 2],
                 "prediction_time": [datetime(2020, 1, 1), datetime(2020, 1, 1)],
-                "code": ["A", "A"],
+                "query": ["A", "A"],
                 "duration_days": [10, 10],
             }
         ).with_columns(pl.col("prediction_time").cast(pl.Datetime("us")))
@@ -328,7 +328,7 @@ class TestReadEventShardDtypeNormalization:
             {
                 "subject_id": [1],
                 "prediction_time": [datetime(2020, 1, 1)],
-                "code": ["A"],
+                "query": ["A"],
                 "duration_days": [10],
             }
         ).with_columns(pl.col("prediction_time").cast(pl.Datetime("us")))
@@ -445,7 +445,7 @@ class TestRunWorkerPipeline:
             "prediction_time",
             "boolean_value",
             "occurs",
-            "code",
+            "query",
             "duration_days",
         }
 
@@ -547,7 +547,7 @@ class TestRunWorkerPipeline:
 
         def _task_multiset(fp):
             df = pl.read_parquet(fp)
-            return sorted(zip(df["code"].to_list(), df["duration_days"].to_list(), strict=True))
+            return sorted(zip(df["query"].to_list(), df["duration_days"].to_list(), strict=True))
 
         assert _task_multiset(labels_a_fp) != _task_multiset(labels_b_fp)
 
@@ -590,8 +590,8 @@ class TestRunWorkerPipeline:
         df_1 = pl.read_parquet(labels_1_fp)
 
         # Same tasks across input shards (task_seed depends only on task_shard).
-        tasks_0 = sorted(set(zip(df_0["code"].to_list(), df_0["duration_days"].to_list(), strict=True)))
-        tasks_1 = sorted(set(zip(df_1["code"].to_list(), df_1["duration_days"].to_list(), strict=True)))
+        tasks_0 = sorted(set(zip(df_0["query"].to_list(), df_0["duration_days"].to_list(), strict=True)))
+        tasks_1 = sorted(set(zip(df_1["query"].to_list(), df_1["duration_days"].to_list(), strict=True)))
         assert tasks_0 == tasks_1, "tasks should be identical across input_shards at fixed task_shard"
 
         # ... but the sampled context pairs must differ (context_seed depends on both axes).
@@ -678,7 +678,7 @@ class TestRunWorkerPipeline:
         assert labels_fp is not None
         labels = pl.read_parquet(labels_fp)
         # The queries in the output must all come from codes.parquet under codes_dir.
-        assert set(labels["code"].to_list()) <= set(synthetic_query_codes)
+        assert set(labels["query"].to_list()) <= set(synthetic_query_codes)
 
 
 # ---------------------------------------------------------------------------
@@ -782,7 +782,7 @@ class TestEndToEndWithDataset:
                 {
                     "subject_id": subj,
                     "prediction_time": _E2E_PRED_TIMES[subj],
-                    "code": q,
+                    "query": q,
                     "duration_days": 30,
                 }
                 for subj in _E2E_TRAIN_SUBJECTS
@@ -792,7 +792,7 @@ class TestEndToEndWithDataset:
             {
                 "subject_id": pl.Int64,
                 "prediction_time": pl.Datetime("us"),
-                "code": pl.Utf8,
+                "query": pl.Utf8,
                 "duration_days": pl.Int64,
             }
         )
@@ -806,7 +806,7 @@ class TestEndToEndWithDataset:
             "prediction_time",
             "boolean_value",
             "occurs",
-            "code",
+            "query",
             "duration_days",
         }
         assert labeled.schema["boolean_value"] == pl.Boolean

--- a/tests/test_sample_tasks.py
+++ b/tests/test_sample_tasks.py
@@ -25,6 +25,7 @@ from meds import train_split
 from meds_torchdata.config import MEDSTorchDataConfig
 
 from every_query.data.dataset import EveryQueryPytorchDataset
+from every_query.data.schema import TaskQuerySchema
 from every_query.generate_tasks import sample_tasks as st
 from every_query.generate_tasks.sample_tasks import (
     TaskSpec,
@@ -432,13 +433,9 @@ class TestRunWorkerPipeline:
 
         labels = pl.read_parquet(labels_fp)
         assert labels.height == 32
-        assert set(labels.columns) == {
-            "subject_id",
-            "prediction_time",
-            "boolean_value",
-            "query",
-            "duration_days",
-        }
+        # Schema conformance is the invariant — validate directly against TaskQuerySchema
+        # rather than hand-rolling the column set (which would drift if the schema grows).
+        TaskQuerySchema.validate(labels.to_arrow())
 
     def test_rerun_is_idempotent_noop(self, tmp_path, synthetic_events, synthetic_query_codes):
         """Second invocation with identical args returns ``None`` and leaves outputs untouched."""
@@ -784,22 +781,17 @@ class TestEndToEndWithDataset:
                 "subject_id": pl.Int64,
                 "prediction_time": pl.Datetime("us"),
                 "query": pl.Utf8,
-                "duration_days": pl.Int64,
+                # Float32 to match TaskQuerySchema.duration_days.
+                "duration_days": pl.Float32,
             }
         )
 
         max_time_df = compute_max_time_per_subject(events_df)
         labeled = evaluate_index_df(index_df, events_df, max_time_df)
 
-        # Sanity: schema matches EveryQueryPytorchDataset's expectations exactly.
-        assert set(labeled.columns) == {
-            "subject_id",
-            "prediction_time",
-            "boolean_value",
-            "query",
-            "duration_days",
-        }
-        assert labeled.schema["boolean_value"] == pl.Boolean
+        # Sanity: labeled output conforms to TaskQuerySchema — same check the write path
+        # in ``run_worker`` does, exercised here at the per-function boundary.
+        TaskQuerySchema.validate(labeled.to_arrow())
 
         labels_fp = Path(labels_dir) / "0.parquet"
         labeled.write_parquet(labels_fp)

--- a/tests/test_sample_tasks.py
+++ b/tests/test_sample_tasks.py
@@ -189,7 +189,11 @@ class TestEvaluateIndexDfEdgeCases:
     """Hand-crafted edge-case tests for ``evaluate_index_df``."""
 
     def test_event_exactly_at_prediction_time_is_excluded(self):
-        """``prediction_time == event_time`` must not count as an occurrence (strict ``>``)."""
+        """``prediction_time == event_time`` must not count as an occurrence (strict ``>``).
+
+        Under the collapsed ``TaskQuerySchema`` label: non-censored row with an event in
+        the window → ``boolean_value = True``; non-censored row without → ``False``.
+        """
         events = pl.DataFrame(
             {
                 "subject_id": [1, 1, 1, 1, 1],
@@ -205,7 +209,7 @@ class TestEvaluateIndexDfEdgeCases:
         ).sort(["subject_id", "time"])
 
         # Construct one index row at prediction_time = 2020-01-03. The event at 2020-01-03
-        # should NOT count. The next event is 2020-01-04, which is within 10d → occurs=True.
+        # should NOT count. The next event is 2020-01-04, which is within 10d → True.
         index_df = pl.DataFrame(
             {
                 "subject_id": [1],
@@ -216,23 +220,17 @@ class TestEvaluateIndexDfEdgeCases:
         ).with_columns(pl.col("prediction_time").cast(pl.Datetime("us")))
         max_time_df = compute_max_time_per_subject(events)
         result = evaluate_index_df(index_df, events, max_time_df)
-        assert result["boolean_value"].to_list() == [False]
-        assert result["occurs"].to_list() == [True]
+        assert result["boolean_value"].to_list() == [True]
 
-        # Now with duration=0: no window → occurs=False (and not censored because 2020-01-03
+        # Now with duration=0: no window → False (and not censored because 2020-01-03
         # + 0 days = 2020-01-03 which is <= 2021-01-01).
         index_df_zero = index_df.with_columns(pl.lit(0, dtype=pl.Int64).alias("duration_days"))
         result_zero = evaluate_index_df(index_df_zero, events, max_time_df)
-        assert result_zero["occurs"].to_list() == [False]
+        assert result_zero["boolean_value"].to_list() == [False]
 
     def test_unknown_subject_is_treated_as_censored(self, caplog):
-        """An index_df row referencing a subject absent from events_df must not produce null booleans — the
-        torch collate can't consume nulls.
-
-        Policy: treat missing-subject rows as
-        censored (boolean_value=True, occurs=False) and emit a warning so the condition is
-        visible to the user.
-        """
+        """An index_df row referencing a subject absent from events_df resolves to censored (``boolean_value =
+        null``) under the collapsed schema, and emits a warning."""
         events = pl.DataFrame(
             {
                 "subject_id": [1],
@@ -255,14 +253,9 @@ class TestEvaluateIndexDfEdgeCases:
         with caplog.at_level("WARNING", logger="every_query.generate_tasks.sample_tasks"):
             result = evaluate_index_df(index_df, events, max_time_df)
 
-        # Neither row produces a null label.
-        assert result["boolean_value"].null_count() == 0
-        assert result["occurs"].null_count() == 0
-
-        # Subject 2 (unknown) → censored, not occurred.
+        # Subject 2 (unknown) → censored → null boolean_value.
         unknown = result.filter(pl.col("subject_id") == 2)
-        assert unknown["boolean_value"].to_list() == [True]
-        assert unknown["occurs"].to_list() == [False]
+        assert unknown["boolean_value"].to_list() == [None]
 
         # Warning was emitted with a count.
         assert any("not present in events_df" in record.message for record in caplog.records), (
@@ -335,9 +328,8 @@ class TestReadEventShardDtypeNormalization:
 
         result = evaluate_index_df(index_df, events, compute_max_time_per_subject(events))
         # Uncensored (max_time = 2021-01-01 is way past prediction + 10d) and the next "A"
-        # event is 2020-01-02, which is strictly within the window → occurs=True.
-        assert result["boolean_value"].to_list() == [False]
-        assert result["occurs"].to_list() == [True]
+        # event is 2020-01-02, which is strictly within the window → boolean_value=True.
+        assert result["boolean_value"].to_list() == [True]
 
 
 class TestAtomicWriteConcurrency:
@@ -444,7 +436,6 @@ class TestRunWorkerPipeline:
             "subject_id",
             "prediction_time",
             "boolean_value",
-            "occurs",
             "query",
             "duration_days",
         }
@@ -805,12 +796,10 @@ class TestEndToEndWithDataset:
             "subject_id",
             "prediction_time",
             "boolean_value",
-            "occurs",
             "query",
             "duration_days",
         }
         assert labeled.schema["boolean_value"] == pl.Boolean
-        assert labeled.schema["occurs"] == pl.Boolean
 
         labels_fp = Path(labels_dir) / "0.parquet"
         labeled.write_parquet(labels_fp)

--- a/tests/training_validity/README.md
+++ b/tests/training_validity/README.md
@@ -172,41 +172,45 @@ shape: (10, 4)
 
 ```
 
-The head of the labels DataFrame shows how the marker pair maps onto
-(censored, occurs) across the three durations — three rows per subject, one per
-queried duration:
+The head of the labels DataFrame shows how the marker pair maps onto the
+collapsed nullable `boolean_value` (per `TaskQuerySchema`: `null` =
+censored, `true` = event occurred in window, `false` = no event and not
+censored) across the three durations — three rows per subject, one per queried
+duration:
 
 ```python
 >>> labels.head(9)
-shape: (9, 6)
-┌────────────┬─────────────────────┬───────────────┬────────┬────────┬───────────────┐
-│ subject_id ┆ prediction_time     ┆ boolean_value ┆ occurs ┆ query  ┆ duration_days │
-│ ---        ┆ ---                 ┆ ---           ┆ ---    ┆ ---    ┆ ---           │
-│ i64        ┆ datetime[μs]        ┆ bool          ┆ bool   ┆ str    ┆ i64           │
-╞════════════╪═════════════════════╪═══════════════╪════════╪════════╪═══════════════╡
-│ 1000       ┆ 2020-01-11 00:00:00 ┆ false         ┆ false  ┆ TARGET ┆ 1             │
-│ 1000       ┆ 2020-01-11 00:00:00 ┆ false         ┆ false  ┆ TARGET ┆ 7             │
-│ 1000       ┆ 2020-01-11 00:00:00 ┆ false         ┆ true   ┆ TARGET ┆ 30            │
-│ 1001       ┆ 2020-01-11 00:00:00 ┆ false         ┆ false  ┆ TARGET ┆ 1             │
-│ 1001       ┆ 2020-01-11 00:00:00 ┆ false         ┆ false  ┆ TARGET ┆ 7             │
-│ 1001       ┆ 2020-01-11 00:00:00 ┆ false         ┆ true   ┆ TARGET ┆ 30            │
-│ 1002       ┆ 2020-01-11 00:00:00 ┆ false         ┆ false  ┆ TARGET ┆ 1             │
-│ 1002       ┆ 2020-01-11 00:00:00 ┆ false         ┆ false  ┆ TARGET ┆ 7             │
-│ 1002       ┆ 2020-01-11 00:00:00 ┆ true          ┆ false  ┆ TARGET ┆ 30            │
-└────────────┴─────────────────────┴───────────────┴────────┴────────┴───────────────┘
+shape: (9, 5)
+┌────────────┬─────────────────────┬───────────────┬────────┬───────────────┐
+│ subject_id ┆ prediction_time     ┆ boolean_value ┆ query  ┆ duration_days │
+│ ---        ┆ ---                 ┆ ---           ┆ ---    ┆ ---           │
+│ i64        ┆ datetime[μs]        ┆ bool          ┆ str    ┆ i64           │
+╞════════════╪═════════════════════╪═══════════════╪════════╪═══════════════╡
+│ 1000       ┆ 2020-01-11 00:00:00 ┆ false         ┆ TARGET ┆ 1             │
+│ 1000       ┆ 2020-01-11 00:00:00 ┆ false         ┆ TARGET ┆ 7             │
+│ 1000       ┆ 2020-01-11 00:00:00 ┆ true          ┆ TARGET ┆ 30            │
+│ 1001       ┆ 2020-01-11 00:00:00 ┆ false         ┆ TARGET ┆ 1             │
+│ 1001       ┆ 2020-01-11 00:00:00 ┆ false         ┆ TARGET ┆ 7             │
+│ 1001       ┆ 2020-01-11 00:00:00 ┆ true          ┆ TARGET ┆ 30            │
+│ 1002       ┆ 2020-01-11 00:00:00 ┆ false         ┆ TARGET ┆ 1             │
+│ 1002       ┆ 2020-01-11 00:00:00 ┆ false         ┆ TARGET ┆ 7             │
+│ 1002       ┆ 2020-01-11 00:00:00 ┆ null          ┆ TARGET ┆ 30            │
+└────────────┴─────────────────────┴───────────────┴────────┴───────────────┘
 
 ```
 
 Aggregate positive / censored rates across the full 100-subject training split —
-17/33/26 `occurs=True` at d=1/7/30 (monotone, as the duration-monotonicity check
-requires) and 52/100 censored at d=30 (driven by the `P_END_D20` end marker, which
-ends observation at day 20 — inside the 30-day query window):
+17/33/26 `boolean_value=True` (event occurred) at d=1/7/30 (monotone, as the
+duration-monotonicity check requires), and 52/100 censored at d=30 (driven by
+the `P_END_D20` end marker, which ends observation at day 20 — inside the
+30-day query window). Counts are derived directly from the nullable
+`boolean_value`: `n_censored` = null count, `n_occurs` = True count:
 
 ```python
 >>> labels.group_by("duration_days").agg(
 ...     pl.len().alias("n"),
-...     pl.col("boolean_value").sum().alias("n_censored"),
-...     pl.col("occurs").sum().alias("n_occurs"),
+...     pl.col("boolean_value").is_null().sum().alias("n_censored"),
+...     pl.col("boolean_value").sum().alias("n_occurs"),
 ... ).sort("duration_days")
 shape: (3, 4)
 ┌───────────────┬─────┬────────────┬──────────┐
@@ -242,36 +246,36 @@ shape: (3, 4)
 │ 1000       ┆ 2020-01-01 00:00:00 UTC ┆ P_FIRE_D15 ┆ null          │
 │ 1000       ┆ 2020-01-26 00:00:00 UTC ┆ TARGET     ┆ null          │
 └────────────┴─────────────────────────┴────────────┴───────────────┘
->>> labels.filter(pl.col("subject_id") == 1000).select("duration_days", "boolean_value", "occurs")
-shape: (3, 3)
-┌───────────────┬───────────────┬────────┐
-│ duration_days ┆ boolean_value ┆ occurs │
-│ ---           ┆ ---           ┆ ---    │
-│ i64           ┆ bool          ┆ bool   │
-╞═══════════════╪═══════════════╪════════╡
-│ 1             ┆ false         ┆ false  │
-│ 7             ┆ false         ┆ false  │
-│ 30            ┆ false         ┆ true   │
-└───────────────┴───────────────┴────────┘
+>>> labels.filter(pl.col("subject_id") == 1000).select("duration_days", "boolean_value")
+shape: (3, 2)
+┌───────────────┬───────────────┐
+│ duration_days ┆ boolean_value │
+│ ---           ┆ ---           │
+│ i64           ┆ bool          │
+╞═══════════════╪═══════════════╡
+│ 1             ┆ false         │
+│ 7             ┆ false         │
+│ 30            ┆ true          │
+└───────────────┴───────────────┘
 
 ```
 
 Contrast: `subject_id=1003` drew `P_FIRE_D05 + P_END_D20` — `TARGET` fires on day
 10.5 (inside every duration window) but observation ends at day 20, censoring the
-d=30 window:
+d=30 window (`boolean_value = null`):
 
 ```python
->>> labels.filter(pl.col("subject_id") == 1003).select("duration_days", "boolean_value", "occurs")
-shape: (3, 3)
-┌───────────────┬───────────────┬────────┐
-│ duration_days ┆ boolean_value ┆ occurs │
-│ ---           ┆ ---           ┆ ---    │
-│ i64           ┆ bool          ┆ bool   │
-╞═══════════════╪═══════════════╪════════╡
-│ 1             ┆ false         ┆ true   │
-│ 7             ┆ false         ┆ true   │
-│ 30            ┆ true          ┆ false  │
-└───────────────┴───────────────┴────────┘
+>>> labels.filter(pl.col("subject_id") == 1003).select("duration_days", "boolean_value")
+shape: (3, 2)
+┌───────────────┬───────────────┐
+│ duration_days ┆ boolean_value │
+│ ---           ┆ ---           │
+│ i64           ┆ bool          │
+╞═══════════════╪═══════════════╡
+│ 1             ┆ true          │
+│ 7             ┆ true          │
+│ 30            ┆ null          │
+└───────────────┴───────────────┘
 
 ```
 
@@ -331,13 +335,17 @@ was dropped back to 2000.
 Three label-semantics and dataset-construction details worth calling out; all are
 documented inline in the test module too.
 
-1. **`boolean_value` = *censored*, not *occurs***. The EQ sampler overloads MEDS's
-    `boolean_value` label column to mean "censored" (observation ended before we could
-    observe the outcome), and uses a separate `occurs` column for the real positive-class
-    label. The dataset derives `batch.censor = boolean_value` and the model's
-    occurs-loss is masked to `~batch.censor`. Swapping the two labels silently inverts
-    training. (See also [#122][issue-122] for the ongoing discussion of collapsing these
-    into one nullable column.)
+1. **`boolean_value` is a single nullable column**. Per `TaskQuerySchema` in
+    `every_query.data.schema`, the on-disk label collapses censor + occurs into one
+    three-valued column:
+    - `null` → censored (observation ended before we could see)
+    - `True` → event occurred in the duration window
+    - `False` → no event in the window, and not censored
+        At read time, `EveryQueryPytorchDataset.__init__` splits it back into
+        `batch.censor = boolean_value.is_null()` and
+        `batch.occurs = boolean_value.fill_null(False)` so the model's loss wiring
+        (`occurs_loss(mask=~batch.censor)`) doesn't need to change. The test uses the
+        split tensors directly, same as the model. Closes #122.
 2. **`MEDSDataset.write` treats `data_shards` keys as path stems**, so the key
     `"train/0"` produces `data/train/0.parquet` but `"train"` produces
     `data/train.parquet`. MEDS-transforms expects the sharded layout; flat layout
@@ -354,6 +362,5 @@ documented inline in the test module too.
 
 [d1a]: https://github.com/payalchandak/EveryQuery/tree/test/e2e-training-validity-d1a
 [issue-104]: https://github.com/payalchandak/EveryQuery/issues/104
-[issue-122]: https://github.com/payalchandak/EveryQuery/issues/122
 [issue-123]: https://github.com/payalchandak/EveryQuery/issues/123
 [meicar-gen]: https://github.com/mmcdermott/MEDS_EIC_AR/blob/main/tests/test_pattern_generation.py

--- a/tests/training_validity/README.md
+++ b/tests/training_validity/README.md
@@ -180,7 +180,7 @@ queried duration:
 >>> labels.head(9)
 shape: (9, 6)
 ┌────────────┬─────────────────────┬───────────────┬────────┬────────┬───────────────┐
-│ subject_id ┆ prediction_time     ┆ boolean_value ┆ occurs ┆ code   ┆ duration_days │
+│ subject_id ┆ prediction_time     ┆ boolean_value ┆ occurs ┆ query  ┆ duration_days │
 │ ---        ┆ ---                 ┆ ---           ┆ ---    ┆ ---    ┆ ---           │
 │ i64        ┆ datetime[μs]        ┆ bool          ┆ bool   ┆ str    ┆ i64           │
 ╞════════════╪═════════════════════╪═══════════════╪════════╪════════╪═══════════════╡

--- a/tests/training_validity/README.md
+++ b/tests/training_validity/README.md
@@ -180,7 +180,7 @@ queried duration:
 >>> labels.head(9)
 shape: (9, 6)
 ┌────────────┬─────────────────────┬───────────────┬────────┬────────┬───────────────┐
-│ subject_id ┆ prediction_time     ┆ boolean_value ┆ occurs ┆ query  ┆ duration_days │
+│ subject_id ┆ prediction_time     ┆ boolean_value ┆ occurs ┆ code   ┆ duration_days │
 │ ---        ┆ ---                 ┆ ---           ┆ ---    ┆ ---    ┆ ---           │
 │ i64        ┆ datetime[μs]        ┆ bool          ┆ bool   ┆ str    ┆ i64           │
 ╞════════════╪═════════════════════╪═══════════════╪════════╪════════╪═══════════════╡

--- a/tests/training_validity/test_training_validity.py
+++ b/tests/training_validity/test_training_validity.py
@@ -176,7 +176,7 @@ def _compute_labels(events: pl.DataFrame, subject_ids: list[int]) -> pl.DataFram
                     "prediction_time": window_start,
                     "boolean_value": censored,
                     "occurs": occurs,
-                    "code": _TARGET_CODE,
+                    "query": _TARGET_CODE,
                     "duration_days": duration_days,
                 }
             )
@@ -188,7 +188,7 @@ def _compute_labels(events: pl.DataFrame, subject_ids: list[int]) -> pl.DataFram
             "prediction_time": pl.Datetime("us", "UTC"),
             "boolean_value": pl.Boolean,
             "occurs": pl.Boolean,
-            "code": pl.Utf8,
+            "query": pl.Utf8,
             "duration_days": pl.Int64,
         },
     ).with_columns(pl.col("prediction_time").dt.replace_time_zone(None))
@@ -322,7 +322,7 @@ def test_trained_model_learns_occurs_and_censor(
             _, outputs = module.model(batch)
         rows.append(
             {
-                "code": dataset.query[i],
+                "query": dataset.query[i],
                 "duration_days": int(dataset.duration_days[i]),
                 "occurs_true": int(item["occurs"]),
                 "censor_true": int(item["boolean_value"]),
@@ -335,7 +335,7 @@ def test_trained_model_learns_occurs_and_censor(
     # Diagnostics — always print, regardless of pass/fail.
     print("\n[Design 2] per-cell label + prediction distribution (tuning):")
     per_cell = (
-        df.group_by(["code", "duration_days"])
+        df.group_by(["query", "duration_days"])
         .agg(
             pl.len().alias("n"),
             pl.col("occurs_true").cast(pl.Float64).mean().alias("p_occurs_true"),
@@ -343,11 +343,11 @@ def test_trained_model_learns_occurs_and_censor(
             pl.col("censor_true").cast(pl.Float64).mean().alias("p_censor_true"),
             pl.col("censor_pred").mean().alias("p_censor_pred"),
         )
-        .sort(["code", "duration_days"])
+        .sort(["query", "duration_days"])
     )
     for r in per_cell.iter_rows(named=True):
         print(
-            f"  {r['code']:8s} d={r['duration_days']:3d}  n={r['n']:3d}  "
+            f"  {r['query']:8s} d={r['duration_days']:3d}  n={r['n']:3d}  "
             f"p(occurs)={r['p_occurs_true']:.3f} (pred {r['p_occurs_pred']:.3f})  "
             f"p(censor)={r['p_censor_true']:.3f} (pred {r['p_censor_pred']:.3f})"
         )
@@ -380,7 +380,7 @@ def test_trained_model_learns_occurs_and_censor(
     # degenerate cell means synthesis/labeling regressed, so fail explicitly.
     for duration in _DURATIONS_DAYS:
         cell = df.filter(
-            (pl.col("code") == _TARGET_CODE)
+            (pl.col("query") == _TARGET_CODE)
             & (pl.col("duration_days") == duration)
             & (pl.col("censor_true") == 0)
         )

--- a/tests/training_validity/test_training_validity.py
+++ b/tests/training_validity/test_training_validity.py
@@ -176,7 +176,7 @@ def _compute_labels(events: pl.DataFrame, subject_ids: list[int]) -> pl.DataFram
                     "prediction_time": window_start,
                     "boolean_value": censored,
                     "occurs": occurs,
-                    "query": _TARGET_CODE,
+                    "code": _TARGET_CODE,
                     "duration_days": duration_days,
                 }
             )
@@ -188,7 +188,7 @@ def _compute_labels(events: pl.DataFrame, subject_ids: list[int]) -> pl.DataFram
             "prediction_time": pl.Datetime("us", "UTC"),
             "boolean_value": pl.Boolean,
             "occurs": pl.Boolean,
-            "query": pl.Utf8,
+            "code": pl.Utf8,
             "duration_days": pl.Int64,
         },
     ).with_columns(pl.col("prediction_time").dt.replace_time_zone(None))
@@ -322,7 +322,7 @@ def test_trained_model_learns_occurs_and_censor(
             _, outputs = module.model(batch)
         rows.append(
             {
-                "query": dataset.query[i],
+                "code": dataset.query[i],
                 "duration_days": int(dataset.duration_days[i]),
                 "occurs_true": int(item["occurs"]),
                 "censor_true": int(item["boolean_value"]),
@@ -335,7 +335,7 @@ def test_trained_model_learns_occurs_and_censor(
     # Diagnostics — always print, regardless of pass/fail.
     print("\n[Design 2] per-cell label + prediction distribution (tuning):")
     per_cell = (
-        df.group_by(["query", "duration_days"])
+        df.group_by(["code", "duration_days"])
         .agg(
             pl.len().alias("n"),
             pl.col("occurs_true").cast(pl.Float64).mean().alias("p_occurs_true"),
@@ -343,11 +343,11 @@ def test_trained_model_learns_occurs_and_censor(
             pl.col("censor_true").cast(pl.Float64).mean().alias("p_censor_true"),
             pl.col("censor_pred").mean().alias("p_censor_pred"),
         )
-        .sort(["query", "duration_days"])
+        .sort(["code", "duration_days"])
     )
     for r in per_cell.iter_rows(named=True):
         print(
-            f"  {r['query']:8s} d={r['duration_days']:3d}  n={r['n']:3d}  "
+            f"  {r['code']:8s} d={r['duration_days']:3d}  n={r['n']:3d}  "
             f"p(occurs)={r['p_occurs_true']:.3f} (pred {r['p_occurs_pred']:.3f})  "
             f"p(censor)={r['p_censor_true']:.3f} (pred {r['p_censor_pred']:.3f})"
         )
@@ -380,7 +380,7 @@ def test_trained_model_learns_occurs_and_censor(
     # degenerate cell means synthesis/labeling regressed, so fail explicitly.
     for duration in _DURATIONS_DAYS:
         cell = df.filter(
-            (pl.col("query") == _TARGET_CODE)
+            (pl.col("code") == _TARGET_CODE)
             & (pl.col("duration_days") == duration)
             & (pl.col("censor_true") == 0)
         )

--- a/tests/training_validity/test_training_validity.py
+++ b/tests/training_validity/test_training_validity.py
@@ -169,13 +169,16 @@ def _compute_labels(events: pl.DataFrame, subject_ids: list[int]) -> pl.DataFram
                 & (pl.col("time") > window_start)
                 & (pl.col("time") < window_end)
             ).is_empty()
-            occurs = (not censored) and event_fires
+            # Collapsed nullable boolean_value per TaskQuerySchema:
+            #   null  → censored
+            #   True  → event occurred in window
+            #   False → no event, not censored
+            boolean_value = None if censored else event_fires
             rows.append(
                 {
                     "subject_id": subj,
                     "prediction_time": window_start,
-                    "boolean_value": censored,
-                    "occurs": occurs,
+                    "boolean_value": boolean_value,
                     "query": _TARGET_CODE,
                     "duration_days": duration_days,
                 }
@@ -187,7 +190,6 @@ def _compute_labels(events: pl.DataFrame, subject_ids: list[int]) -> pl.DataFram
             "subject_id": pl.Int64,
             "prediction_time": pl.Datetime("us", "UTC"),
             "boolean_value": pl.Boolean,
-            "occurs": pl.Boolean,
             "query": pl.Utf8,
             "duration_days": pl.Int64,
         },


### PR DESCRIPTION
## Summary

Closes #80, closes #122.  Defines the cross-stage task-query schema AND wires it through the sampler + dataset so it's actually load-bearing — not just an unused type definition.

## What lands

- **`src/every_query/data/schema.py`** — `TaskQuerySchema(LabelSchema)` with two required columns plus a nullability override on the inherited `boolean_value`:
  - `query: Required(pa.large_string(), nullable=False)` — the MEDS code the query asks about.  `large_string` matches what polars' `Utf8` serialises to when converted to arrow (verified via `df.to_arrow().schema`), so producers emit schema-conformant output natively and `validate()` / `align()` work without type coercion.
  - `duration_days: Required(pa.float32(), nullable=False)` — fractional-days-capable horizon.
  - `boolean_value: Optional(pa.bool_(), nullable=True)` — overrides MEDS `LabelSchema`'s `nullable=NONE` to allow nulls, since the EveryQuery convention collapses censor + occurs into this single three-valued column (closes #122): `null` = censored, `True` = event occurred, `False` = no event and not censored.
- **Sampler wires the schema through** (`generate_tasks/sample_tasks.py`):
  - `build_index_df` emits `Float32` `duration_days` natively (was `Int64`).
  - `evaluate_index_df` emits the collapsed nullable `boolean_value` (null/True/False) instead of the old `(boolean_value, occurs)` pair.
  - Empty-input fast-path delegates to the new `empty_task_query_df()` helper in `every_query.data.schema` (keyed off the schema's exported `_name` attrs) — no hand-rolled polars-schema dict.
  - `run_worker` calls `TaskQuerySchema.align(labeled.to_arrow())` at the write boundary.  `align()` over `validate()` because it reorders columns + coerces polars-native types (`Utf8` → `large_string`) that producers emit naturally, while still erroring on missing/extra columns or unreconcilable type drift — matching the pattern MEDS-transforms / meds-testing-helpers use internally.
  - All hardcoded `"subject_id"` / `"prediction_time"` / `"query"` / `"duration_days"` / `"boolean_value"` string literals replaced with the schema's exported `{col}_name` class attributes (same for the events-frame columns, which pull from `meds.DataSchema.{col}_name`).
- **Dataset reads the collapsed column + splits it back at read time** (`data/dataset.py::EveryQueryPytorchDataset.__init__`): derives `schema_df["boolean_value"] = is_null()` (censor indicator) + `schema_df["occurs"] = fill_null(False)`.  Batch-level API unchanged — `EveryQueryBatch.censor` + `EveryQueryBatch.occurs` are the names downstream code uses.
- **Other producers** (`predict/external_tasks/aces_to_eq.py`, `evaluate/gen_task.py`) emit the collapsed column too.  `aces_to_eq` now also takes `duration_days` as a required config knob and stamps it into the output, then aligns via `TaskQuerySchema.align(...)` at write.
- **Dataset back-compat branch** — `EveryQueryPytorchDataset.__init__` detects legacy two-column parquets via the presence of an `occurs` column and passes them through untouched; new collapsed parquets (nullable `boolean_value` only) are expanded to the `(boolean_value, occurs)` pair the super class consumes.
- **Tests use `TaskQuerySchema.validate()` for schema assertions** — in `tests/test_sample_tasks.py` and `tests/test_eval_suite.py` — replacing hand-rolled column-set checks.  Test fixtures (`conftest.py::task_labels_dir`, `demo_dataset`, `tests/training_validity/`) updated to emit the collapsed column with correct `Float32` dtype for `duration_days`.
- **Training-validity README doctest** updated to show `boolean_value`-only tables with `null` entries for censored rows; "Gotchas" section rewritten.

## Design choices locked in

- **Extends `LabelSchema`, not `PyArrowSchema` directly.** Matches the pattern `meds-evaluation`'s `PredictionSchema` uses.  Inherited columns: `subject_id`, `prediction_time`, `boolean_value` (now `nullable=True`), `integer_value`, `float_value`, `categorical_value`.
- **Column named `query`, not `code`.** Matches what the sampler / dataset / `EveryQueryBatch.query` already call this column; `code` would collide with `EveryQueryBatch.code` (the inherited event-sequence-token tensor — a distinct thing semantically).
- **`boolean_value` collapsed to a single nullable column** rather than two columns (`boolean_value` + `occurs`).  Cleaner schema contract, and the dataset can always derive the split back if downstream code needs it.  Mirrors MEDS's own label conventions.
- **No `task_query` struct yet.**  Keeping the query flat (just `query` + `duration_days`) honors the narrow-initial-scope direction from #54.  Compound ANY/ALL grammars, structured-query payloads, etc. are extension points for follow-up PRs.

## Test plan

- [x] `uv run pytest` — 206 passed, 1 deselected (slow) in 136s locally.
- [x] `pre-commit run --all-files` — clean.
- [x] CI green (code-quality + tests 3.11/3.12 all pass on 4bc0905).

## Follow-ups

- `EQ_predict` (draft PR [#99](https://github.com/payalchandak/EveryQuery/pull/99)) now inherits `TaskQuerySchema` for `PredictionSchema` + emits `censor_prob` + `occurs_prob` (two-head probabilities).  Unblocked by this PR.
- `EQ_evaluate` consolidation (draft PR [#100](https://github.com/payalchandak/EveryQuery/pull/100)) consumes `PredictionSchema` parquets.  Unblocked by this PR + #99.
- [#129](https://github.com/payalchandak/EveryQuery/issues/129) tracks renaming `occurs_prob → label_prob` once non-occurrence task types land (post-NeurIPS).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
