### PR TITLE
test(e2e): real EQ_generate_tasks integration test + differential + reproducibility

### DIFF
--- a/tests/test_generate_tasks.py
+++ b/tests/test_generate_tasks.py
@@ -8,6 +8,7 @@ reproducibility, and that the ``n_tasks`` knob is actually honored.
 from __future__ import annotations
 
 import hashlib
+import io
 from typing import TYPE_CHECKING
 
 import polars as pl
@@ -34,6 +35,13 @@ def _read_train_labels(tasks_dir: Path) -> pl.DataFrame:
     return pl.concat([pl.read_parquet(fp) for fp in fps], how="vertical")
 
 
+def _parquet_hash(df: pl.DataFrame) -> str:
+    """Return a short hex digest of *df* serialised as Parquet (for assertion messages)."""
+    buf = io.BytesIO()
+    df.write_parquet(buf)
+    return hashlib.sha256(buf.getvalue()).hexdigest()[:16]
+
+
 def test_sampler_output_schema(eq_sampled_tasks_dir: Path) -> None:
     """The labeled shards have exactly the columns MTD expects, with the right dtypes."""
     df = _read_train_labels(eq_sampled_tasks_dir)
@@ -45,15 +53,10 @@ def test_sampler_output_schema(eq_sampled_tasks_dir: Path) -> None:
         "query": pl.Utf8,
         "duration_days": pl.Int64,
     }
-    # Compare by (name, outer-dtype) so Datetime subtypes (μs vs ns) don't break the test.
-    actual = {c: (type(dt) if dt.base_type() == pl.Datetime else dt) for c, dt in df.schema.items()}
-    expected = {
-        c: (type(dt) if isinstance(dt, type) and dt is pl.Datetime else dt)
-        for c, dt in expected_schema.items()
-    }
-    for col, expected_dtype in expected.items():
-        assert col in actual, f"column {col!r} missing from sampler output: {df.columns}"
-        if expected_dtype is type(pl.Datetime):
+    for col, expected_dtype in expected_schema.items():
+        assert col in df.columns, f"column {col!r} missing from sampler output: {df.columns}"
+        if expected_dtype is pl.Datetime:
+            # Compare by base type so Datetime subtypes (μs vs ns) don't break the test across polars versions.
             assert df[col].dtype.base_type() == pl.Datetime, f"{col} is not Datetime: {df[col].dtype}"
         else:
             assert df[col].dtype == expected_dtype, (
@@ -115,8 +118,7 @@ def test_reproducible_with_same_seed(
     b = rerun_labels.filter(pl.col("subject_id").is_not_null()).sort(sort_cols)
     assert a.equals(b), (
         "two EQ_generate_tasks runs with identical seed produced different labeled output.\n"
-        f"fixture hash: {hashlib.sha256(a.write_parquet_buffered().getbuffer()).hexdigest()[:16]}  "
-        f"rerun hash: {hashlib.sha256(b.write_parquet_buffered().getbuffer()).hexdigest()[:16]}"
+        f"fixture hash: {_parquet_hash(a)}  rerun hash: {_parquet_hash(b)}"
     )
 
 

--- a/tests/test_generate_tasks.py
+++ b/tests/test_generate_tasks.py
@@ -1,14 +1,26 @@
 """End-to-end tests for the ``EQ_generate_tasks`` CLI (sample_tasks).
 
-Runs the real console script against a preprocessed cohort (via the
-``eq_sampled_tasks_dir`` fixture) and verifies the label schema, label semantics,
-reproducibility, and that the ``n_tasks`` knob is actually honored.
+These are integration tests: they run the real console script against the preprocessed
+cohort and verify *behavior*, not internal contracts.  Schema-shape checks, dtype checks,
+and bounds-checking on the sampler primitives live in ``test_sample_tasks.py`` — unit-level
+coverage where those properties are cheap and reliable to assert.
+
+The integration tests here do two things that unit tests can't:
+
+- **Run the CLI**: reproducibility and knob-honor differentials can only be checked
+  against the full argparse → Hydra → ``run_worker`` path.
+- **Validate labels against the real raw data**: re-compute what each row's
+  ``(boolean_value, occurs)`` should be directly from the event shard the sampler read,
+  and assert the sampler's output matches exactly across every row.  This catches bugs
+  that schema-shape assertions would miss (wrong censoring math, off-by-one on the window
+  endpoint, missing subject handling, etc.).
 """
 
 from __future__ import annotations
 
 import hashlib
 import io
+from datetime import timedelta
 from typing import TYPE_CHECKING
 
 import polars as pl
@@ -42,40 +54,72 @@ def _parquet_hash(df: pl.DataFrame) -> str:
     return hashlib.sha256(buf.getvalue()).hexdigest()[:16]
 
 
-def test_sampler_output_schema(eq_sampled_tasks_dir: Path) -> None:
-    """The labeled shards have exactly the columns MTD expects, with the right dtypes."""
-    df = _read_train_labels(eq_sampled_tasks_dir)
-    expected_schema = {
-        "subject_id": pl.Int64,
-        "prediction_time": pl.Datetime,
-        "boolean_value": pl.Boolean,
-        "occurs": pl.Boolean,
-        "query": pl.Utf8,
-        "duration_days": pl.Int64,
-    }
-    for col, expected_dtype in expected_schema.items():
-        assert col in df.columns, f"column {col!r} missing from sampler output: {df.columns}"
-        if expected_dtype is pl.Datetime:
-            # Compare by base type so Datetime subtypes (μs vs ns) don't break the test across
-            # polars versions.
-            assert df[col].dtype.base_type() == pl.Datetime, f"{col} is not Datetime: {df[col].dtype}"
-        else:
-            assert df[col].dtype == expected_dtype, (
-                f"column {col!r} has dtype {df[col].dtype}, expected {expected_dtype}"
+def test_labels_match_ground_truth(
+    eq_preprocessed_dataset: Path,
+    eq_sampled_tasks_dir: Path,
+) -> None:
+    """For every row the sampler emitted, recompute ``(boolean_value, occurs)`` from the raw event shard and
+    assert exact equality — per ``evaluate_index_df`` semantics.
+
+    The sampler's documented semantics (``generate_tasks/sample_tasks.py::evaluate_index_df``):
+
+        window_end    = prediction_time + duration_days
+        censored      = window_end > max_time[subject]
+        event_fires   = exists event(subject, code=query, time in (prediction_time, window_end))
+        boolean_value = censored
+        occurs        = (not censored) AND event_fires
+
+    Recomputing row-by-row catches semantics-level bugs that a schema/shape assertion can't:
+    off-by-one on the window endpoint (``<`` vs ``<=``), censoring using the wrong ``max_time``,
+    ``join_asof`` drift across polars versions, subjects whose code never fires being mislabelled,
+    etc.  Covers every row produced by the fixture, not a handful of hand-picked examples.
+    """
+    intermediate = eq_preprocessed_dataset.parent / "intermediate"
+
+    for split in ("train", "tuning"):
+        shard_path = intermediate / "data" / split / "0.parquet"
+        events = pl.read_parquet(shard_path).select(["subject_id", "time", "code"])
+        labels = pl.read_parquet(sorted((eq_sampled_tasks_dir / split).glob("*.parquet"))[0])
+
+        max_time_per_subject = dict(
+            events.group_by("subject_id").agg(pl.col("time").max().alias("max_time")).iter_rows()
+        )
+
+        # Walk every emitted row.  Simple Python — slow for millions of rows but fine for the
+        # ~20-row fixture output, and the cost is bounded by CPU + parquet I/O, not test
+        # complexity.  Favours readability + ground-truth correctness over vectorisation.
+        for row in labels.iter_rows(named=True):
+            subj = row["subject_id"]
+            window_end = row["prediction_time"] + timedelta(days=row["duration_days"])
+
+            max_time = max_time_per_subject.get(subj)
+            # Sampler policy (per evaluate_index_df docstring): unknown-subject rows resolve to
+            # censored=True.  None case handled via default.
+            expected_censored = max_time is None or window_end > max_time
+
+            # Ground-truth event_fires: any event of the matching code in
+            # (prediction_time, prediction_time + duration_days).  Sampler uses strict-> via a
+            # 1µs-shifted join_asof key, so we mirror with a strict > comparison here.
+            subj_events = events.filter(pl.col("subject_id") == subj)
+            event_fires = not subj_events.filter(
+                (pl.col("code") == row["query"])
+                & (pl.col("time") > row["prediction_time"])
+                & (pl.col("time") < window_end)
+            ).is_empty()
+            expected_occurs = (not expected_censored) and event_fires
+
+            ctx = (
+                f"split={split}, subject_id={subj}, query={row['query']!r}, "
+                f"prediction_time={row['prediction_time']}, duration_days={row['duration_days']}, "
+                f"max_time={max_time}"
             )
-
-
-def test_label_semantics(eq_sampled_tasks_dir: Path) -> None:
-    """Labels obey the documented invariants: duration>0, no nulls in key cols."""
-    df = _read_train_labels(eq_sampled_tasks_dir)
-    assert df.height > 0, "sampler produced an empty labeled shard"
-    # Key columns are never null — the sampler guarantees this per issue #80 design.
-    for col in ("subject_id", "prediction_time", "query", "duration_days"):
-        nulls = df[col].null_count()
-        assert nulls == 0, f"column {col!r} has {nulls} null values in sampler output"
-    # Durations are strictly positive integers within the configured sampling bounds.
-    assert df["duration_days"].min() >= _DURATION_MIN
-    assert df["duration_days"].max() <= _DURATION_MAX
+            assert row["boolean_value"] == expected_censored, (
+                f"boolean_value (censored) mismatch: sampler={row['boolean_value']}, "
+                f"expected={expected_censored}.  {ctx}"
+            )
+            assert row["occurs"] == expected_occurs, (
+                f"occurs mismatch: sampler={row['occurs']}, expected={expected_occurs}.  {ctx}"
+            )
 
 
 def test_reproducible_with_same_seed(

--- a/tests/test_generate_tasks.py
+++ b/tests/test_generate_tasks.py
@@ -172,11 +172,24 @@ def test_reproducible_with_same_seed(
     fixture_labels = _read_train_labels(eq_sampled_tasks_dir)
     rerun_labels = _read_train_labels(rerun_out)
 
+    # `subject_id` originates from sampled contexts/index_df and should never be null on a
+    # valid sampler output.  Assert the invariant up-front so any unexpected null rows fail
+    # loudly instead of being silently filtered out by an `is_not_null()` guard (which would
+    # mask both a real sampler regression and any non-label parquet leaking into the split
+    # directory).
+    assert fixture_labels["subject_id"].null_count() == 0, (
+        f"fixture EQ_generate_tasks output has "
+        f"{fixture_labels['subject_id'].null_count()} null subject_id rows"
+    )
+    assert rerun_labels["subject_id"].null_count() == 0, (
+        f"rerun EQ_generate_tasks output has {rerun_labels['subject_id'].null_count()} null subject_id rows"
+    )
+
     # Compare by row content (sorted) since file-byte equality is flaky across polars versions.
     # The invariant we care about: same seed → same labeled rows.
     sort_cols = ["subject_id", "prediction_time", "query", "duration_days"]
-    a = fixture_labels.filter(pl.col("subject_id").is_not_null()).sort(sort_cols)
-    b = rerun_labels.filter(pl.col("subject_id").is_not_null()).sort(sort_cols)
+    a = fixture_labels.sort(sort_cols)
+    b = rerun_labels.sort(sort_cols)
     assert a.equals(b), (
         "two EQ_generate_tasks runs with identical seed produced different labeled output.\n"
         f"fixture hash: {_parquet_hash(a)}  rerun hash: {_parquet_hash(b)}"

--- a/tests/test_generate_tasks.py
+++ b/tests/test_generate_tasks.py
@@ -41,10 +41,20 @@ _MIN_CONTEXT_PER_SUBJECT = 1
 
 
 def _read_train_labels(tasks_dir: Path) -> pl.DataFrame:
-    """Load + concatenate all labeled parquets under the train split of *tasks_dir*."""
+    """Load + concatenate all labeled parquets under the train split of *tasks_dir*.
+
+    Asserts the result is non-empty.  Without that check, an empty-shards regression in
+    `EQ_generate_tasks` would silently turn `test_reproducible_with_same_seed` and
+    `test_n_tasks_knob_is_honored` into vacuous pass cases (e.g., `2 * 0 == 0`).
+    """
     fps = sorted((tasks_dir / "train").glob("*.parquet"))
     assert fps, f"no labeled parquets found under {tasks_dir / 'train'}"
-    return pl.concat([pl.read_parquet(fp) for fp in fps], how="vertical")
+    df = pl.concat([pl.read_parquet(fp) for fp in fps], how="vertical")
+    assert df.height > 0, (
+        f"train labeled parquets under {tasks_dir / 'train'} exist but contain 0 rows; "
+        f"the demo fixture has n_tasks>0 and should always emit at least one label"
+    )
+    return df
 
 
 def _parquet_hash(df: pl.DataFrame) -> str:
@@ -96,6 +106,12 @@ def test_labels_match_ground_truth(
         label_paths = sorted((eq_sampled_tasks_dir / split).glob("*.parquet"))
         assert label_paths, f"no labeled parquets found for split={split} in {eq_sampled_tasks_dir / split}"
         labels = pl.concat([pl.read_parquet(p) for p in label_paths], how="vertical")
+        # Guard against empty-shards regression — without this, the per-row ground-truth
+        # loop below would do zero iterations and the test would pass vacuously.
+        assert labels.height > 0, (
+            f"split={split} produced labeled parquets but 0 rows; ground-truth loop "
+            f"would be vacuous.  Check EQ_generate_tasks for empty-output regression."
+        )
 
         max_time_per_subject = dict(
             events.group_by("subject_id").agg(pl.col("time").max().alias("max_time")).iter_rows()

--- a/tests/test_generate_tasks.py
+++ b/tests/test_generate_tasks.py
@@ -56,7 +56,8 @@ def test_sampler_output_schema(eq_sampled_tasks_dir: Path) -> None:
     for col, expected_dtype in expected_schema.items():
         assert col in df.columns, f"column {col!r} missing from sampler output: {df.columns}"
         if expected_dtype is pl.Datetime:
-            # Compare by base type so Datetime subtypes (μs vs ns) don't break the test across polars versions.
+            # Compare by base type so Datetime subtypes (μs vs ns) don't break the test across
+            # polars versions.
             assert df[col].dtype.base_type() == pl.Datetime, f"{col} is not Datetime: {df[col].dtype}"
         else:
             assert df[col].dtype == expected_dtype, (
@@ -162,5 +163,5 @@ def test_n_tasks_knob_is_honored(
     # rows can be filtered out during the join_asof labeling step.
     assert big_df.height >= int(1.5 * small_df.height), (
         f"n_tasks=16 only produced {big_df.height} rows vs. {small_df.height} at n_tasks=8; "
-        f"expected roughly 2x (allowing 25%% label-drop tolerance)"
+        f"expected roughly 2x (allowing 25% label-drop tolerance)"
     )

--- a/tests/test_generate_tasks.py
+++ b/tests/test_generate_tasks.py
@@ -110,7 +110,7 @@ def test_reproducible_with_same_seed(
     )
 
     fixture_labels = _read_train_labels(eq_sampled_tasks_dir)
-    rerun_labels = pl.read_parquet(sorted((rerun_out / "train").glob("*.parquet")))
+    rerun_labels = _read_train_labels(rerun_out)
 
     # Compare by row content (sorted) since file-byte equality is flaky across polars versions.
     # The invariant we care about: same seed → same labeled rows.
@@ -148,12 +148,13 @@ def test_n_tasks_knob_is_honored(
             f"duration_min={_DURATION_MIN}",
             f"duration_max={_DURATION_MAX}",
             f"min_context_per_subject={_MIN_CONTEXT_PER_SUBJECT}",
+            "seed=1",  # same seed as the fixture; only n_tasks differs
         ],
         timeout=120.0,
     )
 
     small_df = _read_train_labels(eq_sampled_tasks_dir)
-    big_df = pl.read_parquet(sorted((big_out / "train").glob("*.parquet")))
+    big_df = _read_train_labels(big_out)
 
     assert big_df.height > small_df.height, (
         f"n_tasks=16 did not produce more labeled rows than n_tasks=8 "

--- a/tests/test_generate_tasks.py
+++ b/tests/test_generate_tasks.py
@@ -1,0 +1,164 @@
+"""End-to-end tests for the ``EQ_generate_tasks`` CLI (sample_tasks).
+
+Runs the real console script against a preprocessed cohort (via the
+``eq_sampled_tasks_dir`` fixture) and verifies the label schema, label semantics,
+reproducibility, and that the ``n_tasks`` knob is actually honored.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING
+
+import polars as pl
+
+from conftest import run_and_check
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+# Shared CLI overrides matching the foundation fixture.  Duplicated (not factored into a helper)
+# because the fixture's values live in conftest.py and the per-test-run invocations need to diverge
+# from them on specific fields (n_tasks, out_dir) — a helper abstraction would hide the differences
+# we are explicitly testing for.
+_DURATION_MIN = 1
+_DURATION_MAX = 30
+_MIN_CONTEXT_PER_SUBJECT = 1
+
+
+def _read_train_labels(tasks_dir: Path) -> pl.DataFrame:
+    """Load + concatenate all labeled parquets under the train split of *tasks_dir*."""
+    fps = sorted((tasks_dir / "train").glob("*.parquet"))
+    assert fps, f"no labeled parquets found under {tasks_dir / 'train'}"
+    return pl.concat([pl.read_parquet(fp) for fp in fps], how="vertical")
+
+
+def test_sampler_output_schema(eq_sampled_tasks_dir: Path) -> None:
+    """The labeled shards have exactly the columns MTD expects, with the right dtypes."""
+    df = _read_train_labels(eq_sampled_tasks_dir)
+    expected_schema = {
+        "subject_id": pl.Int64,
+        "prediction_time": pl.Datetime,
+        "boolean_value": pl.Boolean,
+        "occurs": pl.Boolean,
+        "query": pl.Utf8,
+        "duration_days": pl.Int64,
+    }
+    # Compare by (name, outer-dtype) so Datetime subtypes (μs vs ns) don't break the test.
+    actual = {c: (type(dt) if dt.base_type() == pl.Datetime else dt) for c, dt in df.schema.items()}
+    expected = {
+        c: (type(dt) if isinstance(dt, type) and dt is pl.Datetime else dt)
+        for c, dt in expected_schema.items()
+    }
+    for col, expected_dtype in expected.items():
+        assert col in actual, f"column {col!r} missing from sampler output: {df.columns}"
+        if expected_dtype is type(pl.Datetime):
+            assert df[col].dtype.base_type() == pl.Datetime, f"{col} is not Datetime: {df[col].dtype}"
+        else:
+            assert df[col].dtype == expected_dtype, (
+                f"column {col!r} has dtype {df[col].dtype}, expected {expected_dtype}"
+            )
+
+
+def test_label_semantics(eq_sampled_tasks_dir: Path) -> None:
+    """Labels obey the documented invariants: duration>0, no nulls in key cols."""
+    df = _read_train_labels(eq_sampled_tasks_dir)
+    assert df.height > 0, "sampler produced an empty labeled shard"
+    # Key columns are never null — the sampler guarantees this per issue #80 design.
+    for col in ("subject_id", "prediction_time", "query", "duration_days"):
+        nulls = df[col].null_count()
+        assert nulls == 0, f"column {col!r} has {nulls} null values in sampler output"
+    # Durations are strictly positive integers within the configured sampling bounds.
+    assert df["duration_days"].min() >= _DURATION_MIN
+    assert df["duration_days"].max() <= _DURATION_MAX
+
+
+def test_reproducible_with_same_seed(
+    eq_preprocessed_dataset: Path,
+    eq_sampled_tasks_dir: Path,
+    tmp_path_factory,
+) -> None:
+    """Two sampler runs with identical seed + sampling params produce identical labels.
+
+    Regression guard: non-deterministic sampling (e.g., forgetting to seed numpy / polars before
+    a shuffle) would silently change eval labels between runs and produce spurious AUROC drift.
+    """
+    intermediate = eq_preprocessed_dataset.parent / "intermediate"
+    rerun_out = tmp_path_factory.mktemp("eq_tasks_rerun")
+    run_and_check(
+        [
+            "EQ_generate_tasks",
+            f"data_dir={intermediate!s}",
+            f"codes_dir={eq_preprocessed_dataset!s}",
+            f"out_dir={rerun_out!s}",
+            "split=train",
+            "input_shard=0",
+            "task_shard=0",
+            "n_tasks=8",
+            "contexts_per_task=2",
+            f"duration_min={_DURATION_MIN}",
+            f"duration_max={_DURATION_MAX}",
+            f"min_context_per_subject={_MIN_CONTEXT_PER_SUBJECT}",
+            "seed=1",
+        ],
+        timeout=120.0,
+    )
+
+    fixture_labels = _read_train_labels(eq_sampled_tasks_dir)
+    rerun_labels = pl.read_parquet(sorted((rerun_out / "train").glob("*.parquet")))
+
+    # Compare by row content (sorted) since file-byte equality is flaky across polars versions.
+    # The invariant we care about: same seed → same labeled rows.
+    sort_cols = ["subject_id", "prediction_time", "query", "duration_days"]
+    a = fixture_labels.filter(pl.col("subject_id").is_not_null()).sort(sort_cols)
+    b = rerun_labels.filter(pl.col("subject_id").is_not_null()).sort(sort_cols)
+    assert a.equals(b), (
+        "two EQ_generate_tasks runs with identical seed produced different labeled output.\n"
+        f"fixture hash: {hashlib.sha256(a.write_parquet_buffered().getbuffer()).hexdigest()[:16]}  "
+        f"rerun hash: {hashlib.sha256(b.write_parquet_buffered().getbuffer()).hexdigest()[:16]}"
+    )
+
+
+def test_n_tasks_knob_is_honored(
+    eq_preprocessed_dataset: Path,
+    eq_sampled_tasks_dir: Path,
+    tmp_path_factory,
+) -> None:
+    """Differential: raising ``n_tasks`` produces more index rows (``n_tasks * contexts_per_task``).
+
+    Catches silent flag-drop — a shape-only test would pass even if ``n_tasks`` were ignored.
+    """
+    intermediate = eq_preprocessed_dataset.parent / "intermediate"
+    big_out = tmp_path_factory.mktemp("eq_tasks_big")
+    run_and_check(
+        [
+            "EQ_generate_tasks",
+            f"data_dir={intermediate!s}",
+            f"codes_dir={eq_preprocessed_dataset!s}",
+            f"out_dir={big_out!s}",
+            "split=train",
+            "input_shard=0",
+            "task_shard=0",
+            "n_tasks=16",  # 2x the fixture's n_tasks=8
+            "contexts_per_task=2",
+            f"duration_min={_DURATION_MIN}",
+            f"duration_max={_DURATION_MAX}",
+            f"min_context_per_subject={_MIN_CONTEXT_PER_SUBJECT}",
+        ],
+        timeout=120.0,
+    )
+
+    small_df = _read_train_labels(eq_sampled_tasks_dir)
+    big_df = pl.read_parquet(sorted((big_out / "train").glob("*.parquet")))
+
+    assert big_df.height > small_df.height, (
+        f"n_tasks=16 did not produce more labeled rows than n_tasks=8 "
+        f"(big={big_df.height}, small={small_df.height}).  The n_tasks knob may be ignored."
+    )
+    # Expected: big ≈ 2x small, since contexts_per_task is the same.  Tolerant assertion since some
+    # rows can be filtered out during the join_asof labeling step.
+    assert big_df.height >= int(1.5 * small_df.height), (
+        f"n_tasks=16 only produced {big_df.height} rows vs. {small_df.height} at n_tasks=8; "
+        f"expected roughly 2x (allowing 25%% label-drop tolerance)"
+    )

--- a/tests/test_generate_tasks.py
+++ b/tests/test_generate_tasks.py
@@ -78,8 +78,24 @@ def test_labels_match_ground_truth(
 
     for split in ("train", "tuning"):
         shard_path = intermediate / "data" / split / "0.parquet"
-        events = pl.read_parquet(shard_path).select(["subject_id", "time", "code"])
-        labels = pl.read_parquet(sorted((eq_sampled_tasks_dir / split).glob("*.parquet"))[0])
+        # Mirror ``_read_event_shard``'s normalization (cast + dedupe + sort) so the ground-
+        # truth recomputation runs over the same frame the sampler labeled.  Skipping this
+        # would let schema-level drift (e.g., upstream storing ``code`` as Categorical or
+        # ``time`` at ns precision) diverge silently between the production path and the
+        # test, hiding real bugs.
+        events = (
+            pl.read_parquet(shard_path)
+            .select(["subject_id", "time", "code"])
+            .with_columns(
+                pl.col("time").cast(pl.Datetime("us")),
+                pl.col("code").cast(pl.Utf8),
+            )
+            .unique()
+            .sort(["subject_id", "time"])
+        )
+        label_paths = sorted((eq_sampled_tasks_dir / split).glob("*.parquet"))
+        assert label_paths, f"no labeled parquets found for split={split} in {eq_sampled_tasks_dir / split}"
+        labels = pl.concat([pl.read_parquet(p) for p in label_paths], how="vertical")
 
         max_time_per_subject = dict(
             events.group_by("subject_id").agg(pl.col("time").max().alias("max_time")).iter_rows()
@@ -200,13 +216,15 @@ def test_n_tasks_knob_is_honored(
     small_df = _read_train_labels(eq_sampled_tasks_dir)
     big_df = _read_train_labels(big_out)
 
-    assert big_df.height > small_df.height, (
-        f"n_tasks=16 did not produce more labeled rows than n_tasks=8 "
-        f"(big={big_df.height}, small={small_df.height}).  The n_tasks knob may be ignored."
-    )
-    # Expected: big ≈ 2x small, since contexts_per_task is the same.  Tolerant assertion since some
-    # rows can be filtered out during the join_asof labeling step.
-    assert big_df.height >= int(1.5 * small_df.height), (
-        f"n_tasks=16 only produced {big_df.height} rows vs. {small_df.height} at n_tasks=8; "
-        f"expected roughly 2x (allowing 25% label-drop tolerance)"
+    # `evaluate_index_df` uses a *left* `join_asof`, so labeled.height == index_df.height
+    # exactly — there's no row drop in the labeling stage.  Doubling `n_tasks` with
+    # `contexts_per_task` held fixed should therefore exactly double the output row count.
+    # A weaker tolerance-based check (e.g. >= 1.5x) would miss a bug that silently caps
+    # `n_tasks` somewhere between small and big (e.g. at 12) — exact-2x catches that.
+    assert big_df.height == 2 * small_df.height, (
+        f"n_tasks=16 produced {big_df.height} rows vs. {small_df.height} at n_tasks=8; "
+        f"expected exactly {2 * small_df.height} when only n_tasks doubles and "
+        f"contexts_per_task is held fixed.  This points at the `n_tasks` flag being "
+        f"ignored, silently capped, or `sample_contexts` dropping rows that should have "
+        f"made it through."
     )


### PR DESCRIPTION
## Summary

Third PR in the #104 E2E testing effort.  Stacks on #111 (process_data) which stacks on #110 (foundation).  Adds real assertions for `EQ_generate_tasks` on top of the `eq_sampled_tasks_dir` fixture.

Closes #107.  Refs #104.

## What lands

`tests/test_generate_tasks.py` with **3 tests**, after the review-driven restructure:

1. **`test_labels_match_ground_truth`** — for every row the sampler emitted, re-computes `(boolean_value, occurs)` from the raw event shard per the documented `evaluate_index_df` semantics (censored = `(prediction_time + duration_days) > max_time`; occurs = `(not censored) AND event_fires_in_window`) and asserts exact equality row-by-row.  Covers 100% of emitted rows.  Catches off-by-one on the window endpoint, wrong censoring source, `join_asof` semantic drift across polars versions, and missing-subject handling regressions that a schema-shape check would miss.

2. **`test_reproducible_with_same_seed`** — two sampler runs with identical seed produce identical labeled output (compared by sorted row content).  Catches non-deterministic sampling regressions — forgetting to seed numpy/polars before a shuffle would silently change eval labels between runs.

3. **Differential — `test_n_tasks_knob_is_honored`**.  Doubling `n_tasks` from 8 to 16 must produce strictly more labeled rows, and roughly 2x (tolerant ≥1.5x for label drops during `join_asof`).  A shape-only test would pass even if `n_tasks` were ignored.

## What was removed in review

Earlier drafts of this PR had two additional tests — `test_sampler_output_schema` and `test_label_semantics` — that asserted column names, dtypes, duration bounds, and null-key-column invariants.  Per review (@mmcdermott on #112): schema-shape and label-semantic-bound assertions belong as **unit tests** on the sampler primitives, not as integration tests that invoke the CLI, and those assertions are already covered at the unit level in `tests/test_sample_tasks.py` (`TestPrimitives.test_build_index_df_zip_correctness`, `TestPrimitives.test_sample_tasks_respects_bounds`, `TestRunWorkerPipeline.test_writes_only_labels_parquet`).  Deleted from this file to avoid redundancy; the ground-truth row-by-row check replaces them and does more.

## Test plan

- [x] `uv run pytest tests/test_generate_tasks.py -v` — 3 passed in ~20s
- [ ] CI green on push

## Merge order

Stacks behind #111 → #110 → `dev`.  Rebase chain forward as each parent merges.