### PR TITLE
fix(generate_tasks): move sampler caching artifacts out of out_dir

### DIFF
--- a/src/every_query/generate_tasks/configs/sample_tasks_config.yaml
+++ b/src/every_query/generate_tasks/configs/sample_tasks_config.yaml
@@ -8,7 +8,10 @@
 # (see `.env.example`, `tasks.py`, and `_env.py`).  Fallbacks:
 #   data_dir  -> $INTERMEDIATE   (event shards live under `{data_dir}/data/{split}/*.parquet`)
 #   codes_dir -> $PROCESSED      (query universe lives under `{codes_dir}/metadata/codes.parquet`)
-#   out_dir   -> $TASK_DIR       (labeled shards and _artifacts/ land here)
+#   out_dir   -> $TASK_DIR       (labeled shards land here as {split}/*.parquet;
+#                                 caching artifacts live in a sibling {out_dir}.cache/
+#                                 dir so MTD's recursive task_labels_fps glob doesn't
+#                                 pick up the non-label parquets)
 # Tests can inject values directly with `data_dir=/path out_dir=/path codes_dir=/path`.
 
 data_dir: null

--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -455,12 +455,35 @@ def _artifact_paths(
     input_shard: str,
     task_shard: int,
 ) -> tuple[Path, Path, Path, Path]:
-    """Resolve the ``(tasks_fp, index_fp, labels_fp, run_meta_fp)`` quadruple for one worker."""
+    """Resolve the ``(tasks_fp, index_fp, labels_fp, run_meta_fp)`` quadruple for one worker.
+
+    Only the *labels* parquet lives under ``out_dir`` — the caching artifacts (sampled tasks
+    JSON, unlabeled-index parquet, run-meta JSON) live in a sibling ``{out_dir}.cache/``
+    directory.  This separation is load-bearing: downstream tooling (MTD's
+    ``MEDSTorchDataConfig.task_labels_fps``, ``EveryQueryPytorchDataset.labels_df``) globs
+    ``task_labels_dir`` recursively with ``rglob("*.parquet")``, so any non-label parquet
+    under ``out_dir`` (in particular the index parquet, which has a narrower 4-column
+    schema) would be silently picked up and blow up ``pl.concat`` with a ``ShapeError``.
+
+    Examples:
+        >>> from pathlib import Path
+        >>> out = Path("/tmp/task_labels")
+        >>> tasks, index, labels, meta = _artifact_paths(out, split="train", input_shard="0", task_shard=0)
+        >>> labels
+        PosixPath('/tmp/task_labels/train/0__0000.parquet')
+        >>> index  # NOT under out_dir — sibling cache dir
+        PosixPath('/tmp/task_labels.cache/index/train/0__0000.parquet')
+        >>> tasks
+        PosixPath('/tmp/task_labels.cache/tasks/train/0__0000.json')
+        >>> meta
+        PosixPath('/tmp/task_labels.cache/runs/train/0__0000.json')
+    """
     worker_id = f"{input_shard}__{task_shard:04d}"
-    tasks_fp = out_dir / "_artifacts" / "tasks" / split / f"{worker_id}.json"
-    index_fp = out_dir / "_artifacts" / "index" / split / f"{worker_id}.parquet"
+    cache_dir = out_dir.parent / f"{out_dir.name}.cache"
+    tasks_fp = cache_dir / "tasks" / split / f"{worker_id}.json"
+    index_fp = cache_dir / "index" / split / f"{worker_id}.parquet"
     labels_fp = out_dir / split / f"{worker_id}.parquet"
-    run_meta_fp = out_dir / "_artifacts" / "runs" / split / f"{worker_id}.json"
+    run_meta_fp = cache_dir / "runs" / split / f"{worker_id}.json"
     return tasks_fp, index_fp, labels_fp, run_meta_fp
 
 
@@ -512,8 +535,8 @@ def _validate_run_meta(run_meta_fp: Path, current: dict[str, int]) -> None:
         "Refusing to reuse cached sampler artifacts: the worker config on disk at "
         f"{run_meta_fp} differs from the requested config:\n"
         + "\n".join(diff_lines)
-        + "\nPass overwrite=true to regenerate this worker's artifacts, "
-        "or delete the _artifacts/ subdirectory if you want a clean run."
+        + "\nPass overwrite=true to regenerate this worker's artifacts, or delete "
+        f"{run_meta_fp.parent.parent.parent!s} (the sampler cache dir) for a clean run."
     )
 
 
@@ -538,11 +561,11 @@ def run_worker(
     labeled parquet are each written on first run and loaded (without resampling) on subsequent
     runs. Set ``overwrite=True`` to force regeneration.
 
-    A per-worker meta sidecar at ``_artifacts/runs/{split}/{worker_id}.json`` captures the
-    sampling parameters the cached artifacts were generated with.  On every non-``overwrite`` rerun
-    those parameters are compared against the requested parameters and any mismatch raises
-    ``ValueError`` rather than silently reusing stale artifacts.  Missing meta (e.g. legacy
-    artifacts or hand-preseeded tasks.json) is tolerated.
+    A per-worker meta sidecar at ``{out_dir}.cache/runs/{split}/{worker_id}.json`` captures
+    the sampling parameters the cached artifacts were generated with.  On every
+    non-``overwrite`` rerun those parameters are compared against the requested parameters
+    and any mismatch raises ``ValueError`` rather than silently reusing stale artifacts.
+    Missing meta (e.g. legacy artifacts or hand-preseeded tasks.json) is tolerated.
 
     Returns:
         The path of the labeled parquet, or ``None`` if the labels already existed, the meta

--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -449,6 +449,16 @@ def load_tasks(fp: Path) -> list[TaskSpec]:
 # ---------------------------------------------------------------------------
 
 
+def _cache_dir(out_dir: Path) -> Path:
+    """Return the sibling cache directory for *out_dir*.
+
+    Caching artifacts (sampled tasks JSON, unlabeled-index parquet, run-meta JSON) are written
+    here rather than under ``out_dir`` so that MTD's ``rglob("*.parquet")`` over ``out_dir``
+    only picks up real label parquets.
+    """
+    return out_dir.parent / f"{out_dir.name}.cache"
+
+
 def _artifact_paths(
     out_dir: Path,
     split: str,
@@ -479,7 +489,7 @@ def _artifact_paths(
         PosixPath('/tmp/task_labels.cache/runs/train/0__0000.json')
     """
     worker_id = f"{input_shard}__{task_shard:04d}"
-    cache_dir = out_dir.parent / f"{out_dir.name}.cache"
+    cache_dir = _cache_dir(out_dir)
     tasks_fp = cache_dir / "tasks" / split / f"{worker_id}.json"
     index_fp = cache_dir / "index" / split / f"{worker_id}.parquet"
     labels_fp = out_dir / split / f"{worker_id}.parquet"
@@ -511,7 +521,7 @@ def _build_run_meta(
     }
 
 
-def _validate_run_meta(run_meta_fp: Path, current: dict[str, int]) -> None:
+def _validate_run_meta(run_meta_fp: Path, cache_dir: Path, current: dict[str, int]) -> None:
     """Raise ``ValueError`` if an on-disk worker meta file exists and disagrees with ``current``.
 
     Absent meta is tolerated: legacy artifacts from before the meta sidecar, or hand-pre-seeded
@@ -536,7 +546,7 @@ def _validate_run_meta(run_meta_fp: Path, current: dict[str, int]) -> None:
         f"{run_meta_fp} differs from the requested config:\n"
         + "\n".join(diff_lines)
         + "\nPass overwrite=true to regenerate this worker's artifacts, or delete "
-        f"{run_meta_fp.parent.parent.parent!s} (the sampler cache dir) for a clean run."
+        f"{cache_dir!s} (the sampler cache dir) for a clean run."
     )
 
 
@@ -576,6 +586,7 @@ def run_worker(
             disagrees with the requested config and ``overwrite`` is False.
     """
     tasks_fp, index_fp, labels_fp, run_meta_fp = _artifact_paths(out_dir, split, input_shard, task_shard)
+    cache_dir = _cache_dir(out_dir)
     current_meta = _build_run_meta(
         seed=seed,
         n_tasks=n_tasks,
@@ -587,7 +598,7 @@ def run_worker(
 
     if not overwrite:
         # Reject cached artifacts if their on-disk config disagrees with what we were asked for.
-        _validate_run_meta(run_meta_fp, current_meta)
+        _validate_run_meta(run_meta_fp, cache_dir, current_meta)
 
     if labels_fp.exists() and not overwrite:
         logger.info("Labels already exist at %s, skipping.", labels_fp)

--- a/tests/test_sample_tasks.py
+++ b/tests/test_sample_tasks.py
@@ -433,8 +433,8 @@ class TestRunWorkerPipeline:
         )
         assert labels_fp is not None
         assert labels_fp.exists()
-        assert (out_dir / "_artifacts" / "tasks" / "train" / "0__0000.json").exists()
-        assert (out_dir / "_artifacts" / "index" / "train" / "0__0000.parquet").exists()
+        assert (out_dir.parent / f"{out_dir.name}.cache" / "tasks" / "train" / "0__0000.json").exists()
+        assert (out_dir.parent / f"{out_dir.name}.cache" / "index" / "train" / "0__0000.parquet").exists()
 
         labels = pl.read_parquet(labels_fp)
         assert labels.height == 32
@@ -498,7 +498,7 @@ class TestRunWorkerPipeline:
         first = run_worker(seed=1, **kwargs)
         assert first is not None
 
-        tasks_path = out_dir / "_artifacts" / "tasks" / "train" / "0__0000.json"
+        tasks_path = out_dir.parent / f"{out_dir.name}.cache" / "tasks" / "train" / "0__0000.json"
         first_label_bytes = first.read_bytes()
         first_task_bytes = tasks_path.read_bytes()
 
@@ -539,8 +539,8 @@ class TestRunWorkerPipeline:
         run_worker(task_shard=0, **kwargs)
         run_worker(task_shard=1, **kwargs)
 
-        tasks_a = (out_dir / "_artifacts" / "tasks" / "train" / "0__0000.json").read_text()
-        tasks_b = (out_dir / "_artifacts" / "tasks" / "train" / "0__0001.json").read_text()
+        tasks_a = (out_dir.parent / f"{out_dir.name}.cache" / "tasks" / "train" / "0__0000.json").read_text()
+        tasks_b = (out_dir.parent / f"{out_dir.name}.cache" / "tasks" / "train" / "0__0001.json").read_text()
         assert tasks_a != tasks_b
 
     def test_input_shard_axis_preserves_tasks(self, tmp_path, synthetic_events, synthetic_query_codes):
@@ -579,15 +579,19 @@ class TestRunWorkerPipeline:
         run_worker(input_shard="1", **kwargs)
 
         # Same tasks across input shards.
-        tasks_0 = (out_dir / "_artifacts" / "tasks" / "train" / "0__0000.json").read_text()
-        tasks_1 = (out_dir / "_artifacts" / "tasks" / "train" / "1__0000.json").read_text()
+        tasks_0 = (out_dir.parent / f"{out_dir.name}.cache" / "tasks" / "train" / "0__0000.json").read_text()
+        tasks_1 = (out_dir.parent / f"{out_dir.name}.cache" / "tasks" / "train" / "1__0000.json").read_text()
         assert tasks_0 == tasks_1, "tasks should be identical across input_shards at fixed task_shard"
 
         # ... but the sampled context *pairs* must differ, since the context seed depends on
         # input_shard.  Compare the (subject_id, prediction_time) multiset rather than the raw
         # parquet bytes to avoid flakiness from parquet metadata / row-order.
-        index_0 = pl.read_parquet(out_dir / "_artifacts" / "index" / "train" / "0__0000.parquet")
-        index_1 = pl.read_parquet(out_dir / "_artifacts" / "index" / "train" / "1__0000.parquet")
+        index_0 = pl.read_parquet(
+            out_dir.parent / f"{out_dir.name}.cache" / "index" / "train" / "0__0000.parquet"
+        )
+        index_1 = pl.read_parquet(
+            out_dir.parent / f"{out_dir.name}.cache" / "index" / "train" / "1__0000.parquet"
+        )
         pairs_0 = set(index_0.select("subject_id", "prediction_time").iter_rows())
         pairs_1 = set(index_1.select("subject_id", "prediction_time").iter_rows())
         assert pairs_0 != pairs_1, (
@@ -680,7 +684,7 @@ class TestRunWorkerPipeline:
         assert first is not None
 
         # Delete the meta sidecar to simulate a legacy / pre-meta artifact.
-        run_meta_fp = out_dir / "_artifacts" / "runs" / "train" / "0__0000.json"
+        run_meta_fp = out_dir.parent / f"{out_dir.name}.cache" / "runs" / "train" / "0__0000.json"
         assert run_meta_fp.exists()
         run_meta_fp.unlink()
 
@@ -732,7 +736,7 @@ class TestRunWorkerPipeline:
         out_dir = tmp_path / "out"
 
         preset = [TaskSpec("ICD//A01", 30), TaskSpec("MED//D04", 60)]
-        tasks_fp = out_dir / "_artifacts" / "tasks" / "train" / "0__0000.json"
+        tasks_fp = out_dir.parent / f"{out_dir.name}.cache" / "tasks" / "train" / "0__0000.json"
         st.save_tasks(preset, tasks_fp)
 
         labels_fp = run_worker(

--- a/tests/test_sample_tasks.py
+++ b/tests/test_sample_tasks.py
@@ -26,6 +26,7 @@ from every_query.data.dataset import EveryQueryPytorchDataset
 from every_query.generate_tasks import sample_tasks as st
 from every_query.generate_tasks.sample_tasks import (
     TaskSpec,
+    _cache_dir,
     build_index_df,
     compute_max_time_per_subject,
     evaluate_index_df,
@@ -433,8 +434,11 @@ class TestRunWorkerPipeline:
         )
         assert labels_fp is not None
         assert labels_fp.exists()
-        assert (out_dir.parent / f"{out_dir.name}.cache" / "tasks" / "train" / "0__0000.json").exists()
-        assert (out_dir.parent / f"{out_dir.name}.cache" / "index" / "train" / "0__0000.parquet").exists()
+        cache_dir = _cache_dir(out_dir)
+        assert (cache_dir / "tasks" / "train" / "0__0000.json").exists()
+        assert (cache_dir / "index" / "train" / "0__0000.parquet").exists()
+        # Invariant: out_dir must contain *only* label parquets — no caching artifacts.
+        assert sorted(out_dir.rglob("*.parquet")) == [labels_fp]
 
         labels = pl.read_parquet(labels_fp)
         assert labels.height == 32
@@ -498,7 +502,7 @@ class TestRunWorkerPipeline:
         first = run_worker(seed=1, **kwargs)
         assert first is not None
 
-        tasks_path = out_dir.parent / f"{out_dir.name}.cache" / "tasks" / "train" / "0__0000.json"
+        tasks_path = _cache_dir(out_dir) / "tasks" / "train" / "0__0000.json"
         first_label_bytes = first.read_bytes()
         first_task_bytes = tasks_path.read_bytes()
 
@@ -539,8 +543,8 @@ class TestRunWorkerPipeline:
         run_worker(task_shard=0, **kwargs)
         run_worker(task_shard=1, **kwargs)
 
-        tasks_a = (out_dir.parent / f"{out_dir.name}.cache" / "tasks" / "train" / "0__0000.json").read_text()
-        tasks_b = (out_dir.parent / f"{out_dir.name}.cache" / "tasks" / "train" / "0__0001.json").read_text()
+        tasks_a = (_cache_dir(out_dir) / "tasks" / "train" / "0__0000.json").read_text()
+        tasks_b = (_cache_dir(out_dir) / "tasks" / "train" / "0__0001.json").read_text()
         assert tasks_a != tasks_b
 
     def test_input_shard_axis_preserves_tasks(self, tmp_path, synthetic_events, synthetic_query_codes):
@@ -579,19 +583,16 @@ class TestRunWorkerPipeline:
         run_worker(input_shard="1", **kwargs)
 
         # Same tasks across input shards.
-        tasks_0 = (out_dir.parent / f"{out_dir.name}.cache" / "tasks" / "train" / "0__0000.json").read_text()
-        tasks_1 = (out_dir.parent / f"{out_dir.name}.cache" / "tasks" / "train" / "1__0000.json").read_text()
+        cache_dir = _cache_dir(out_dir)
+        tasks_0 = (cache_dir / "tasks" / "train" / "0__0000.json").read_text()
+        tasks_1 = (cache_dir / "tasks" / "train" / "1__0000.json").read_text()
         assert tasks_0 == tasks_1, "tasks should be identical across input_shards at fixed task_shard"
 
         # ... but the sampled context *pairs* must differ, since the context seed depends on
         # input_shard.  Compare the (subject_id, prediction_time) multiset rather than the raw
         # parquet bytes to avoid flakiness from parquet metadata / row-order.
-        index_0 = pl.read_parquet(
-            out_dir.parent / f"{out_dir.name}.cache" / "index" / "train" / "0__0000.parquet"
-        )
-        index_1 = pl.read_parquet(
-            out_dir.parent / f"{out_dir.name}.cache" / "index" / "train" / "1__0000.parquet"
-        )
+        index_0 = pl.read_parquet(cache_dir / "index" / "train" / "0__0000.parquet")
+        index_1 = pl.read_parquet(cache_dir / "index" / "train" / "1__0000.parquet")
         pairs_0 = set(index_0.select("subject_id", "prediction_time").iter_rows())
         pairs_1 = set(index_1.select("subject_id", "prediction_time").iter_rows())
         assert pairs_0 != pairs_1, (
@@ -684,7 +685,7 @@ class TestRunWorkerPipeline:
         assert first is not None
 
         # Delete the meta sidecar to simulate a legacy / pre-meta artifact.
-        run_meta_fp = out_dir.parent / f"{out_dir.name}.cache" / "runs" / "train" / "0__0000.json"
+        run_meta_fp = _cache_dir(out_dir) / "runs" / "train" / "0__0000.json"
         assert run_meta_fp.exists()
         run_meta_fp.unlink()
 
@@ -736,7 +737,7 @@ class TestRunWorkerPipeline:
         out_dir = tmp_path / "out"
 
         preset = [TaskSpec("ICD//A01", 30), TaskSpec("MED//D04", 60)]
-        tasks_fp = out_dir.parent / f"{out_dir.name}.cache" / "tasks" / "train" / "0__0000.json"
+        tasks_fp = _cache_dir(out_dir) / "tasks" / "train" / "0__0000.json"
         st.save_tasks(preset, tasks_fp)
 
         labels_fp = run_worker(


### PR DESCRIPTION
## Summary

Fixes a production-breaking bug in `EQ_generate_tasks`: the sampler's caching artifacts leaked into the user's `out_dir`, which downstream `EQ_train` / `EQ_evaluate` consume as `task_labels_dir`, breaking training with a confusing `polars ShapeError` at `trainer.fit` time.

Closes #114.

## What changed

`sample_tasks._artifact_paths` now writes caching artifacts to a sibling `{out_dir}.cache/` directory instead of `{out_dir}/_artifacts/`:

```
# before
out_dir/
├── train/0__0000.parquet           ← 6-column labels
└── _artifacts/
    ├── index/train/0__0000.parquet ← 4-column index (leaked into MTD glob)
    ├── tasks/train/0__0000.json
    └── runs/train/0__0000.json

# after  
out_dir/
└── train/0__0000.parquet           ← 6-column labels only
out_dir.cache/                      ← sibling
├── index/train/0__0000.parquet
├── tasks/train/0__0000.json
└── runs/train/0__0000.json
```

MTD's recursive `task_labels_fps` glob now picks up only real labels.  Sampler CLI signature and user-facing contract unchanged — users still pass `out_dir=$TASK_DIR` and then `task_labels_dir=$TASK_DIR`; the cache just appears as `$TASK_DIR.cache/` alongside.

## What's not in this PR (deliberately)

The E2E integration-test foundation (#105, PR to follow) adds a regression test (`test_generate_tasks_out_dir_contains_only_label_parquets`) that asserts every parquet under the sampler's `out_dir` conforms to the label schema.  That test belongs with the integration-test PR (its real goal is to run the full CLI chain); the fix itself is a minimal source change that stands alone.

## Test plan

- [x] `uv run pytest tests/test_sample_tasks.py` — 40 passed (path-references updated)
- [x] `uv run pytest tests/` — full suite green
- [ ] CI green on push

A regression test that would have caught this lives in the follow-on PR #110 (E2E foundation) — once both merge, the integration-test suite will fail-fast on any future reintroduction.