### PR TITLE
refactor(generate_tasks): remove sampler caching; worker is a pure function

### DIFF
--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -9,9 +9,11 @@ The script runs on one MEDS shard at a time and is parameterized by ``(input_sha
 so that a ``hydra -m`` sweep covers the ``(task axis x patient axis)`` cartesian product with one output
 file per worker.
 
-Three stages execute inside a single ``main()`` call and are **idempotent**: the sampled task list,
-the unlabeled index DataFrame, and the final labeled task parquet are each written to disk on first
-run and loaded (without resampling) on subsequent runs. Set ``overwrite=true`` to force regeneration.
+The worker is a pure function of its inputs: all three stages execute in-memory inside a single
+``main()`` call and write only the final labeled parquet to disk.  Reruns with identical inputs
+produce identical labels — determinism comes from :func:`~every_query.utils.seeds.derive_seed`
+splitting the task and context axes, not from persisted intermediate state.  Set
+``overwrite=true`` to regenerate labels for a worker whose output file already exists.
 
 Design decisions (see issue #33):
 - **Seeding**: tasks-seed depends only on ``(seed, task_shard)``, contexts-seed depends on
@@ -27,7 +29,6 @@ Design decisions (see issue #33):
   the whole ``index_df`` against the events table, regardless of how many distinct codes are present.
 """
 
-import json
 import logging
 import os
 import tempfile
@@ -400,22 +401,6 @@ def _unique_tmp_path(fp: Path) -> Path:
     return Path(tmp_name)
 
 
-def _atomic_write_text(fp: Path, text: str) -> None:
-    """Write ``text`` to ``fp`` atomically via a unique sibling tmpfile + ``os.replace``.
-
-    A failed mid-write leaves at most an orphan tmpfile; the target ``fp`` either has its
-    previous contents or the fully-written new contents.  Concurrent writers to the same ``fp``
-    don't corrupt each other because the tmp filename is unique per call.
-    """
-    tmp = _unique_tmp_path(fp)
-    try:
-        tmp.write_text(text)
-        os.replace(tmp, fp)
-    except Exception:
-        tmp.unlink(missing_ok=True)
-        raise
-
-
 def _atomic_write_parquet(df: pl.DataFrame, fp: Path) -> None:
     """Write ``df`` to ``fp`` atomically via a unique sibling tmpfile + ``os.replace``."""
     tmp = _unique_tmp_path(fp)
@@ -427,94 +412,15 @@ def _atomic_write_parquet(df: pl.DataFrame, fp: Path) -> None:
         raise
 
 
-def save_tasks(tasks: list[TaskSpec], fp: Path) -> None:
-    """Serialize a task list to JSON with one entry per task (atomic)."""
-    _atomic_write_text(
-        fp,
-        json.dumps(
-            [{"code": t.code, "duration_days": t.duration_days} for t in tasks],
-            indent=2,
-        ),
-    )
-
-
-def load_tasks(fp: Path) -> list[TaskSpec]:
-    """Load a task list previously written by :func:`save_tasks`."""
-    data = json.loads(Path(fp).read_text())
-    return [TaskSpec(code=d["code"], duration_days=int(d["duration_days"])) for d in data]
-
-
 # ---------------------------------------------------------------------------
 # End-to-end pipeline
 # ---------------------------------------------------------------------------
 
 
-def _artifact_paths(
-    out_dir: Path,
-    split: str,
-    input_shard: str,
-    task_shard: int,
-) -> tuple[Path, Path, Path, Path]:
-    """Resolve the ``(tasks_fp, index_fp, labels_fp, run_meta_fp)`` quadruple for one worker."""
+def _labels_fp(out_dir: Path, split: str, input_shard: str, task_shard: int) -> Path:
+    """Resolve the labeled-parquet output path for one worker."""
     worker_id = f"{input_shard}__{task_shard:04d}"
-    tasks_fp = out_dir / "_artifacts" / "tasks" / split / f"{worker_id}.json"
-    index_fp = out_dir / "_artifacts" / "index" / split / f"{worker_id}.parquet"
-    labels_fp = out_dir / split / f"{worker_id}.parquet"
-    run_meta_fp = out_dir / "_artifacts" / "runs" / split / f"{worker_id}.json"
-    return tasks_fp, index_fp, labels_fp, run_meta_fp
-
-
-def _build_run_meta(
-    seed: int,
-    n_tasks: int,
-    contexts_per_task: int,
-    duration_min: int,
-    duration_max: int,
-    min_context_per_subject: int,
-) -> dict[str, int]:
-    """Capture the sampling parameters that must match for a cached worker's artifacts to be reusable.
-
-    The file-level identity of the worker (``split``, ``input_shard``, ``task_shard``) is encoded
-    in the output path itself and therefore intentionally omitted here — two artifacts with different
-    worker identities can never collide on disk, so comparing them here would be redundant.
-    """
-    return {
-        "seed": int(seed),
-        "n_tasks": int(n_tasks),
-        "contexts_per_task": int(contexts_per_task),
-        "duration_min": int(duration_min),
-        "duration_max": int(duration_max),
-        "min_context_per_subject": int(min_context_per_subject),
-    }
-
-
-def _validate_run_meta(run_meta_fp: Path, current: dict[str, int]) -> None:
-    """Raise ``ValueError`` if an on-disk worker meta file exists and disagrees with ``current``.
-
-    Absent meta is tolerated: legacy artifacts from before the meta sidecar, or hand-pre-seeded
-    tasks/index files dropped by a user debugging the pipeline, have no sidecar to validate against
-    and are assumed to be the user's intent.  Mismatched meta is a hard failure — the whole point
-    of the sidecar is to prevent silent stale-artifact reuse.
-    """
-    if not run_meta_fp.exists():
-        return
-    on_disk = json.loads(run_meta_fp.read_text())
-    if on_disk == current:
-        return
-    diff_lines = []
-    all_keys = sorted(set(on_disk) | set(current))
-    for key in all_keys:
-        on_disk_val = on_disk.get(key, "<missing>")
-        current_val = current.get(key, "<missing>")
-        if on_disk_val != current_val:
-            diff_lines.append(f"  {key}: on_disk={on_disk_val!r}, current={current_val!r}")
-    raise ValueError(
-        "Refusing to reuse cached sampler artifacts: the worker config on disk at "
-        f"{run_meta_fp} differs from the requested config:\n"
-        + "\n".join(diff_lines)
-        + "\nPass overwrite=true to regenerate this worker's artifacts, "
-        "or delete the _artifacts/ subdirectory if you want a clean run."
-    )
+    return out_dir / split / f"{worker_id}.parquet"
 
 
 def run_worker(
@@ -532,94 +438,52 @@ def run_worker(
     min_context_per_subject: int,
     overwrite: bool = False,
 ) -> Path | None:
-    """Run the three-stage pipeline for one worker.
+    """Run the three-stage sampling pipeline for one worker in-memory.
 
-    Each stage is idempotent: the sampled task list, the unlabeled index DataFrame, and the final
-    labeled parquet are each written on first run and loaded (without resampling) on subsequent
-    runs. Set ``overwrite=True`` to force regeneration.
-
-    A per-worker meta sidecar at ``_artifacts/runs/{split}/{worker_id}.json`` captures the
-    sampling parameters the cached artifacts were generated with.  On every non-``overwrite`` rerun
-    those parameters are compared against the requested parameters and any mismatch raises
-    ``ValueError`` rather than silently reusing stale artifacts.  Missing meta (e.g. legacy
-    artifacts or hand-preseeded tasks.json) is tolerated.
+    The worker is a pure function of ``(data_dir, codes_dir, config, seed, split, input_shard,
+    task_shard)`` — no per-stage checkpoints on disk, no meta sidecar, no cache-validation
+    protocol.  Determinism comes from :func:`derive_seed` separating the task and context
+    axes; a rerun with identical inputs produces identical labels.
 
     Returns:
-        The path of the labeled parquet, or ``None`` if the labels already existed, the meta
-        sidecar matched the current config, and ``overwrite=False``.
-
-    Raises:
-        ValueError: If cached artifacts exist alongside a meta sidecar whose recorded config
-            disagrees with the requested config and ``overwrite`` is False.
+        The path of the labeled parquet, or ``None`` if labels already existed at that path
+        and ``overwrite=False``.
     """
-    tasks_fp, index_fp, labels_fp, run_meta_fp = _artifact_paths(out_dir, split, input_shard, task_shard)
-    current_meta = _build_run_meta(
-        seed=seed,
-        n_tasks=n_tasks,
-        contexts_per_task=contexts_per_task,
-        duration_min=duration_min,
-        duration_max=duration_max,
-        min_context_per_subject=min_context_per_subject,
-    )
-
-    if not overwrite:
-        # Reject cached artifacts if their on-disk config disagrees with what we were asked for.
-        _validate_run_meta(run_meta_fp, current_meta)
+    labels_fp = _labels_fp(out_dir, split, input_shard, task_shard)
 
     if labels_fp.exists() and not overwrite:
         logger.info("Labels already exist at %s, skipping.", labels_fp)
         return None
 
-    # Stage 1: tasks
-    if tasks_fp.exists() and not overwrite:
-        logger.info("Loading tasks from %s", tasks_fp)
-        tasks = load_tasks(tasks_fp)
-    else:
-        query_codes = _read_query_codes(codes_dir)
-        tasks_seed = derive_seed(seed, "tasks", task_shard)
-        tasks = sample_tasks(
-            n=n_tasks,
-            query_codes=query_codes,
-            duration_low=duration_min,
-            duration_high=duration_max,
-            seed=tasks_seed,
-        )
-        save_tasks(tasks, tasks_fp)
-        logger.info("Wrote %d tasks to %s", len(tasks), tasks_fp)
+    query_codes = _read_query_codes(codes_dir)
+    tasks_seed = derive_seed(seed, "tasks", task_shard)
+    tasks = sample_tasks(
+        n=n_tasks,
+        query_codes=query_codes,
+        duration_low=duration_min,
+        duration_high=duration_max,
+        seed=tasks_seed,
+    )
 
-    # Load the shard once.
     shard_path = data_dir / "data" / split / f"{input_shard}.parquet"
     events_df = _read_event_shard(shard_path)
     logger.info("Loaded %d events from %s", events_df.height, shard_path)
 
-    # Stage 2: index
-    if index_fp.exists() and not overwrite:
-        logger.info("Loading index from %s", index_fp)
-        index_df = pl.read_parquet(index_fp)
-    else:
-        contexts_seed = derive_seed(seed, "contexts", input_shard, task_shard)
-        contexts = sample_contexts(
-            events_df=events_df,
-            n=len(tasks) * contexts_per_task,
-            min_context_per_subject=min_context_per_subject,
-            seed=contexts_seed,
-        )
-        index_df = build_index_df(tasks, contexts)
-        _atomic_write_parquet(index_df, index_fp)
-        logger.info("Wrote %d index rows to %s", index_df.height, index_fp)
+    contexts_seed = derive_seed(seed, "contexts", input_shard, task_shard)
+    contexts = sample_contexts(
+        events_df=events_df,
+        n=len(tasks) * contexts_per_task,
+        min_context_per_subject=min_context_per_subject,
+        seed=contexts_seed,
+    )
+    index_df = build_index_df(tasks, contexts)
 
-    # Stage 3: labels
     max_time_df = compute_max_time_per_subject(events_df)
     labeled = evaluate_index_df(index_df, events_df, max_time_df)
     # Downstream MEDS dataloader does not use task_id; it is intentionally absent from the
     # published schema.
     _atomic_write_parquet(labeled, labels_fp)
     logger.info("Wrote %d labeled rows to %s", labeled.height, labels_fp)
-
-    # Persist the meta sidecar last so that a crash partway through leaves the cache in a state
-    # where the next rerun will detect an incomplete artifact set (labels missing) and redo the
-    # work, rather than trusting a meta that points at nonexistent artifacts.
-    _atomic_write_text(run_meta_fp, json.dumps(current_meta, indent=2, sort_keys=True))
     return labels_fp
 
 

--- a/tests/test_sample_tasks.py
+++ b/tests/test_sample_tasks.py
@@ -5,8 +5,10 @@ Structure:
 - ``TestPrimitives`` — unit tests for the pure building blocks.
 - ``TestEvaluateIndexDfEdgeCases`` — hand-crafted edge cases for ``evaluate_index_df`` (strict-``>``
   semantics, missing-subject handling).
-- ``TestRunWorkerPipeline`` — artifact-level tests for the three-stage idempotent pipeline:
-  stage skip on rerun, overwrite, seed-axis independence, pre-seeded tasks.
+- ``TestRunWorkerPipeline`` — pipeline-level tests: the worker writes one output (labels), is
+  idempotent on rerun, regenerates on ``overwrite=True``, preserves the seed-derived axis
+  invariants across input and task shards, and — since the cache was removed — returns stale
+  labels silently if a config is changed without ``overwrite=True`` (caller-enforced contract).
 - ``TestEndToEndWithDataset`` — smoke test that builds sampler-shaped labels referencing real
   subject IDs from ``tensorized_cohort_dir``, feeds them through ``EveryQueryPytorchDataset``, and
   pushes one collated batch through ``demo_model``.  Verifies schema compatibility with the

--- a/tests/test_sample_tasks.py
+++ b/tests/test_sample_tasks.py
@@ -360,14 +360,6 @@ class TestAtomicWriteConcurrency:
         a.unlink(missing_ok=True)
         b.unlink(missing_ok=True)
 
-    def test_atomic_write_text_round_trip(self, tmp_path):
-        fp = tmp_path / "out.json"
-        st._atomic_write_text(fp, '{"hello": "world"}')
-        assert fp.read_text() == '{"hello": "world"}'
-        # No orphan tmpfiles should linger after a successful write.
-        orphans = [p for p in tmp_path.iterdir() if p.name != "out.json"]
-        assert orphans == []
-
     def test_atomic_write_parquet_round_trip(self, tmp_path):
         fp = tmp_path / "out.parquet"
         df = pl.DataFrame({"a": [1, 2, 3]})
@@ -414,7 +406,14 @@ def _write_fake_cohort(
 
 
 class TestRunWorkerPipeline:
-    def test_writes_all_three_artifacts(self, tmp_path, synthetic_events, synthetic_query_codes):
+    def test_writes_only_labels_parquet(self, tmp_path, synthetic_events, synthetic_query_codes):
+        """The worker writes exactly one on-disk artifact per call: the labels parquet.
+
+        Regression guard: prior versions wrote a ``tasks.json`` + unlabeled-index parquet +
+        run-meta sidecar under ``out_dir``, and the index parquet (schema-incompatible with
+        labels) was silently globbed as a task-label by MTD downstream, breaking training.
+        Catching any future re-introduction of intermediate artifacts alongside labels.
+        """
         data_dir, codes_dir = _write_fake_cohort(tmp_path, synthetic_events, synthetic_query_codes)
         out_dir = tmp_path / "out"
         labels_fp = run_worker(
@@ -433,8 +432,9 @@ class TestRunWorkerPipeline:
         )
         assert labels_fp is not None
         assert labels_fp.exists()
-        assert (out_dir / "_artifacts" / "tasks" / "train" / "0__0000.json").exists()
-        assert (out_dir / "_artifacts" / "index" / "train" / "0__0000.parquet").exists()
+        # Exactly one file under out_dir, exactly labels_fp.  No sidecars, no cache parquets.
+        all_files = [p for p in out_dir.rglob("*") if p.is_file()]
+        assert all_files == [labels_fp], f"expected only {labels_fp}, got {all_files}"
 
         labels = pl.read_parquet(labels_fp)
         assert labels.height == 32
@@ -474,11 +474,17 @@ class TestRunWorkerPipeline:
         assert first.read_bytes() == first_bytes  # untouched
 
     def test_overwrite_regenerates(self, tmp_path, synthetic_events, synthetic_query_codes):
-        """``overwrite=True`` must actually regenerate; ``overwrite=False`` must not.
+        """``overwrite=True`` regenerates labels; ``overwrite=False`` returns the existing file.
 
-        Captures bytes before and after each rerun and asserts the invariant directly — the earlier version of
-        this test only checked that the tasks file existed and was non-None, which would pass even if
-        overwrite were silently ignored (Copilot review on #41).
+        With the caching removed, sampler behavior is now:
+        - ``overwrite=False`` + labels exist: return ``None``, leave labels untouched.
+        - ``overwrite=True``: re-runs end-to-end, labels reflect the new inputs.
+        - ``overwrite=False`` + no labels: labels are computed and written.
+
+        Note: because there is no longer a meta-sidecar check, changing the config WITHOUT
+        ``overwrite`` is a silent no-op — the caller is responsible for passing
+        ``overwrite=True`` when they've changed sampling parameters.  See the
+        ``test_stale_labels_on_config_change_without_overwrite`` guard below.
         """
         data_dir, codes_dir = _write_fake_cohort(tmp_path, synthetic_events, synthetic_query_codes)
         out_dir = tmp_path / "out"
@@ -497,30 +503,28 @@ class TestRunWorkerPipeline:
         }
         first = run_worker(seed=1, **kwargs)
         assert first is not None
+        first_bytes = first.read_bytes()
 
-        tasks_path = out_dir / "_artifacts" / "tasks" / "train" / "0__0000.json"
-        first_label_bytes = first.read_bytes()
-        first_task_bytes = tasks_path.read_bytes()
-
-        # No-op rerun with same seed: bytes untouched.
+        # No-op rerun with same seed: labels untouched, worker returns None.
         skipped = run_worker(seed=1, **kwargs)
         assert skipped is None
-        assert first.read_bytes() == first_label_bytes
-        assert tasks_path.read_bytes() == first_task_bytes
+        assert first.read_bytes() == first_bytes
 
-        # Overwrite with a different seed: both labels and tasks must change.
+        # Overwrite with a different seed: labels must change.
         second = run_worker(seed=2, overwrite=True, **kwargs)
         assert second is not None
         assert first == second  # same path
-        assert second.read_bytes() != first_label_bytes, (
+        assert second.read_bytes() != first_bytes, (
             "overwrite=True with a new seed did not change the labels parquet"
-        )
-        assert tasks_path.read_bytes() != first_task_bytes, (
-            "overwrite=True with a new seed did not change the tasks JSON"
         )
 
     def test_task_shard_axis_changes_tasks(self, tmp_path, synthetic_events, synthetic_query_codes):
-        """Fixing ``input_shard`` and varying ``task_shard`` must change the sampled tasks."""
+        """Fixing ``input_shard`` and varying ``task_shard`` must change the sampled tasks.
+
+        Since the tasks JSON is no longer persisted, read the labels parquet and compare the
+        ``(query, duration_days)`` multiset — that's the full surface of what "tasks" means
+        downstream.
+        """
         data_dir, codes_dir = _write_fake_cohort(tmp_path, synthetic_events, synthetic_query_codes)
         out_dir = tmp_path / "out"
         kwargs = {
@@ -536,16 +540,18 @@ class TestRunWorkerPipeline:
             "duration_max": 365,
             "min_context_per_subject": 5,
         }
-        run_worker(task_shard=0, **kwargs)
-        run_worker(task_shard=1, **kwargs)
+        labels_a_fp = run_worker(task_shard=0, **kwargs)
+        labels_b_fp = run_worker(task_shard=1, **kwargs)
 
-        tasks_a = (out_dir / "_artifacts" / "tasks" / "train" / "0__0000.json").read_text()
-        tasks_b = (out_dir / "_artifacts" / "tasks" / "train" / "0__0001.json").read_text()
-        assert tasks_a != tasks_b
+        def _task_multiset(fp):
+            df = pl.read_parquet(fp)
+            return sorted(zip(df["query"].to_list(), df["duration_days"].to_list(), strict=True))
+
+        assert _task_multiset(labels_a_fp) != _task_multiset(labels_b_fp)
 
     def test_input_shard_axis_preserves_tasks(self, tmp_path, synthetic_events, synthetic_query_codes):
-        """Fixing ``task_shard`` and varying ``input_shard`` must keep the same task list but still draw
-        *different* contexts.
+        """Fixing ``task_shard`` and varying ``input_shard`` keeps the same tasks but draws *different*
+        contexts.
 
         This is what enables ``hydra -m input_shard=range(K)`` to evaluate *the same* sampled tasks
         across every shard — a key property for producing a coherent PT dataset — while ensuring
@@ -575,34 +581,38 @@ class TestRunWorkerPipeline:
             "duration_max": 365,
             "min_context_per_subject": 5,
         }
-        run_worker(input_shard="0", **kwargs)
-        run_worker(input_shard="1", **kwargs)
+        labels_0_fp = run_worker(input_shard="0", **kwargs)
+        labels_1_fp = run_worker(input_shard="1", **kwargs)
 
-        # Same tasks across input shards.
-        tasks_0 = (out_dir / "_artifacts" / "tasks" / "train" / "0__0000.json").read_text()
-        tasks_1 = (out_dir / "_artifacts" / "tasks" / "train" / "1__0000.json").read_text()
+        df_0 = pl.read_parquet(labels_0_fp)
+        df_1 = pl.read_parquet(labels_1_fp)
+
+        # Same tasks across input shards (task_seed depends only on task_shard).
+        tasks_0 = sorted(set(zip(df_0["query"].to_list(), df_0["duration_days"].to_list(), strict=True)))
+        tasks_1 = sorted(set(zip(df_1["query"].to_list(), df_1["duration_days"].to_list(), strict=True)))
         assert tasks_0 == tasks_1, "tasks should be identical across input_shards at fixed task_shard"
 
-        # ... but the sampled context *pairs* must differ, since the context seed depends on
-        # input_shard.  Compare the (subject_id, prediction_time) multiset rather than the raw
-        # parquet bytes to avoid flakiness from parquet metadata / row-order.
-        index_0 = pl.read_parquet(out_dir / "_artifacts" / "index" / "train" / "0__0000.parquet")
-        index_1 = pl.read_parquet(out_dir / "_artifacts" / "index" / "train" / "1__0000.parquet")
-        pairs_0 = set(index_0.select("subject_id", "prediction_time").iter_rows())
-        pairs_1 = set(index_1.select("subject_id", "prediction_time").iter_rows())
+        # ... but the sampled context pairs must differ (context_seed depends on both axes).
+        pairs_0 = set(df_0.select("subject_id", "prediction_time").iter_rows())
+        pairs_1 = set(df_1.select("subject_id", "prediction_time").iter_rows())
         assert pairs_0 != pairs_1, (
             "contexts should differ across input_shards at fixed task_shard "
             "(contexts_seed depends on both axes)"
         )
 
-    def test_config_mismatch_raises_without_overwrite(
+    def test_stale_labels_on_config_change_without_overwrite(
         self, tmp_path, synthetic_events, synthetic_query_codes
     ):
-        """A second run with a different sampling config must not silently reuse stale artifacts.
+        """Documents the contract: config changes without ``overwrite=True`` return stale labels.
 
-        Catches the failure mode Copilot flagged on #41: without a meta sidecar check, the
-        artifact filename only keys on ``(split, input_shard, task_shard)``, so changing
-        ``seed``, ``n_tasks``, etc. would silently reuse the old output.
+        This used to raise ``ValueError`` via a meta-sidecar check.  That check was removed along
+        with the rest of the sampler cache because the sidecar and its associated intermediate
+        artifacts leaked into ``task_labels_dir`` and broke downstream training.  The contract now
+        is simpler but *caller-enforced*: if you change ``seed``, ``n_tasks``, etc., pass
+        ``overwrite=True`` or point at a fresh ``out_dir``.
+
+        This test pins that behavior so a future reviewer sees the tradeoff explicitly rather than
+        discovering it via surprise in production.
         """
         data_dir, codes_dir = _write_fake_cohort(tmp_path, synthetic_events, synthetic_query_codes)
         out_dir = tmp_path / "out"
@@ -621,77 +631,19 @@ class TestRunWorkerPipeline:
         }
         first = run_worker(n_tasks=16, **kwargs)
         assert first is not None
+        assert pl.read_parquet(first).height == 16
 
-        # Changing n_tasks without overwrite must fail loudly.
-        with pytest.raises(ValueError, match="worker config"):
-            run_worker(n_tasks=32, **kwargs)
-
-        # overwrite=True bypasses the check and actually regenerates.
-        second = run_worker(n_tasks=32, overwrite=True, **kwargs)
-        assert second is not None
-        labels = pl.read_parquet(second)
-        assert labels.height == 32, "overwrite with n_tasks=32 should produce 32 labels"
-
-    def test_config_mismatch_raises_on_seed_change(self, tmp_path, synthetic_events, synthetic_query_codes):
-        """Changing only ``seed`` is the other obvious way to produce silent staleness."""
-        data_dir, codes_dir = _write_fake_cohort(tmp_path, synthetic_events, synthetic_query_codes)
-        out_dir = tmp_path / "out"
-        kwargs = {
-            "data_dir": data_dir,
-            "codes_dir": codes_dir,
-            "out_dir": out_dir,
-            "split": "train",
-            "input_shard": "0",
-            "task_shard": 0,
-            "n_tasks": 8,
-            "contexts_per_task": 1,
-            "duration_min": 10,
-            "duration_max": 365,
-            "min_context_per_subject": 5,
-        }
-        run_worker(seed=1, **kwargs)
-        with pytest.raises(ValueError, match="seed"):
-            run_worker(seed=999, **kwargs)
-
-    def test_missing_meta_is_tolerated(self, tmp_path, synthetic_events, synthetic_query_codes):
-        """Legacy or hand-injected artifacts without a meta sidecar must still load.
-
-        This preserves the pre-seeding workflow: a user drops tasks.json by hand (without any
-        corresponding meta file) and reruns; the sampler loads the preseeded tasks verbatim.
-        """
-        data_dir, codes_dir = _write_fake_cohort(tmp_path, synthetic_events, synthetic_query_codes)
-        out_dir = tmp_path / "out"
-        kwargs = {
-            "data_dir": data_dir,
-            "codes_dir": codes_dir,
-            "out_dir": out_dir,
-            "split": "train",
-            "input_shard": "0",
-            "task_shard": 0,
-            "seed": 1,
-            "n_tasks": 8,
-            "contexts_per_task": 1,
-            "duration_min": 10,
-            "duration_max": 365,
-            "min_context_per_subject": 5,
-        }
-        # First run: creates artifacts and meta.
-        first = run_worker(**kwargs)
-        assert first is not None
-
-        # Delete the meta sidecar to simulate a legacy / pre-meta artifact.
-        run_meta_fp = out_dir / "_artifacts" / "runs" / "train" / "0__0000.json"
-        assert run_meta_fp.exists()
-        run_meta_fp.unlink()
-
-        # Rerun with the same config: should succeed (labels already exist, no-op path).
-        skipped = run_worker(**kwargs)
+        # Changing n_tasks without overwrite → no-op (labels still have 16 rows).
+        skipped = run_worker(n_tasks=32, **kwargs)
         assert skipped is None
+        assert pl.read_parquet(first).height == 16, (
+            "no-op path returned stale labels silently — expected behavior post-cache-removal"
+        )
 
-        # Rerun with a changed config: should also succeed (no meta to validate against);
-        # labels already exist so it's a no-op regardless.
-        skipped2 = run_worker(**{**kwargs, "n_tasks": 99})
-        assert skipped2 is None
+        # overwrite=True actually regenerates.
+        regenerated = run_worker(n_tasks=32, overwrite=True, **kwargs)
+        assert regenerated is not None
+        assert pl.read_parquet(regenerated).height == 32
 
     def test_codes_dir_is_read_from_a_distinct_root(self, tmp_path, synthetic_events, synthetic_query_codes):
         """Smoke test that codes_dir is actually read *from* codes_dir, not data_dir.
@@ -725,34 +677,6 @@ class TestRunWorkerPipeline:
         labels = pl.read_parquet(labels_fp)
         # The queries in the output must all come from codes.parquet under codes_dir.
         assert set(labels["query"].to_list()) <= set(synthetic_query_codes)
-
-    def test_preseeded_tasks_are_honored(self, tmp_path, synthetic_events, synthetic_query_codes):
-        """Dropping a ``tasks.json`` on disk before run → the sampler uses it verbatim."""
-        data_dir, codes_dir = _write_fake_cohort(tmp_path, synthetic_events, synthetic_query_codes)
-        out_dir = tmp_path / "out"
-
-        preset = [TaskSpec("ICD//A01", 30), TaskSpec("MED//D04", 60)]
-        tasks_fp = out_dir / "_artifacts" / "tasks" / "train" / "0__0000.json"
-        st.save_tasks(preset, tasks_fp)
-
-        labels_fp = run_worker(
-            data_dir=data_dir,
-            codes_dir=codes_dir,
-            out_dir=out_dir,
-            split="train",
-            input_shard="0",
-            task_shard=0,
-            seed=999,  # would normally draw different tasks
-            n_tasks=2,
-            contexts_per_task=1,
-            duration_min=10,
-            duration_max=365,
-            min_context_per_subject=5,
-        )
-        assert labels_fp is not None
-        labels = pl.read_parquet(labels_fp)
-        assert sorted(labels["query"].unique().to_list()) == sorted(["ICD//A01", "MED//D04"])
-        assert sorted(labels["duration_days"].unique().to_list()) == [30, 60]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Replaces the closed PR #115 with the simpler fix we agreed on in chat: **delete the sampler's per-worker cache entirely** rather than moving it to a sibling directory.

Fixes #114.

## Why

The sampler was writing three on-disk side files per worker (tasks JSON, unlabeled index parquet, run-meta sidecar) alongside the real output (labels parquet).  The framing was "cache so reruns are cheap," but:

1. **The only expensive step is `join_asof`**, and its result already lives in `labels.parquet`.  The other two artifacts recompute in a fraction of a second — pennies of savings.
2. **The index parquet leaked into `task_labels_dir`** — MTD globs that directory recursively for parquets, and the narrower 4-column schema broke `pl.concat` at `trainer.fit` time.  Production-breaking bug.
3. **Framed as cache but acting as outputs without the properties of outputs** — no schema contract, hidden dir naming, and a `_validate_run_meta` sidecar whose whole existence pointed at the mismatch.  Cache with eviction semantics this complex usually means you need real outputs.

Deleting the cache is simpler than fixing it.  Determinism is already pinned by `derive_seed(seed, axis, *keys)` per the original design (`tasks_seed` depends on `(seed, task_shard)`, `contexts_seed` depends on `(seed, input_shard, task_shard)`).  Reruns with identical inputs produce identical labels without any persisted intermediate state.

## What lands

**`sample_tasks.py`** — net −317 / +105 LOC:
- Deleted: `_artifact_paths`, `_build_run_meta`, `_validate_run_meta`, `save_tasks`, `load_tasks`, `_atomic_write_text`, and the associated `json` import.
- `run_worker` simplified: tasks + contexts + labels now execute in-memory as a single pass; only `labels.parquet` is written.
- `overwrite` at the labels level unchanged.
- **Contract change**: modifying sampling params without `overwrite=True` now returns stale labels silently instead of raising `ValueError`.  Caller-enforced rather than sidecar-enforced.  This is explicitly pinned by a new test (see below).

**`test_sample_tasks.py`**:
- Renamed `test_writes_all_three_artifacts` → `test_writes_only_labels_parquet`.  Now asserts *exactly one file* under `out_dir` — a regression guard against any future reintroduction of intermediate artifacts.
- Rewrote `test_task_shard_axis_changes_tasks` + `test_input_shard_axis_preserves_tasks` to inspect the labels parquet's `(query, duration_days)` multiset instead of reading the deleted `tasks.json`.
- Added `test_stale_labels_on_config_change_without_overwrite` — documents the caller-enforced contract explicitly so a future reviewer sees the tradeoff rather than hitting it in production.
- Deleted: `test_config_mismatch_raises_*`, `test_missing_meta_is_tolerated`, `test_preseeded_tasks_are_honored`, `test_atomic_write_text_round_trip`.

## Follow-up (out of scope here)

A proper two-stage decomposition — `EQ_sample_task_queries` writes `TaskQuerySchema`-conformant parquet, `EQ_label_task_queries` reads it + events and writes labels — is the right long-term shape and aligns with #96's `TaskQuerySchema` contract.  That's Phase 2 / #54 work, not this PR.  See the chat discussion with @mmcdermott for context.

## Test plan

- [x] `uv run pytest tests/test_sample_tasks.py` — 36 passed (was 40; −4 obsolete tests removed)
- [x] `uv run pytest tests/` — 166 passed on this branch
- [ ] CI green on push
- [ ] Rebase E2E test stack (#110 / #111 / #112 / #113) onto this branch — the `eq_sampled_tasks_dir` fixture's regression test (under #110) still fires correctly here, and in fact becomes nearly trivial since nothing but labels is ever written.

## Stacked PRs to update

After this merges, #110 / #111 / #112 / #113 need their bases retargeted from `fix/sampler-artifacts-outside-out-dir` (now deleted) to `refactor/remove-sampler-caching` or directly to `dev`.