### PR TITLE
docs(readme): reconcile with current refactor progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -279,12 +279,12 @@ shared cross-stage task-query schema.
 
 ### Phase 2 status
 
-| Sub-phase                      | Issue                                                       | State                                                                |
-| ------------------------------ | ----------------------------------------------------------- | -------------------------------------------------------------------- |
+| Sub-phase                      | Issue                                                       | State                                                                                |
+| ------------------------------ | ----------------------------------------------------------- | ------------------------------------------------------------------------------------ |
 | 2.1: TaskQuerySchema design    | [#80](https://github.com/payalchandak/EveryQuery/issues/80) | Draft PR [#96](https://github.com/payalchandak/EveryQuery/pull/96) (open for review) |
-| 2.2: EQ_predict                | [#81](https://github.com/payalchandak/EveryQuery/issues/81) | Draft PR [#99](https://github.com/payalchandak/EveryQuery/pull/99)   |
-| 2.3: eval-suite inventory      | [#82](https://github.com/payalchandak/EveryQuery/issues/82) | Open (design)                                                        |
-| 2.4: EQ_evaluate consolidation | [#83](https://github.com/payalchandak/EveryQuery/issues/83) | Draft PR [#100](https://github.com/payalchandak/EveryQuery/pull/100) |
+| 2.2: EQ_predict                | [#81](https://github.com/payalchandak/EveryQuery/issues/81) | Draft PR [#99](https://github.com/payalchandak/EveryQuery/pull/99)                   |
+| 2.3: eval-suite inventory      | [#82](https://github.com/payalchandak/EveryQuery/issues/82) | Open (design)                                                                        |
+| 2.4: EQ_evaluate consolidation | [#83](https://github.com/payalchandak/EveryQuery/issues/83) | Draft PR [#100](https://github.com/payalchandak/EveryQuery/pull/100)                 |
 
 ### E2E testing status ([#104](https://github.com/payalchandak/EveryQuery/issues/104))
 

--- a/README.md
+++ b/README.md
@@ -149,12 +149,12 @@ EQ_generate_tasks \
 Sweep across shards with
 `python -m every_query.generate_tasks.sample_tasks -m input_shard=0,1,2,… task_shard=range(0,K)`.
 Each worker writes labeled task parquets under `$TASK_DIR/{split}/*.parquet` idempotently.
-Output columns: `subject_id, prediction_time, boolean_value, occurs, code, duration_days`.
-The `code` column is the MEDS code the query asks about; `duration_days` is the prediction
+Output columns: `subject_id, prediction_time, boolean_value, occurs, query, duration_days`.
+The `query` column is the MEDS code the query asks about; `duration_days` is the prediction
 horizon. These two columns will constitute the `TaskQuerySchema` being defined in
-[#96](https://github.com/payalchandak/EveryQuery/pull/96) (draft PR, closes #80); the extra
+[#96](https://github.com/payalchandak/EveryQuery/pull/96) (open PR, closes #80); the extra
 `occurs` column (EQ's positive-class label) currently sits alongside — collapsing it into
-a single nullable label is tracked in [#122].
+a single nullable label is tracked in [#122] and now in-scope of #96.
 
 ### 3. Train
 
@@ -304,7 +304,7 @@ shared cross-stage task-query schema.
 | [#64](https://github.com/payalchandak/EveryQuery/issues/64)   | Drop gitignored `{train,eval}_codes` defaults (design pick pending)                                                             |
 | [#85](https://github.com/payalchandak/EveryQuery/issues/85)   | Rewrite `sample_codes/` dataset-agnostic — draft PR [#97](https://github.com/payalchandak/EveryQuery/pull/97)                   |
 | [#117](https://github.com/payalchandak/EveryQuery/issues/117) | Env-var audit — phase 1 merged via [#127](https://github.com/payalchandak/EveryQuery/pull/127); phases 2-4 pending              |
-| [#122](https://github.com/payalchandak/EveryQuery/issues/122) | Collapse EQ sampler's `boolean_value` + `occurs` into one nullable label                                                        |
+| [#122](https://github.com/payalchandak/EveryQuery/issues/122) | Collapse EQ sampler's `boolean_value` + `occurs` into one nullable label — in scope of #96                                      |
 | [#125](https://github.com/payalchandak/EveryQuery/issues/125) | Adopt hypothesis-based property tests for the sampler                                                                           |
 | [#59](https://github.com/payalchandak/EveryQuery/issues/59)   | Docs: final rewrite after the refactor settles                                                                                  |
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Given a tensorized MEDS cohort, EveryQuery trains a ModernBERT-style encoder to 
 > [!NOTE]
 > A substantial refactor is in progress — see [#54](https://github.com/payalchandak/EveryQuery/issues/54).
 > The pipeline is being consolidated into fewer, clearer CLIs. This README reflects the
-> current state on `dev`.
+> current state on `dev`; see [Roadmap](#roadmap) for what's changing next.
 
 ## Install
 
@@ -46,11 +46,11 @@ src/every_query/
 ├── preprocessing/      → EQ_process_data        (raw MEDS → tensorized cohort)
 ├── generate_tasks/     → EQ_generate_tasks      (task-label parquets for PT)
 ├── train/              → EQ_train               (train the model)
-├── predict/            → (planned: EQ_predict)  (inference; #81)
+├── predict/            → (planned: EQ_predict)  (inference; #81, draft PR #99)
 │   └── external_tasks/                         (ACES + composite aggregation)
-├── evaluate/           → EQ_evaluate + 3 sibling CLIs  (metrics, model selection; #83 consolidates)
+├── evaluate/           → EQ_evaluate + 3 sibling CLIs  (#83 consolidates into one; draft PR #100)
 ├── model/              (shared: nn.Module + LightningModule)
-├── data/               (shared: PyTorch Dataset + Batch types)
+├── data/               (shared: PyTorch Dataset + Batch types + TaskQuerySchema)
 ├── paper_experiments/  (research-only: ID/OOD splits, ablations, figure code)
 │   └── sample_codes/   (query-code sampling for paper experiments)
 └── utils/              (helpers: seeds, code slugs, env-var validation)
@@ -62,19 +62,29 @@ position, and the tracking issues for remaining work.
 ## Console scripts
 
 `pip install` exposes the CLIs below, all Hydra-configurable. Run any with `--help` or
-`--cfg job` to inspect the resolved config.
+`--cfg job` to inspect the resolved config. The **Tests** column summarises the coverage
+that lands with each CLI on `dev` today — unit tests (fast, `tests/test_<name>_logic.py`
+or `tests/test_<module>.py`), CLI smoke tests (`tests/test_cli_smoke.py`, `--help`-exits-0),
+and end-to-end subprocess tests that run the real script against a fixture cohort.
 
-| Script              | Stage         | Purpose                                                                     |
-| ------------------- | ------------- | --------------------------------------------------------------------------- |
-| `EQ_process_data`   | preprocessing | Orchestrate MEDS-transforms + `meds-torch-data` tensorization               |
-| `EQ_generate_tasks` | task labels   | Sample `N` tasks × `M` contexts, label via single-pass asof (PT-ready)      |
-| `EQ_train`          | training      | Train the ModernBERT encoder on the labeled tasks                           |
-| `EQ_gen_eval_index` | eval setup    | Sample held-out prediction times into a deterministic index                 |
-| `EQ_gen_eval_tasks` | eval setup    | Slice per-duration task matrices by `(code, duration)` using the index      |
-| `EQ_evaluate`       | eval          | Run a trained checkpoint against the sliced eval tasks, write per-code AUCs |
-| `EQ_select_model`   | analysis      | Rank models by pairwise win rate over `(code, duration)` pairs              |
+| Script              | Stage         | Purpose                                                                     | Tests                                                                                                                                 |
+| ------------------- | ------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+| `EQ_process_data`   | preprocessing | Orchestrate MEDS-transforms + `meds-torch-data` tensorization               | smoke; E2E via `test_process_data.py` + `test_e2e_foundation.py`                                                                      |
+| `EQ_generate_tasks` | task labels   | Sample `N` tasks × `M` contexts, label via single-pass asof (PT-ready)      | smoke; unit `test_sample_tasks.py`; E2E `test_generate_tasks.py` (#107)                                                               |
+| `EQ_train`          | training      | Train the ModernBERT encoder on the labeled tasks                           | smoke; unit `test_training.py`; E2E `test_train_cli.py` + `test_train.py` (#108); signal test `tests/training_validity/` (#118, slow) |
+| `EQ_gen_eval_index` | eval setup    | Sample held-out prediction times into a deterministic index                 | smoke only                                                                                                                            |
+| `EQ_gen_eval_tasks` | eval setup    | Slice per-duration task matrices by `(code, duration)` using the index      | smoke; unit `test_eval_suite.py`                                                                                                      |
+| `EQ_evaluate`       | eval          | Run a trained checkpoint against the sliced eval tasks, write per-code AUCs | smoke; unit `test_eval.py`; full E2E pending #109 (needs #100 landed)                                                                 |
+| `EQ_select_model`   | analysis      | Rank models by pairwise win rate over `(code, duration)` pairs              | smoke only                                                                                                                            |
+
+*Planned:* `EQ_predict` (draft PR #99, closes #81) — inference entry point that consumes
+`TaskQuerySchema`-conformant rows and writes a `PredictionSchema`-conformant parquet.
+Once it lands, `EQ_evaluate` consolidation (draft PR #100, closes #83) collapses the
+four current eval CLIs into a single metrics-only stage that reads the predictions parquet.
 
 ## Pipeline
+
+### Current (on `dev`)
 
 ```
            MEDS cohort  ──►  EQ_process_data  ──►  tensorized cohort ($FINAL_DATA_DIR)
@@ -94,11 +104,23 @@ evaluation:                     EQ_gen_eval_index  ──►  EQ_gen_eval_tasks 
                                                                                 EQ_select_model
 ```
 
-> The eval pipeline is being consolidated — `EQ_gen_eval_tasks` currently expects a
-> per-duration wide task matrix whose dedicated producer was removed in
-> [#76](https://github.com/payalchandak/EveryQuery/pull/76). Phase 2 of
-> [#54](https://github.com/payalchandak/EveryQuery/issues/54) replaces these four CLIs with
-> a schema-driven `EQ_predict` + a single consolidated `EQ_evaluate`.
+### Planned (post Phase 2 of #54)
+
+```
+           MEDS cohort  ──►  EQ_process_data  ──►  tensorized cohort
+                                                           │
+                                                           ▼
+                                                EQ_generate_tasks
+                                                           │  TaskQuerySchema parquets
+                                                           ▼
+                                                     EQ_train ──► best_model.ckpt
+                                                                         │
+                                                                         ▼
+                                                                    EQ_predict  ──►  PredictionSchema
+                                                                                         │
+                                                                                         ▼
+                                                                                    EQ_evaluate ──►  metrics
+```
 
 ### 1. Preprocess
 
@@ -127,6 +149,10 @@ EQ_generate_tasks \
 Sweep across shards with
 `python -m every_query.generate_tasks.sample_tasks -m input_shard=0,1,2,… task_shard=range(0,K)`.
 Each worker writes labeled task parquets under `$TASK_DIR/{split}/*.parquet` idempotently.
+Output columns: `subject_id, prediction_time, boolean_value, occurs, code, duration_days`.
+The `code` column matches `TaskQuerySchema` in `every_query.data.schema`; the extra
+`occurs` column (EQ's positive-class label) currently sits alongside — collapsing it into
+a single nullable label is tracked in [#122].
 
 ### 3. Train
 
@@ -141,6 +167,11 @@ EQ_train \
 inline collation step that lived in `train.py` was removed in
 [#76](https://github.com/payalchandak/EveryQuery/pull/76).
 
+Seeding: `cfg.seed` (default `140799`) is passed through `lightning.seed_everything` *before*
+model + datamodule instantiation (fix landed in [#124](https://github.com/payalchandak/EveryQuery/pull/124)),
+so model weight initialization is byte-reproducible across Python versions and platforms
+for a given seed.
+
 ### 4. Evaluate
 
 ```bash
@@ -149,6 +180,11 @@ EQ_gen_eval_tasks # slice per-duration task matrices by (code, duration)
 EQ_evaluate model_run_dirs='["'"$OUTPUT_DIR"'/outputs/YYYY-MM-DD/HH-MM-SS"]'
 EQ_select_model model_run_dirs='["..."]' split=tuning
 ```
+
+`model_run_dirs` is a required override (no default) in both `EQ_evaluate` and
+`EQ_select_model` as of [#126](https://github.com/payalchandak/EveryQuery/pull/126);
+Hydra reports "mandatory value missing" on a fresh clone instead of failing later with
+`FileNotFoundError` on a stale hardcoded path.
 
 ## Configuration
 
@@ -160,20 +196,24 @@ whether you run from a source checkout or a `pip install`ed wheel.
 ### Environment variables
 
 `ensure_env()` (in `utils/_env.py`) requires these be set before `EQ_train` and the eval
-CLIs:
+CLIs. Scope of this gate was tightened in [#127](https://github.com/payalchandak/EveryQuery/pull/127)
+— `PROCESSED` and `INTERMEDIATE` were dropped because no Hydra config interpolates them
+(they were only read by a dotenv fallback in the sampler, which already tolerates missing
+env vars when CLI config values are supplied).
 
-| Var              | Purpose                                                       |
-| ---------------- | ------------------------------------------------------------- |
-| `PROJECT_DIR`    | Repo root (for relative output paths in a few configs)        |
-| `OUTPUT_DIR`     | Where training run dirs land                                  |
-| `TASK_DIR`       | Where task parquets read / write                              |
-| `PROCESSED`      | MEDS cohort `processed/` dir (holds `metadata/codes.parquet`) |
-| `INTERMEDIATE`   | MEDS cohort `intermediate/` dir (event shards)                |
-| `FINAL_DATA_DIR` | Tensorized cohort (output of `EQ_process_data`)               |
-| `WANDB_ENTITY`   | W&B entity for training telemetry                             |
+| Var              | Purpose                                                |
+| ---------------- | ------------------------------------------------------ |
+| `PROJECT_DIR`    | Repo root (for relative output paths in a few configs) |
+| `OUTPUT_DIR`     | Where training run dirs land                           |
+| `TASK_DIR`       | Where task parquets read / write                       |
+| `FINAL_DATA_DIR` | Tensorized cohort (output of `EQ_process_data`)        |
+| `WANDB_ENTITY`   | W&B entity for training telemetry                      |
 
 `.env.example` is the reference — copy to `.env` and edit. Both Python (via
-`python-dotenv`) and the SLURM wrappers under `scripts/` source it.
+`python-dotenv`) and the SLURM wrappers under `scripts/` source it. Further phases of
+[#117](https://github.com/payalchandak/EveryQuery/issues/117) will migrate the remaining
+gated vars to `${oc.env:VAR,???}` / `${oc.env:VAR,default}` form (Hydra-native required
+or optional-with-fallback) and eventually retire `ensure_env()` entirely.
 
 ### Known gotcha: code-group YAMLs
 
@@ -194,13 +234,39 @@ The smoke-test fixture in `tests/test_cli_smoke.py` shows the minimal shape of e
 
 ```bash
 uv sync --group dev
-uv run pytest                         # full suite (~90 s)
+uv run pytest                         # full suite, excluding slow tests (~2 min)
+uv run pytest -m 'slow or not slow'   # full suite incl. slow training-validity test (~8-10 min extra)
 uv run pytest tests/test_cli_smoke.py # CLI smoke tests only
 uv run pre-commit run --all-files     # lint, format, codespell
 ```
 
-CI runs the full `pytest` plus `ruff check` and `ruff format --check` on every PR; coverage
-is uploaded to Codecov.
+CI runs the full `pytest -m "slow or not slow"` (both `slow`-marked and unmarked tests)
+on Python 3.11 and 3.12, plus `ruff check` and `ruff format --check` on every PR; coverage
+is uploaded to Codecov. Full CI session: ~10-11 min typical.
+
+### Test layout
+
+```
+tests/
+├── test_cli_smoke.py               (all 7 EQ_* CLIs; --help exits 0)
+├── test_process_data.py            (E2E: EQ_process_data output shape + metadata)
+├── test_generate_tasks.py          (E2E: ground-truth label recompute + reproducibility + n_tasks differential)
+├── test_sample_tasks.py            (unit: sampler primitives, determinism, edge cases)
+├── test_train_cli.py               (E2E: EQ_train CLI, resume flow, overwrite flag)
+├── test_train.py                   (E2E: resume-actually-loads-ckpt two-stage differential)
+├── test_training.py                (unit: single training step, checkpoint roundtrip, demo-mode checks)
+├── test_e2e_foundation.py          (E2E: full preprocess → generate_tasks → train pipeline chains)
+├── test_eval.py                    (unit: eval.py helpers)
+├── test_eval_suite.py              (unit: gen_task.py, process_eval_tasks)
+├── test_dataset_logic.py           (unit: EveryQueryPytorchDataset + EveryQueryBatch)
+├── test_lightning_logic.py         (unit: LightningModule loss wiring, mask semantics)
+├── test_model_logic.py             (unit: model heads, censored/occurs loss flip sensitivity)
+├── test_run_id.py                  (unit: run_id resolver determinism)
+└── training_validity/              (E2E @pytest.mark.slow: model actually learns; see its README)
+    ├── conftest.py
+    ├── README.md
+    └── test_training_validity.py
+```
 
 ## Roadmap
 
@@ -208,20 +274,41 @@ Overall refactor umbrella: [#54](https://github.com/payalchandak/EveryQuery/issu
 target architecture is `preprocess → generate_tasks → train → predict → evaluate` with a
 shared cross-stage task-query schema.
 
-Live child issues:
+### Phase 2 status
 
-- [#59](https://github.com/payalchandak/EveryQuery/issues/59) — docs: final rewrite after the refactor settles
-- [#62](https://github.com/payalchandak/EveryQuery/issues/62) — promote `aces_to_eq` / `process_composite` to entry points (scaffolded here under `predict/external_tasks/`)
-- [#64](https://github.com/payalchandak/EveryQuery/issues/64) — drop gitignored `{train,eval}_codes` defaults
-- [#66](https://github.com/payalchandak/EveryQuery/issues/66) — unbreak `eval_config.yaml`'s hardcoded run dirs
-- [#68](https://github.com/payalchandak/EveryQuery/issues/68) — wheel-install CI + staged CLI functional tests
-- [#79](https://github.com/payalchandak/EveryQuery/issues/79) — Phase 1 restructure (this PR)
-- [#80](https://github.com/payalchandak/EveryQuery/issues/80) — design cross-stage task-query schema
-- [#81](https://github.com/payalchandak/EveryQuery/issues/81) — `EQ_predict` entry point
-- [#82](https://github.com/payalchandak/EveryQuery/issues/82) — inventory `evaluate/` code paths
-- [#83](https://github.com/payalchandak/EveryQuery/issues/83) — consolidate `EQ_evaluate`
-- [#85](https://github.com/payalchandak/EveryQuery/issues/85) — rewrite `sample_codes/` dataset-agnostic
-- [#91](https://github.com/payalchandak/EveryQuery/issues/91) — `do_resume` structural-drift check
+| Sub-phase                      | Issue                                                       | State                                                                |
+| ------------------------------ | ----------------------------------------------------------- | -------------------------------------------------------------------- |
+| 2.1: TaskQuerySchema design    | [#80](https://github.com/payalchandak/EveryQuery/issues/80) | **Merged** via #96 (schema + sampler-side `code` wire)               |
+| 2.2: EQ_predict                | [#81](https://github.com/payalchandak/EveryQuery/issues/81) | Draft PR [#99](https://github.com/payalchandak/EveryQuery/pull/99)   |
+| 2.3: eval-suite inventory      | [#82](https://github.com/payalchandak/EveryQuery/issues/82) | Open (design)                                                        |
+| 2.4: EQ_evaluate consolidation | [#83](https://github.com/payalchandak/EveryQuery/issues/83) | Draft PR [#100](https://github.com/payalchandak/EveryQuery/pull/100) |
+
+### E2E testing status ([#104](https://github.com/payalchandak/EveryQuery/issues/104))
+
+| Subprocess test                  | Issue                                                         | State                                                                                                     |
+| -------------------------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
+| `test_process_data.py`           | (pre-104)                                                     | ✅ merged                                                                                                 |
+| `test_generate_tasks.py`         | [#107](https://github.com/payalchandak/EveryQuery/issues/107) | ✅ merged via [#112](https://github.com/payalchandak/EveryQuery/pull/112)                                 |
+| `test_train.py`                  | [#108](https://github.com/payalchandak/EveryQuery/issues/108) | ✅ merged via [#113](https://github.com/payalchandak/EveryQuery/pull/113)                                 |
+| `test_evaluate.py`               | [#109](https://github.com/payalchandak/EveryQuery/issues/109) | Blocked on #99 + #100 landing (needs `EQ_predict` + consolidated `EQ_evaluate`)                           |
+| training-validity (model learns) | [#118](https://github.com/payalchandak/EveryQuery/issues/118) | ✅ merged via [#119](https://github.com/payalchandak/EveryQuery/pull/119) — runs slow, gated by `-m slow` |
+
+### Hygiene / follow-ups
+
+| Issue                                                         | Description                                                                                                                     |
+| ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| [#62](https://github.com/payalchandak/EveryQuery/issues/62)   | Promote `aces_to_eq` / `process_composite` to entry points — draft PR [#95](https://github.com/payalchandak/EveryQuery/pull/95) |
+| [#64](https://github.com/payalchandak/EveryQuery/issues/64)   | Drop gitignored `{train,eval}_codes` defaults (design pick pending)                                                             |
+| [#85](https://github.com/payalchandak/EveryQuery/issues/85)   | Rewrite `sample_codes/` dataset-agnostic — draft PR [#97](https://github.com/payalchandak/EveryQuery/pull/97)                   |
+| [#117](https://github.com/payalchandak/EveryQuery/issues/117) | Env-var audit — phase 1 merged via [#127](https://github.com/payalchandak/EveryQuery/pull/127); phases 2-4 pending              |
+| [#122](https://github.com/payalchandak/EveryQuery/issues/122) | Collapse EQ sampler's `boolean_value` + `occurs` into one nullable label                                                        |
+| [#125](https://github.com/payalchandak/EveryQuery/issues/125) | Adopt hypothesis-based property tests for the sampler                                                                           |
+| [#59](https://github.com/payalchandak/EveryQuery/issues/59)   | Docs: final rewrite after the refactor settles                                                                                  |
+
+### Model / architecture research (non-blocking)
+
+- [#101](https://github.com/payalchandak/EveryQuery/issues/101) / [#102](https://github.com/payalchandak/EveryQuery/issues/102) — RoPE for time-deltas
+- [#103](https://github.com/payalchandak/EveryQuery/issues/103) — Evaluate alternatives to ModernBERT as the encoder backbone
 
 ## Acknowledgements
 
@@ -235,3 +322,5 @@ for training, and [W&B](https://wandb.ai) for telemetry.
 ## License
 
 MIT — see [LICENSE](LICENSE).
+
+[#122]: https://github.com/payalchandak/EveryQuery/issues/122

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ src/every_query/
 │   └── external_tasks/                         (ACES + composite aggregation)
 ├── evaluate/           → EQ_evaluate + 3 sibling CLIs  (#83 consolidates into one; draft PR #100)
 ├── model/              (shared: nn.Module + LightningModule)
-├── data/               (shared: PyTorch Dataset + Batch types + TaskQuerySchema)
+├── data/               (shared: PyTorch Dataset + Batch types)
 ├── paper_experiments/  (research-only: ID/OOD splits, ablations, figure code)
 │   └── sample_codes/   (query-code sampling for paper experiments)
 └── utils/              (helpers: seeds, code slugs, env-var validation)
@@ -150,7 +150,9 @@ Sweep across shards with
 `python -m every_query.generate_tasks.sample_tasks -m input_shard=0,1,2,… task_shard=range(0,K)`.
 Each worker writes labeled task parquets under `$TASK_DIR/{split}/*.parquet` idempotently.
 Output columns: `subject_id, prediction_time, boolean_value, occurs, code, duration_days`.
-The `code` column matches `TaskQuerySchema` in `every_query.data.schema`; the extra
+The `code` column is the MEDS code the query asks about; `duration_days` is the prediction
+horizon. These two columns will constitute the `TaskQuerySchema` being defined in
+[#96](https://github.com/payalchandak/EveryQuery/pull/96) (draft PR, closes #80); the extra
 `occurs` column (EQ's positive-class label) currently sits alongside — collapsing it into
 a single nullable label is tracked in [#122].
 
@@ -263,6 +265,7 @@ tests/
 ├── test_model_logic.py             (unit: model heads, censored/occurs loss flip sensitivity)
 ├── test_run_id.py                  (unit: run_id resolver determinism)
 └── training_validity/              (E2E @pytest.mark.slow: model actually learns; see its README)
+    ├── __init__.py
     ├── conftest.py
     ├── README.md
     └── test_training_validity.py
@@ -278,7 +281,7 @@ shared cross-stage task-query schema.
 
 | Sub-phase                      | Issue                                                       | State                                                                |
 | ------------------------------ | ----------------------------------------------------------- | -------------------------------------------------------------------- |
-| 2.1: TaskQuerySchema design    | [#80](https://github.com/payalchandak/EveryQuery/issues/80) | **Merged** via #96 (schema + sampler-side `code` wire)               |
+| 2.1: TaskQuerySchema design    | [#80](https://github.com/payalchandak/EveryQuery/issues/80) | Draft PR [#96](https://github.com/payalchandak/EveryQuery/pull/96) (open for review) |
 | 2.2: EQ_predict                | [#81](https://github.com/payalchandak/EveryQuery/issues/81) | Draft PR [#99](https://github.com/payalchandak/EveryQuery/pull/99)   |
 | 2.3: eval-suite inventory      | [#82](https://github.com/payalchandak/EveryQuery/issues/82) | Open (design)                                                        |
 | 2.4: EQ_evaluate consolidation | [#83](https://github.com/payalchandak/EveryQuery/issues/83) | Draft PR [#100](https://github.com/payalchandak/EveryQuery/pull/100) |


### PR DESCRIPTION
## Summary

Docs-only update to the top-level `README.md`.  Reconciles the pipeline description, env-var table, and roadmap with the current state of `dev` after the recent merges (#112, #113, #119, #124, #126, #127) and documents what's covered on each CLI endpoint vs. what's planned.

## What changed

- **Console scripts table**: added a "Tests" column so the coverage that lands with each CLI on `dev` today (smoke / unit / E2E subprocess / slow signal test) is visible without grepping, with issue + PR refs for each.
- **Pipeline section**: kept the current diagram, added a "Planned" diagram for the Phase 2 target (preprocess → generate_tasks → train → predict → evaluate).  Inline notes on the current diagram call out the `code` column / `TaskQuerySchema` alignment (#96), the #124 seed-ordering fix, and the #126 `model_run_dirs` required-override.
- **Environment variables**: dropped `PROCESSED` and `INTERMEDIATE` rows (no longer in `REQUIRED_ENV_VARS` after #127); added a note pointing at the remaining phases of #117.
- **Development**: added a full "Test layout" subsection listing every file under `tests/` with its coverage scope, and clarified the `pytest -m 'slow or not slow'` opt-in for the training-validity test.
- **Roadmap**: restructured into three focused tables — Phase 2 status (#80/#81/#82/#83), E2E testing status (#104 umbrella), and hygiene follow-ups.  Merged items are marked ✅; in-flight items link to their issue or draft PR.  Architecture research (RoPE, ModernBERT alternatives) moved to its own subsection so it doesn't compete visually with the refactor tracker.

## Test plan

- [x] `uv run pytest tests/test_cli_smoke.py` — 7/7 pass (docs change doesn't touch code).
- [x] `pre-commit run --all-files` via the commit hook — mdformat applied, commit landed.
- [ ] CI green on push.

Docs-only — no code changes.  No Python files modified; no tests altered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)