### PR TITLE
fix(tests): pin torch seed in demo_model fixture for init determinism

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -88,7 +88,16 @@ def demo_model_config() -> ModernBertConfig:
 
 @pytest.fixture(scope="session")
 def demo_model() -> EveryQueryModel:
-    """Randomly-initialised EveryQueryModel with tiny dimensions."""
+    """Randomly-initialised EveryQueryModel with tiny dimensions, seeded for determinism.
+
+    The seed pin (``torch.manual_seed(0)``) guards against init-RNG-dependent flakiness in
+    tests that compare forward-pass outputs across perturbed inputs — notably
+    ``TestDurationDaysValueAffectsOutput::test_scaling_duration_days_changes_output``, which
+    could produce numerically identical losses before/after scaling ``duration_days`` on
+    unlucky initialisations.  Any test that needs a different initialisation should construct
+    its own model instance rather than mutating this shared fixture.
+    """
+    torch.manual_seed(0)
     model = EveryQueryModel(
         config_overrides=DEMO_CONFIG_OVERRIDES,
         do_demo=True,

--- a/conftest.py
+++ b/conftest.py
@@ -88,15 +88,7 @@ def demo_model_config() -> ModernBertConfig:
 
 @pytest.fixture(scope="session")
 def demo_model() -> EveryQueryModel:
-    """Randomly-initialised EveryQueryModel with tiny dimensions, seeded for determinism.
-
-    The seed pin (``torch.manual_seed(0)``) guards against init-RNG-dependent flakiness in
-    tests that compare forward-pass outputs across perturbed inputs — notably
-    ``TestDurationDaysValueAffectsOutput::test_scaling_duration_days_changes_output``, which
-    could produce numerically identical losses before/after scaling ``duration_days`` on
-    unlucky initialisations.  Any test that needs a different initialisation should construct
-    its own model instance rather than mutating this shared fixture.
-    """
+    """Seeded, tiny EveryQueryModel for CPU-only testing."""
     torch.manual_seed(0)
     model = EveryQueryModel(
         config_overrides=DEMO_CONFIG_OVERRIDES,


### PR DESCRIPTION
## Summary

Small one-liner fix flagged by Copilot while reviewing #99.  Pins `torch.manual_seed(0)` before `EveryQueryModel(...)` in the session-scoped `demo_model` fixture so its weight init is deterministic across runs and across CI's Python-version matrix.

## Why

The `demo_model` fixture constructs a random-weights model but didn't seed torch's global RNG.  `TestDurationDaysValueAffectsOutput::test_scaling_duration_days_changes_output` then occasionally failed on unlucky initialisations that happened to produce numerically identical losses before/after scaling `duration_days` — a genuine flake, not a test-logic bug.

Copilot observed this while reviewing #99:

> `TestDurationDaysValueAffectsOutput::test_scaling_duration_days_changes_output` failed intermittently — the `demo_model` fixture has no fixed random seed [...] I'd recommend adding `torch.manual_seed(42)` before `EveryQueryModel(...)` in the `demo_model` fixture in conftest.py to permanently de-flake it, but I've held off since that fixture lives in the base branch.

## Test plan

- [x] Three consecutive runs of `TestDurationDaysValueAffectsOutput` — all green after the fix.
- [x] Full suite: 174 passed.
- [ ] CI green on push.

## Follow-up

Pull this into the in-flight stacked PRs (#99, #112, #113, #119) via `git merge dev` once merged.  Nothing else consumes the `demo_model` fixture's init RNG state so the blast radius is zero.