### PR TITLE
fix(train): seed RNG before instantiate() so weight init is reproducible

### DIFF
--- a/src/every_query/train/train.py
+++ b/src/every_query/train/train.py
@@ -245,13 +245,23 @@ def main(cfg: DictConfig) -> float | None:
     logger.info("Setting torch float32 matmul precision to 'medium'.")
     torch.set_float32_matmul_precision("medium")
 
+    # Seed *before* any `instantiate(...)` call so that model weight init, DataLoader
+    # generator construction, and any other RNG-consuming work happen under the seeded
+    # RNG state.  Previously this block ran after `instantiate(cfg.lightning_module)`,
+    # which meant the starting weights were sampled from whatever torch's RNG happened
+    # to be at process startup — a state that varies across Python versions and
+    # platforms (PYTHONHASHSEED, module import order, etc.), so two runners with the
+    # same `cfg.seed` still produced different initial weights and different training
+    # trajectories.  Reading `do_demo` off the config (rather than the instantiated
+    # `M.model.do_demo`) lets us keep the gate without needing `M` yet.
+    do_demo = cfg.lightning_module.model.get("do_demo", False)
+    if do_demo or cfg.get("seed", None):
+        seed_everything(cfg.get("seed", 1), workers=True)
+
     D = instantiate(cfg.datamodule)
     logger.info(f"Train dataset contains {len(D.train_dataloader().dataset)} datapoints")
 
     M = hydra.utils.instantiate(cfg.lightning_module)
-
-    if M.model.do_demo or cfg.get("seed", None):
-        seed_everything(cfg.get("seed", 1), workers=True)
 
     trainer = instantiate(cfg.trainer)
 


### PR DESCRIPTION
`train.py` was calling `seed_everything(cfg.seed, workers=True)` *after* `hydra.utils.instantiate(cfg.lightning_module)` built the model and sampled initial weights.  Since `seed_everything` only controls RNG from the call forward, starting weights were drawn from whatever PyTorch's global RNG happened to be at process startup — a state that varies across Python versions (PYTHONHASHSEED, subtle import-order differences) and platforms.

Net effect before this change: two runners with identical `cfg.seed` could still produce different initial weights → different training trajectories → different metrics at any step N.  This was confirmed by a 3.11-vs-3.12 divergence on the training-validity test: censor-head AUROC landed at 0.99+ on 3.11 and 0.765 on 3.12 at 2000 steps, same seed, same data.  The training-validity test had to bump `max_steps` 2000 → 4000 to brute-force past the unlucky-init trajectory; the proper fix is to make the init reproducible in the first place, which is what this change does.

Change is minimal:

* Move the `if do_demo or cfg.get("seed"): seed_everything(...)` block above both `instantiate(cfg.datamodule)` and `instantiate(cfg.lightning_module)`, so the seeded RNG state governs DataLoader generator construction and weight init.

* Read `do_demo` off `cfg.lightning_module.model.get("do_demo", False)` instead of `M.model.do_demo`, since `M` doesn't exist yet at that point in the flow.  The gate semantics are unchanged.

No test currently asserts specific weight/loss/AUROC values from a real train run (`test_train_cli.py`, `test_e2e_foundation.py`, and `test_training.py` all check shape/existence/finiteness), so nothing downstream depends on the pre-change init.  Full local test suite (198 tests, 107s) passes.

Follow-up: once this lands, `tests/training_validity/test_training_validity.py` can drop `trainer.max_steps` 4000 → 2000 and remove the platform-init commentary; that'll be done in a separate PR to keep concerns focused.