### PR TITLE
fix(evaluate): require model_run_dirs override instead of shipping stale dated paths

### DIFF
--- a/src/every_query/evaluate/conf/eval_config.yaml
+++ b/src/every_query/evaluate/conf/eval_config.yaml
@@ -2,20 +2,10 @@ defaults:
   - _self_
   - eval_codes: 10000_ID__8db2be6fadf8
 
-# Model run directory (or list of directories).
-# Paths are rooted at $OUTPUT_DIR so they move with .env across machines
-model_run_dirs:
-  - ${oc.env:OUTPUT_DIR}/outputs/2026-04-02/23-43-54 # 256, 22
-  - ${oc.env:OUTPUT_DIR}/outputs/2026-04-02/23-54-43 # 1028, 22
-  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-08/16-38-46/
-  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-03/00-29-53 #2048,6
-  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-02/23-56-55 # 1028, 6
-  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-02/23-58-42 # 1028, 12
-  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-04/14-08-24 # 1028, 16
-  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-02/23-54-43 # 1028, 22
-  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-03/13-28-12 # 256, 6
-  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-03/12-58-10 # 256, 12
-  # - ${oc.env:OUTPUT_DIR}/outputs/2026-04-02/23-43-55 # 256, 16
+# List of training run directories.  Required override — supply from the CLI, e.g.
+#   EQ_evaluate model_run_dirs=[${oc.env:OUTPUT_DIR}/outputs/YYYY-MM-DD/HH-MM-SS/]
+# Paths are typically rooted at $OUTPUT_DIR so they move with .env across machines.
+model_run_dirs: ???
 
 #
 # Checkpoints to evaluate within each run dir (names without .ckpt extension)

--- a/src/every_query/evaluate/conf/select_model_config.yaml
+++ b/src/every_query/evaluate/conf/select_model_config.yaml
@@ -1,8 +1,8 @@
-# Model run directories to compare. Each contributes one model (best ckpt) to the ranking.
-# Paths are rooted at $OUTPUT_DIR so they move with .env; override from the CLI for ad-hoc comparisons.
-model_run_dirs:
-  - ${oc.env:OUTPUT_DIR}/outputs/2026-04-02/23-54-43/
-  - ${oc.env:OUTPUT_DIR}/outputs/2026-04-02/23-43-54/
+# Model run directories to compare.  Each contributes one model (best ckpt) to the
+# ranking.  Required override — supply from the CLI, e.g.
+#   EQ_select_model model_run_dirs=[${oc.env:OUTPUT_DIR}/outputs/.../run1, ...]
+# Paths are typically rooted at $OUTPUT_DIR so they move with .env across machines.
+model_run_dirs: ???
 
 # Eval split to select on. Must match what was passed to eval.py.
 split: tuning


### PR DESCRIPTION
## Summary

Closes #66.

Both `eval_config.yaml` and `select_model_config.yaml` shipped with two dated experiment run directories (`${oc.env:OUTPUT_DIR}/outputs/2026-04-02/...`) as the `model_run_dirs` default.  A fresh user — or the same user after a new training run — couldn't `EQ_evaluate` / `EQ_select_model` without first editing those files, and nothing signaled that an override was mandatory; the failure mode was a silent `FileNotFoundError` when the first dated path didn't exist on the current machine.

This swaps the hardcoded paths for `???` (Hydra's required-value sentinel) so the requirement surfaces at config-resolution time with a clear "mandatory value missing" error, and adds an inline comment showing the override pattern.

## Files

- `src/every_query/evaluate/conf/eval_config.yaml` — `model_run_dirs: ???`
- `src/every_query/evaluate/conf/select_model_config.yaml` — same

## Test plan

- [x] `uv run pytest tests/test_cli_smoke.py -v` — 7/7 passed.  Hydra's `--help` renders help text without resolving required values, so `EQ_evaluate --help` and `EQ_select_model --help` still exit 0.
- [ ] CI green on push.

🤖 Generated with [Claude Code](https://claude.com/claude-code)