### PR TITLE
fix(env): drop PROCESSED and INTERMEDIATE from REQUIRED_ENV_VARS

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -172,8 +172,6 @@ ENSURE_ENV_PLACEHOLDERS: dict[str, str] = {
     "PROJECT_DIR": "/tmp",
     "OUTPUT_DIR": "/tmp",
     "TASK_DIR": "/tmp",
-    "PROCESSED": "/tmp",
-    "INTERMEDIATE": "/tmp",
     "FINAL_DATA_DIR": "/tmp",
     "WANDB_ENTITY": "test",
 }

--- a/src/every_query/utils/_env.py
+++ b/src/every_query/utils/_env.py
@@ -13,11 +13,15 @@ REQUIRED_ENV_VARS = (
     "PROJECT_DIR",
     "OUTPUT_DIR",
     "TASK_DIR",
-    "PROCESSED",
-    "INTERMEDIATE",
     "FINAL_DATA_DIR",
     "WANDB_ENTITY",
 )
+# `PROCESSED` and `INTERMEDIATE` used to live here too but no Hydra config
+# interpolates `${oc.env:PROCESSED}` or `${oc.env:INTERMEDIATE}`.  Their only use is a
+# dotenv fallback inside `sample_tasks.py::_resolve_path`, which already tolerates
+# missing env vars when config values are supplied (the normal CLI path).  Keeping
+# them in the gate was pure friction: demo fixtures / `--help` invocations had to
+# set throwaway placeholder values for no actual resolution.  See #117.
 
 
 def ensure_env() -> None:

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -28,14 +28,7 @@ def _run_train_subprocess(
     env["PATH"] = _VENV_BIN + os.pathsep + env.get("PATH", "")
     # Provide dummy env vars so ensure_env() passes in the subprocess.
     # Hydra CLI overrides control the actual paths used by the test.
-    for var in (
-        "PROJECT_DIR",
-        "OUTPUT_DIR",
-        "TASK_DIR",
-        "PROCESSED",
-        "INTERMEDIATE",
-        "FINAL_DATA_DIR",
-    ):
+    for var in ("PROJECT_DIR", "OUTPUT_DIR", "TASK_DIR", "FINAL_DATA_DIR"):
         env.setdefault(var, str(output_dir))
     env.setdefault("WANDB_ENTITY", "test")
 


### PR DESCRIPTION
## Summary

Refs #117 (phase 1 of the env-vars audit — the "immediate, one-line, zero-risk" item).

`grep '${oc.env:PROCESSED}' / '${oc.env:INTERMEDIATE}'` across all Hydra configs returns zero hits.  Their only consumer is a dotenv fallback inside `generate_tasks/sample_tasks.py::_resolve_path`, which already tolerates missing env vars when config values are supplied (the normal CLI path).  Keeping them in `REQUIRED_ENV_VARS` was pure friction — demo fixtures and E2E integration tests had to set throwaway `/tmp` placeholders in `ENSURE_ENV_PLACEHOLDERS` / `test_train_cli.py`'s subprocess env just to satisfy a gate that didn't correspond to any real Hydra resolution, and `EQ_* --help` on a fresh machine failed on these vars too.

## Changes

- `src/every_query/utils/_env.py` — drop `PROCESSED`, `INTERMEDIATE` from `REQUIRED_ENV_VARS`.  Comment left in place explaining why.
- `conftest.py` — drop both from `ENSURE_ENV_PLACEHOLDERS`.
- `tests/test_train_cli.py` — drop both from the per-test subprocess env setdefault loop.

## Test plan

- [x] `uv run pytest tests/test_train_cli.py tests/test_e2e_foundation.py tests/test_cli_smoke.py tests/test_training.py -v` — 37/37 passed in 78s locally.
- [ ] CI green on push.

## Follow-ups tracked in #117

- Phase 2: drop `PROJECT_DIR` after #100 lands (its only remaining consumer is the eval-suite code being retired there).
- Phase 3: convert remaining `${oc.env:VAR}` interpolations to `${oc.env:VAR,???}` / `${oc.env:VAR,default}` form so Hydra owns the "required" enforcement directly.
- Phase 4: retire `ensure_env()` entirely.

🤖 Generated with [Claude Code](https://claude.com/claude-code)