### PR TITLE
fix(train): replace leftover `print("fitting model")` with `logger.info(...)`

### DIFF
--- a/src/every_query/train/train.py
+++ b/src/every_query/train/train.py
@@ -269,7 +269,7 @@ def main(cfg: DictConfig) -> float | None:
     if ckpt_path:
         logger.info(f"Trying to resume training from checkpoint {ckpt_path}.")
         trainer_kwargs["ckpt_path"] = ckpt_path
-    print("fitting model")
+    logger.info("Fitting model")
     trainer.fit(**trainer_kwargs)
 
     best_ckpt_path = Path(trainer.checkpoint_callback.best_model_path)


### PR DESCRIPTION
Pre-existing stray `print` in `train.py:272` — inconsistent with the rest of `train.py`'s structured logging (`logger.info(...)` everywhere else in the same function).

Flagged by Copilot during the #131 release-candidate review as the only minor-but-worth-fixing finding.  Small enough that filing a follow-up issue for it felt like more overhead than the fix itself.

One line.  No functional change — routes through the configured logging handlers instead of stdout directly.

## Test plan

- [x] `pre-commit run --all-files` — clean.
- [ ] CI green.