### PR TITLE
ci: upgrade codecov-action v4.0.1 -> v5; relax fail_ci_if_error

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -34,11 +34,15 @@ jobs:
           --junitxml=junit.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4.0.1
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: coverage.xml
-          fail_ci_if_error: true
+          # codecov/codecov-action@v4.0.1 pinned exact produced intermittent EPIPE errors on
+          # the gpg-verification subprocess when Codecov's CDN throttled the uploader binary.
+          # v5 uses the new Codecov CLI (no embedded gpg) and the floating major-tag gives us
+          # patch-level fixes without a second pin-bump PR every time.
+          fail_ci_if_error: false
           verbose: true
 
       - name: Upload test results to Codecov


### PR DESCRIPTION
## Summary

Fixes the intermittent red `run_tests_ubuntu` CI status on PRs (#94 most recently; #97 earlier) where the pytest step was fully green but `codecov-action@v4.0.1` hit

```
Error: write EPIPE
    at afterWriteDispatched (node:internal/stream_base_commons:161:15)
    at module.exports (.../node_modules/gpg/lib/spawnGPG.js:50:1)
```

inside its gpg-verification subprocess.  This fires when Codecov's CDN throttles the embedded uploader binary during download — v4's workflow pipes the signed binary through gpg on-the-fly and the gpg-process stdin dies before the binary finishes streaming.  Unrelated to PR contents; transient infrastructure.

## Two changes

### 1. Pin `codecov-action@v5`

v5 uses the new Codecov CLI and doesn't embed gpg in the upload path, so the EPIPE class of failure is gone.  Using the floating major tag (`v5`) so patch-level fixes land without another pin-bump PR; Codecov Actions is stable enough at the major-version level.

### 2. `fail_ci_if_error: true` -> `false`

Coverage upload is telemetry, not a gate.  A transient CDN flake shouldn't turn CI red on a PR whose tests are green.  Real coverage regressions show up independently in Codecov's PR comment / status check, which is unaffected by this flag.

If we want a strict "coverage must upload successfully" gate, I'd add it via a follow-up that uses a retry-on-error pattern rather than fail-on-first-attempt; that gives real protection without the flake surface.

## Test plan

- [ ] CI green on push (mainly exercising the workflow change itself — no code impact)
- [ ] Codecov upload succeeds on subsequent PRs without the EPIPE

## Note

Landing this before retrying #94's red Codecov step directly — the retry under v4 would just race the CDN again.