### PR TITLE
docs(readme): reconcile with current dev post-Phase-2

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,7 @@ Given a tensorized MEDS cohort, EveryQuery trains a ModernBERT-style encoder to 
 `(code, duration)` combinations.
 
 > [!NOTE]
-> A substantial refactor is in progress — see [#54](https://github.com/payalchandak/EveryQuery/issues/54).
-> The pipeline is being consolidated into fewer, clearer CLIs. This README reflects the
-> current state on `dev`; see [Roadmap](#roadmap) for what's changing next.
+> The Phase-1 + Phase-2 refactor from [#54](https://github.com/payalchandak/EveryQuery/issues/54) has landed: `preprocess → generate_tasks → train → predict → evaluate` with a cross-stage [`TaskQuerySchema`](src/every_query/data/schema.py) is the current shape. One CLI surface is still mid-migration: `EQ_evaluate` console script points at the legacy four-stage evaluator; the new single-stage evaluator (#100) is reachable as `python -m every_query.evaluate.evaluate` today and a future release will flip the entry point ([#83](https://github.com/payalchandak/EveryQuery/issues/83) tracks the rewire). See [Roadmap](#roadmap) for what's next.
 
 ## Install
 
@@ -44,16 +42,16 @@ Every production module lives under a submodule that reflects its role:
 ```
 src/every_query/
 ├── preprocessing/      → EQ_process_data        (raw MEDS → tensorized cohort)
-├── generate_tasks/     → EQ_generate_tasks      (task-label parquets for PT)
+├── generate_tasks/     → EQ_generate_tasks      (TaskQuerySchema-conformant task parquets)
 ├── train/              → EQ_train               (train the model)
-├── predict/            → (planned: EQ_predict)  (inference; #81, draft PR #99)
-│   └── external_tasks/                         (ACES + composite aggregation)
-├── evaluate/           → EQ_evaluate + 3 sibling CLIs  (#83 consolidates into one; draft PR #100)
+├── predict/            → EQ_predict             (inference; consumes TaskQuerySchema, emits PredictionSchema)
+│   └── external_tasks/                         (ACES + composite aggregation; entry points on #95)
+├── evaluate/           → EQ_evaluate (legacy) + new evaluate.py (#83 rewire pending)
 ├── model/              (shared: nn.Module + LightningModule)
-├── data/               (shared: PyTorch Dataset + Batch types)
+├── data/               (shared: PyTorch Dataset + Batch types + TaskQuerySchema)
 ├── paper_experiments/  (research-only: ID/OOD splits, ablations, figure code)
-│   └── sample_codes/   (query-code sampling for paper experiments)
-└── utils/              (helpers: seeds, code slugs, env-var validation)
+│   └── sample_codes/   (query-code sampling for paper experiments; dataset-agnostic on #97)
+└── utils/              (helpers: seeds, code slugs, env-var validation, model_loader)
 ```
 
 Every submodule has its own `README.md` explaining what belongs there, its pipeline
@@ -67,20 +65,18 @@ that lands with each CLI on `dev` today — unit tests (fast, `tests/test_<name>
 or `tests/test_<module>.py`), CLI smoke tests (`tests/test_cli_smoke.py`, `--help`-exits-0),
 and end-to-end subprocess tests that run the real script against a fixture cohort.
 
-| Script              | Stage         | Purpose                                                                     | Tests                                                                                                                                 |
-| ------------------- | ------------- | --------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
-| `EQ_process_data`   | preprocessing | Orchestrate MEDS-transforms + `meds-torch-data` tensorization               | smoke; E2E via `test_process_data.py` + `test_e2e_foundation.py`                                                                      |
-| `EQ_generate_tasks` | task labels   | Sample `N` tasks × `M` contexts, label via single-pass asof (PT-ready)      | smoke; unit `test_sample_tasks.py`; E2E `test_generate_tasks.py` (#107)                                                               |
-| `EQ_train`          | training      | Train the ModernBERT encoder on the labeled tasks                           | smoke; unit `test_training.py`; E2E `test_train_cli.py` + `test_train.py` (#108); signal test `tests/training_validity/` (#118, slow) |
-| `EQ_gen_eval_index` | eval setup    | Sample held-out prediction times into a deterministic index                 | smoke only                                                                                                                            |
-| `EQ_gen_eval_tasks` | eval setup    | Slice per-duration task matrices by `(code, duration)` using the index      | smoke; unit `test_eval_suite.py`                                                                                                      |
-| `EQ_evaluate`       | eval          | Run a trained checkpoint against the sliced eval tasks, write per-code AUCs | smoke; unit `test_eval.py`; full E2E pending #109 (needs #100 landed)                                                                 |
-| `EQ_select_model`   | analysis      | Rank models by pairwise win rate over `(code, duration)` pairs              | smoke only                                                                                                                            |
+| Script              | Stage         | Purpose                                                                                                                               | Tests                                                                                                                    |
+| ------------------- | ------------- | ------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `EQ_process_data`   | preprocessing | Orchestrate MEDS-transforms + `meds-torch-data` tensorization                                                                         | smoke; E2E via `test_process_data.py` + `test_e2e_foundation.py`                                                         |
+| `EQ_generate_tasks` | task labels   | Sample `N` tasks × `M` contexts, label via single-pass asof (`TaskQuerySchema`-conformant)                                            | smoke; unit `test_sample_tasks.py`; E2E `test_generate_tasks.py`                                                         |
+| `EQ_train`          | training      | Train the ModernBERT encoder on the labeled tasks                                                                                     | smoke; unit `test_training.py`; E2E `test_train_cli.py` + `test_train.py`; signal test `tests/training_validity/` (slow) |
+| `EQ_predict`        | inference     | Consume a `TaskQuerySchema` parquet dir + checkpoint, emit a `PredictionSchema` parquet (`censor_prob`, `occurs_prob`)                | smoke; E2E `test_predict_cli.py` (row-order preserved); also exercised by `tests/training_validity/` (slow)              |
+| `EQ_gen_eval_index` | eval (legacy) | Sample held-out prediction times into a deterministic index                                                                           | smoke only                                                                                                               |
+| `EQ_gen_eval_tasks` | eval (legacy) | Slice per-duration task matrices by `(code, duration)` using the index                                                                | smoke; unit `test_eval_suite.py`                                                                                         |
+| `EQ_evaluate`       | eval (legacy) | **Legacy**: runs a trained checkpoint against the sliced eval tasks, writes per-code AUCs. #83 will rewire to the new evaluator below | smoke; unit `test_eval.py`                                                                                               |
+| `EQ_select_model`   | analysis      | Rank models by pairwise win rate over `(code, duration)` pairs                                                                        | smoke only                                                                                                               |
 
-*Planned:* `EQ_predict` (draft PR #99, closes #81) — inference entry point that consumes
-`TaskQuerySchema`-conformant rows and writes a `PredictionSchema`-conformant parquet.
-Once it lands, `EQ_evaluate` consolidation (draft PR #100, closes #83) collapses the
-four current eval CLIs into a single metrics-only stage that reads the predictions parquet.
+**New single-stage evaluator** (`python -m every_query.evaluate.evaluate`) — consumes a `PredictionSchema` parquet from `EQ_predict`, writes per-`(query, duration_days)` metrics (`n_rows`, `n_occurs_labeled`, `n_positive`, `occurs_auroc`, `censor_auroc`). Not yet on `EQ_evaluate` — the `[project.scripts]` rewire is deferred to the [#83](https://github.com/payalchandak/EveryQuery/issues/83) consolidation wave. Tested via `test_evaluate_cli.py` and `tests/training_validity/` (slow).
 
 ## Pipeline
 
@@ -90,37 +86,25 @@ four current eval CLIs into a single metrics-only stage that reads the predictio
            MEDS cohort  ──►  EQ_process_data  ──►  tensorized cohort ($FINAL_DATA_DIR)
                                                                      │
                                                                      ▼
-pre-training:                                              EQ_generate_tasks
-                                                                     │  labeled task parquets
+                                                         EQ_generate_tasks
+                                                                     │  TaskQuerySchema parquets
                                                                      ▼
                                                                 EQ_train  ──►  best_model.ckpt
-                                                                                       │
-evaluation:                     EQ_gen_eval_index  ──►  EQ_gen_eval_tasks              │
-                                                                │                      │
-                                                                ▼                      ▼
-                                                                             EQ_evaluate
-                                                                                       │  per-code AUCs
-                                                                                       ▼
-                                                                                EQ_select_model
+                                                                                     │
+                                                                                     ▼
+                                                                                EQ_predict  ──►  PredictionSchema parquet
+                                                                                                           │
+                                                                                     ┌─────────────────────┤
+                                                                                     │                     │
+                                                                                     ▼                     ▼
+                                             python -m every_query.evaluate.evaluate      EQ_evaluate (legacy, ignores
+                                                          │                                 the PredictionSchema path —
+                                                          ▼                                 runs its own inference loop
+                                                 per-(query, duration_days)                 against the sliced task
+                                                       metrics                              parquets + sibling CLIs)
 ```
 
-### Planned (post Phase 2 of #54)
-
-```
-           MEDS cohort  ──►  EQ_process_data  ──►  tensorized cohort
-                                                           │
-                                                           ▼
-                                                EQ_generate_tasks
-                                                           │  TaskQuerySchema parquets
-                                                           ▼
-                                                     EQ_train ──► best_model.ckpt
-                                                                         │
-                                                                         ▼
-                                                                    EQ_predict  ──►  PredictionSchema
-                                                                                         │
-                                                                                         ▼
-                                                                                    EQ_evaluate ──►  metrics
-```
+Both evaluator paths ship in this release; the legacy one is what `EQ_evaluate` resolves to today, and the new path is reachable via `python -m`. [#83](https://github.com/payalchandak/EveryQuery/issues/83) tracks the rewire that consolidates to a single `EQ_evaluate` pointing at the new module.
 
 ### 1. Preprocess
 
@@ -148,13 +132,7 @@ EQ_generate_tasks \
 
 Sweep across shards with
 `python -m every_query.generate_tasks.sample_tasks -m input_shard=0,1,2,… task_shard=range(0,K)`.
-Each worker writes labeled task parquets under `$TASK_DIR/{split}/*.parquet` idempotently.
-Output columns: `subject_id, prediction_time, boolean_value, occurs, query, duration_days`.
-The `query` column is the MEDS code the query asks about; `duration_days` is the prediction
-horizon. These two columns will constitute the `TaskQuerySchema` being defined in
-[#96](https://github.com/payalchandak/EveryQuery/pull/96) (open PR, closes #80); the extra
-`occurs` column (EQ's positive-class label) currently sits alongside — collapsing it into
-a single nullable label is tracked in [#122] and now in-scope of #96.
+Each worker writes labeled task parquets under `$TASK_DIR/{split}/*.parquet` idempotently. Output columns conform to [`TaskQuerySchema`](src/every_query/data/schema.py) — `subject_id, prediction_time, query, duration_days, boolean_value` — where `boolean_value` is a nullable three-valued label (`null` = censored, `True` = event occurred in `[prediction_time, prediction_time + duration_days)`, `False` = observed-but-no-event).
 
 ### 3. Train
 
@@ -174,7 +152,31 @@ model + datamodule instantiation (fix landed in [#124](https://github.com/payalc
 so model weight initialization is byte-reproducible across Python versions and platforms
 for a given seed.
 
-### 4. Evaluate
+### 4. Predict
+
+```bash
+EQ_predict \
+	model_run_dir="$OUTPUT_DIR/outputs/YYYY-MM-DD/HH-MM-SS" \
+	tasks_dir="$TASK_DIR/tuning" \
+	output_parquet="$OUTPUT_DIR/predictions.parquet" \
+	split=tuning # or split=held_out (default)
+```
+
+Reads every `*.parquet` under `tasks_dir` (`TaskQuerySchema`-conformant), runs the checkpoint's `predict_step` over the chosen split, writes a single `PredictionSchema` parquet with `censor_prob` + `occurs_prob` per input row. See [`predict/README.md`](src/every_query/predict/README.md) for details.
+
+### 5. Evaluate — new single-stage path
+
+```bash
+python -m every_query.evaluate.evaluate \
+	predictions_parquet="$OUTPUT_DIR/predictions.parquet" \
+	metrics_parquet="$OUTPUT_DIR/metrics.parquet"
+```
+
+Per-`(query, duration_days)` metrics from the predictions parquet — `n_rows`, `n_occurs_labeled`, `n_positive`, `occurs_auroc` (on non-censored rows), `censor_auroc`. See [`evaluate/README.md`](src/every_query/evaluate/README.md).
+
+`[project.scripts]` `EQ_evaluate` does **not** yet point at this module — the rewire is the remaining work on [#83](https://github.com/payalchandak/EveryQuery/issues/83).
+
+### 6. Evaluate — legacy four-stage path
 
 ```bash
 EQ_gen_eval_index # sample prediction times into a deterministic eval index
@@ -183,10 +185,7 @@ EQ_evaluate model_run_dirs='["'"$OUTPUT_DIR"'/outputs/YYYY-MM-DD/HH-MM-SS"]'
 EQ_select_model model_run_dirs='["..."]' split=tuning
 ```
 
-`model_run_dirs` is a required override (no default) in both `EQ_evaluate` and
-`EQ_select_model` as of [#126](https://github.com/payalchandak/EveryQuery/pull/126);
-Hydra reports "mandatory value missing" on a fresh clone instead of failing later with
-`FileNotFoundError` on a stale hardcoded path.
+Still what the `EQ_evaluate` console script resolves to today — runs inference + metrics in one shot, with multi-model / id-ood-manual bucketing the new path doesn't have. Preserved until the #83 consolidation wave signs off on migration. `model_run_dirs` is a required override (no default) in both `EQ_evaluate` and `EQ_select_model` as of [#126](https://github.com/payalchandak/EveryQuery/pull/126); Hydra reports "mandatory value missing" on a fresh clone instead of failing later with `FileNotFoundError` on a stale hardcoded path.
 
 ## Configuration
 
@@ -250,21 +249,23 @@ is uploaded to Codecov. Full CI session: ~10-11 min typical.
 
 ```
 tests/
-├── test_cli_smoke.py               (all 7 EQ_* CLIs; --help exits 0)
+├── test_cli_smoke.py               (every EQ_* CLI; --help exits 0)
 ├── test_process_data.py            (E2E: EQ_process_data output shape + metadata)
 ├── test_generate_tasks.py          (E2E: ground-truth label recompute + reproducibility + n_tasks differential)
 ├── test_sample_tasks.py            (unit: sampler primitives, determinism, edge cases)
 ├── test_train_cli.py               (E2E: EQ_train CLI, resume flow, overwrite flag)
 ├── test_train.py                   (E2E: resume-actually-loads-ckpt two-stage differential)
 ├── test_training.py                (unit: single training step, checkpoint roundtrip, demo-mode checks)
+├── test_predict_cli.py             (E2E: EQ_predict against a trained checkpoint + row-order preservation)
+├── test_evaluate_cli.py            (E2E: python -m every_query.evaluate.evaluate on a synthetic PredictionSchema parquet)
 ├── test_e2e_foundation.py          (E2E: full preprocess → generate_tasks → train pipeline chains)
-├── test_eval.py                    (unit: eval.py helpers)
-├── test_eval_suite.py              (unit: gen_task.py, process_eval_tasks)
+├── test_eval.py                    (unit: legacy eval.py helpers)
+├── test_eval_suite.py              (unit: legacy gen_task.py, process_eval_tasks)
 ├── test_dataset_logic.py           (unit: EveryQueryPytorchDataset + EveryQueryBatch)
 ├── test_lightning_logic.py         (unit: LightningModule loss wiring, mask semantics)
 ├── test_model_logic.py             (unit: model heads, censored/occurs loss flip sensitivity)
 ├── test_run_id.py                  (unit: run_id resolver determinism)
-└── training_validity/              (E2E @pytest.mark.slow: model actually learns; see its README)
+└── training_validity/              (E2E @pytest.mark.slow: model actually learns; now runs via EQ_predict → evaluate.evaluate subprocess chain; see its README)
     ├── __init__.py
     ├── conftest.py
     ├── README.md
@@ -279,22 +280,23 @@ shared cross-stage task-query schema.
 
 ### Phase 2 status
 
-| Sub-phase                      | Issue                                                       | State                                                                                |
-| ------------------------------ | ----------------------------------------------------------- | ------------------------------------------------------------------------------------ |
-| 2.1: TaskQuerySchema design    | [#80](https://github.com/payalchandak/EveryQuery/issues/80) | Draft PR [#96](https://github.com/payalchandak/EveryQuery/pull/96) (open for review) |
-| 2.2: EQ_predict                | [#81](https://github.com/payalchandak/EveryQuery/issues/81) | Draft PR [#99](https://github.com/payalchandak/EveryQuery/pull/99)                   |
-| 2.3: eval-suite inventory      | [#82](https://github.com/payalchandak/EveryQuery/issues/82) | Open (design)                                                                        |
-| 2.4: EQ_evaluate consolidation | [#83](https://github.com/payalchandak/EveryQuery/issues/83) | Draft PR [#100](https://github.com/payalchandak/EveryQuery/pull/100)                 |
+| Sub-phase                      | Issue                                                       | State                                                                                                                                       |
+| ------------------------------ | ----------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------- |
+| 2.1: TaskQuerySchema design    | [#80](https://github.com/payalchandak/EveryQuery/issues/80) | ✅ merged via [#96](https://github.com/payalchandak/EveryQuery/pull/96) (also closes #122)                                                  |
+| 2.2: EQ_predict                | [#81](https://github.com/payalchandak/EveryQuery/issues/81) | ✅ merged via [#99](https://github.com/payalchandak/EveryQuery/pull/99)                                                                     |
+| 2.3: eval-suite inventory      | [#82](https://github.com/payalchandak/EveryQuery/issues/82) | Decisions captured on the issue + reflected in #100's scope; no code change needed                                                          |
+| 2.4: EQ_evaluate consolidation | [#83](https://github.com/payalchandak/EveryQuery/issues/83) | 🟡 new `evaluate.py` merged via [#100](https://github.com/payalchandak/EveryQuery/pull/100); `[project.scripts]` rewire + deletions pending |
 
 ### E2E testing status ([#104](https://github.com/payalchandak/EveryQuery/issues/104))
 
-| Subprocess test                  | Issue                                                         | State                                                                                                     |
-| -------------------------------- | ------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------- |
-| `test_process_data.py`           | (pre-104)                                                     | ✅ merged                                                                                                 |
-| `test_generate_tasks.py`         | [#107](https://github.com/payalchandak/EveryQuery/issues/107) | ✅ merged via [#112](https://github.com/payalchandak/EveryQuery/pull/112)                                 |
-| `test_train.py`                  | [#108](https://github.com/payalchandak/EveryQuery/issues/108) | ✅ merged via [#113](https://github.com/payalchandak/EveryQuery/pull/113)                                 |
-| `test_evaluate.py`               | [#109](https://github.com/payalchandak/EveryQuery/issues/109) | Blocked on #99 + #100 landing (needs `EQ_predict` + consolidated `EQ_evaluate`)                           |
-| training-validity (model learns) | [#118](https://github.com/payalchandak/EveryQuery/issues/118) | ✅ merged via [#119](https://github.com/payalchandak/EveryQuery/pull/119) — runs slow, gated by `-m slow` |
+| Subprocess test                  | Issue                                                         | State                                                                                                                                                                            |
+| -------------------------------- | ------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `test_process_data.py`           | (pre-104)                                                     | ✅ merged                                                                                                                                                                        |
+| `test_generate_tasks.py`         | [#107](https://github.com/payalchandak/EveryQuery/issues/107) | ✅ merged via [#112](https://github.com/payalchandak/EveryQuery/pull/112)                                                                                                        |
+| `test_train.py`                  | [#108](https://github.com/payalchandak/EveryQuery/issues/108) | ✅ merged via [#113](https://github.com/payalchandak/EveryQuery/pull/113)                                                                                                        |
+| `test_predict_cli.py`            | (part of #99)                                                 | ✅ merged via [#99](https://github.com/payalchandak/EveryQuery/pull/99) (row-order preservation covered)                                                                         |
+| `test_evaluate_cli.py`           | [#109](https://github.com/payalchandak/EveryQuery/issues/109) | ✅ merged via [#100](https://github.com/payalchandak/EveryQuery/pull/100) (new single-stage evaluator)                                                                           |
+| training-validity (model learns) | [#118](https://github.com/payalchandak/EveryQuery/issues/118) | ✅ merged via [#119](https://github.com/payalchandak/EveryQuery/pull/119); now runs the full `EQ_predict` → `evaluate.evaluate` chain as subprocesses (slow, gated by `-m slow`) |
 
 ### Hygiene / follow-ups
 
@@ -304,8 +306,8 @@ shared cross-stage task-query schema.
 | [#64](https://github.com/payalchandak/EveryQuery/issues/64)   | Drop gitignored `{train,eval}_codes` defaults (design pick pending)                                                             |
 | [#85](https://github.com/payalchandak/EveryQuery/issues/85)   | Rewrite `sample_codes/` dataset-agnostic — draft PR [#97](https://github.com/payalchandak/EveryQuery/pull/97)                   |
 | [#117](https://github.com/payalchandak/EveryQuery/issues/117) | Env-var audit — phase 1 merged via [#127](https://github.com/payalchandak/EveryQuery/pull/127); phases 2-4 pending              |
-| [#122](https://github.com/payalchandak/EveryQuery/issues/122) | Collapse EQ sampler's `boolean_value` + `occurs` into one nullable label — in scope of #96                                      |
 | [#125](https://github.com/payalchandak/EveryQuery/issues/125) | Adopt hypothesis-based property tests for the sampler                                                                           |
+| [#129](https://github.com/payalchandak/EveryQuery/issues/129) | Rename `PredictionSchema.occurs_prob` → `label_prob` post-NeurIPS once non-occurrence task types land                           |
 | [#59](https://github.com/payalchandak/EveryQuery/issues/59)   | Docs: final rewrite after the refactor settles                                                                                  |
 
 ### Model / architecture research (non-blocking)
@@ -325,5 +327,3 @@ for training, and [W&B](https://wandb.ai) for telemetry.
 ## License
 
 MIT — see [LICENSE](LICENSE).
-
-[#122]: https://github.com/payalchandak/EveryQuery/issues/122

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ src/every_query/
 ├── generate_tasks/     → EQ_generate_tasks      (TaskQuerySchema-conformant task parquets)
 ├── train/              → EQ_train               (train the model)
 ├── predict/            → EQ_predict             (inference; consumes TaskQuerySchema, emits PredictionSchema)
-│   └── external_tasks/                         (ACES + composite aggregation; entry points on #95)
+│   └── external_tasks/                         (ACES + composite aggregation — currently `python -m` only;
+│                                                  [#62](https://github.com/payalchandak/EveryQuery/issues/62) tracks promoting to console scripts, draft PR [#95](https://github.com/payalchandak/EveryQuery/pull/95))
 ├── evaluate/           → EQ_evaluate (legacy) + new evaluate.py (#83 rewire pending)
 ├── model/              (shared: nn.Module + LightningModule)
 ├── data/               (shared: PyTorch Dataset + Batch types + TaskQuerySchema)
@@ -83,28 +84,29 @@ and end-to-end subprocess tests that run the real script against a fixture cohor
 ### Current (on `dev`)
 
 ```
-           MEDS cohort  ──►  EQ_process_data  ──►  tensorized cohort ($FINAL_DATA_DIR)
-                                                                     │
-                                                                     ▼
-                                                         EQ_generate_tasks
-                                                                     │  TaskQuerySchema parquets
-                                                                     ▼
-                                                                EQ_train  ──►  best_model.ckpt
-                                                                                     │
-                                                                                     ▼
-                                                                                EQ_predict  ──►  PredictionSchema parquet
-                                                                                                           │
-                                                                                     ┌─────────────────────┤
-                                                                                     │                     │
-                                                                                     ▼                     ▼
-                                             python -m every_query.evaluate.evaluate      EQ_evaluate (legacy, ignores
-                                                          │                                 the PredictionSchema path —
-                                                          ▼                                 runs its own inference loop
-                                                 per-(query, duration_days)                 against the sliced task
-                                                       metrics                              parquets + sibling CLIs)
+    MEDS cohort  ──►  EQ_process_data  ──►  tensorized cohort ($FINAL_DATA_DIR)
+                                                          │
+                                                          ▼
+                                                 EQ_generate_tasks
+                                                          │  TaskQuerySchema parquets
+                                                          ▼
+                                                     EQ_train  ──►  best_model.ckpt
+                                                                            │
+                                              ┌─────────────────────────────┴────────────────────────────┐
+                                              │                                                          │
+                                  New-path (PredictionSchema-based):                  Legacy-path (runs its own inference):
+                                              │                                                          │
+                                              ▼                                                          │
+                                         EQ_predict                                 EQ_gen_eval_index  ──►  EQ_gen_eval_tasks
+                                              │   PredictionSchema parquet                               │
+                                              ▼                                                          ▼
+                              python -m every_query.evaluate.evaluate                     EQ_evaluate  ──►  per-code AUCs
+                                              │                                                          │
+                                              ▼                                                          ▼
+                                   per-(query, duration_days) metrics                          EQ_select_model
 ```
 
-Both evaluator paths ship in this release; the legacy one is what `EQ_evaluate` resolves to today, and the new path is reachable via `python -m`. [#83](https://github.com/payalchandak/EveryQuery/issues/83) tracks the rewire that consolidates to a single `EQ_evaluate` pointing at the new module.
+Both branches ship in this release. The new path is the Phase-2.4 target shape: `EQ_predict` writes a `PredictionSchema` parquet, the new evaluator computes per-`(query, duration_days)` metrics from it. The legacy path is what `EQ_evaluate` resolves to today and runs its own inference loop against the sliced `EQ_gen_eval_tasks` output — it does **not** consume the `PredictionSchema` parquet. [#83](https://github.com/payalchandak/EveryQuery/issues/83) tracks the rewire that retires the legacy branch and points `EQ_evaluate` at the new module.
 
 ### 1. Preprocess
 


### PR DESCRIPTION
The top-level README still described the pre-#96 state: `EQ_predict` "planned", sampler output listing an `occurs` column (collapsed in #96), Phase-2 status table showing open draft PRs that have all merged, legacy-only evaluate section.

Reconciled with what actually ships on dev today.  Specifically:

- Repo layout + console scripts table: drop the "planned" tag from `EQ_predict`; flag the three legacy eval CLIs as such; add a callout for the new `python -m every_query.evaluate.evaluate` path.
- Single current pipeline diagram (both the new-path and the legacy-path branch off `best_model.ckpt`) instead of separate "Current" + "Planned".
- Sampler output: `boolean_value` nullable, no on-disk `occurs`; pointed at `src/every_query/data/schema.py`.
- Workflow sections (4 / 5 / 6): `EQ_predict` → new evaluator → legacy evaluator, so a reader sees today's CLI options in one place.
- Phase 2 status table: marked 2.1 / 2.2 / 2.4 merged with PR links; 2.4 flagged as "new evaluate.py landed, rewire pending".
- E2E testing status: added `test_predict_cli.py` + `test_evaluate_cli.py`; retired the stale "blocked on #99/#100" row.
- Hygiene follow-ups: dropped #122 (closed), added #129 (occurs_prob → label_prob post-NeurIPS).
- Dropped the stale `[#122]:` link reference at the footer.

## Test plan

- [x] `pre-commit run --all-files` — mdformat reformatted then clean.
- [x] README contains no inline `>>>` doctests, so nothing to break; `--doctest-glob=*.md` still passes.
