### PR TITLE
Address @payalchandak review on release PR #131 (round 1)

### DIFF
--- a/src/every_query/data/schema.py
+++ b/src/every_query/data/schema.py
@@ -109,6 +109,12 @@ def empty_task_query_df() -> pl.DataFrame:
     unless we bypassed polars entirely.  Keeping the shape focused on what downstream
     writers actually emit avoids that type-drift landmine.
 
+    Polars dtypes are derived from ``TaskQuerySchema``'s arrow types at call time
+    (``pl.from_arrow`` on an empty arrow table) rather than hardcoded — so any future
+    change to the PyArrow type declarations flows through automatically instead of
+    drifting silently.  ``pa.large_string`` coerces to ``pl.Utf8`` in polars' type
+    system, which is the correct mapping here.
+
     Callers use this at the empty-input fast path (e.g., ``evaluate_index_df`` when no
     tasks were sampled) so the produced parquet still aligns to the schema via
     ``TaskQuerySchema.align`` at the write boundary.
@@ -125,12 +131,12 @@ def empty_task_query_df() -> pl.DataFrame:
         duration_days: Float32
         boolean_value: Boolean
     """
-    return pl.DataFrame(
-        schema={
-            TaskQuerySchema.subject_id_name: pl.Int64,
-            TaskQuerySchema.prediction_time_name: pl.Datetime("us"),
-            TaskQuerySchema.query_name: pl.Utf8,
-            TaskQuerySchema.duration_days_name: pl.Float32,
-            TaskQuerySchema.boolean_value_name: pl.Boolean,
-        }
-    )
+    field_names = [
+        TaskQuerySchema.subject_id_name,
+        TaskQuerySchema.prediction_time_name,
+        TaskQuerySchema.query_name,
+        TaskQuerySchema.duration_days_name,
+        TaskQuerySchema.boolean_value_name,
+    ]
+    pa_fields = [pa.field(name, getattr(TaskQuerySchema, f"{name}_dtype")) for name in field_names]
+    return pl.from_arrow(pa.schema(pa_fields).empty_table())

--- a/src/every_query/predict/README.md
+++ b/src/every_query/predict/README.md
@@ -32,7 +32,7 @@ Key files:
 
 - `predict.py` — `EQ_predict` (inference-only Hydra main).
 - `schema.py` — `PredictionSchema` (`TaskQuerySchema` + `censor_prob` + `occurs_prob`).
-- `configs/predict.yaml` — required: `model_run_dir`, `tasks_dir`, `output_parquet`; optional: `ckpt_name`, `split` (`held_out` | `tuning`).
+- `configs/predict.yaml` — required: `model_run_dir`, `tasks_dir`, `output_parquet`; optional: `ckpt_name`, `split` (`held_out` | `tuning`), `overwrite` (default `false` — refuses to clobber an existing `output_parquet`; pass `overwrite=true` to replace).
 - `external_tasks/` — convert + aggregate tasks outside EQ's native vocabulary (`aces_to_eq.py`, `process_composite.py`, `get_per_code_from_composite.py`).
 
 ## Pipeline position

--- a/src/every_query/predict/configs/predict.yaml
+++ b/src/every_query/predict/configs/predict.yaml
@@ -34,6 +34,11 @@ ckpt_name: null
 # train_dataloader shuffles, which would break the order-preserving hstack.
 split: held_out
 
+# Optional: overwrite ``output_parquet`` if it already exists.  Default false so an
+# existing predictions file is never silently clobbered — re-running against the
+# same output path without this flag raises ``FileExistsError`` at startup.
+overwrite: false
+
 hydra:
   output_subdir: null
   job:

--- a/src/every_query/predict/predict.py
+++ b/src/every_query/predict/predict.py
@@ -131,15 +131,18 @@ def _validate_tasks_dir(tasks_dir: Path) -> None:
         )
 
 
-def _warn_out_of_vocab(task_codes: set[str], train_cfg: DictConfig) -> None:
-    """Warn if any task-query codes are missing from the trained model's vocabulary.
+def _check_vocab(task_codes: set[str], train_cfg: DictConfig) -> None:
+    """Raise if any task-query codes are missing from the trained model's vocabulary.
 
     Out-of-vocab query codes survive the predict loop (``encode_query`` silently falls
-    back to ``PAD_INDEX``) but produce effectively-uniform predictions.  Log a warning
-    at startup so the caller notices rather than silently getting garbage probabilities.
+    back to ``PAD_INDEX``) but produce effectively-uniform (garbage) predictions — so
+    the caller's ``predictions.parquet`` would silently contain rows whose probabilities
+    have no relationship to the model.  Raise at startup rather than write misleading
+    output.  Missing metadata is also a hard error: without the training vocab we can't
+    validate inputs at all.
 
     Examples:
-        Happy path — every task code is present in the training vocab, no warning:
+        Happy path — every task code is present in the training vocab:
 
         >>> import tempfile
         >>> from omegaconf import OmegaConf
@@ -148,36 +151,45 @@ def _warn_out_of_vocab(task_codes: set[str], train_cfg: DictConfig) -> None:
         ...     meta_dir.mkdir()
         ...     pl.DataFrame({"code": ["A", "B", "C"]}).write_parquet(meta_dir / "codes.parquet")
         ...     cfg = OmegaConf.create({"datamodule": {"config": {"tensorized_cohort_dir": tmpdir}}})
-        ...     _warn_out_of_vocab({"A", "B"}, cfg)  # no raise, no logged warning
+        ...     _check_vocab({"A", "B"}, cfg)  # no raise
 
-        Out-of-vocab codes trigger a warning (raised-vs-logged distinction: this is a
-        soft signal, not an error — malformed inputs get visible-but-survivable
-        degradation rather than a hard stop):
+        Out-of-vocab codes raise ``ValueError``:
 
         >>> with tempfile.TemporaryDirectory() as tmpdir:
         ...     meta_dir = Path(tmpdir) / "metadata"
         ...     meta_dir.mkdir()
         ...     pl.DataFrame({"code": ["A"]}).write_parquet(meta_dir / "codes.parquet")
         ...     cfg = OmegaConf.create({"datamodule": {"config": {"tensorized_cohort_dir": tmpdir}}})
-        ...     _warn_out_of_vocab({"A", "MISSING"}, cfg)  # logs warning, no raise
+        ...     try:
+        ...         _check_vocab({"A", "MISSING"}, cfg)
+        ...     except ValueError as e:
+        ...         print(str(e).split(".  ")[0])
+        1 of 2 task-query codes are not in the model's training vocabulary
 
-        Missing metadata file also warns rather than erroring — predict should still
-        be able to run against a training dir that happens to lack the metadata:
+        Missing metadata file also raises — we can't run inference without being
+        able to confirm the inputs match the model's training vocab:
 
         >>> with tempfile.TemporaryDirectory() as tmpdir:
         ...     cfg = OmegaConf.create({"datamodule": {"config": {"tensorized_cohort_dir": tmpdir}}})
-        ...     _warn_out_of_vocab({"A"}, cfg)  # logs warning, no raise
+        ...     try:
+        ...         _check_vocab({"A"}, cfg)
+        ...     except FileNotFoundError as e:
+        ...         print("FileNotFoundError")
+        FileNotFoundError
     """
     metadata_fp = Path(train_cfg.datamodule.config.tensorized_cohort_dir) / "metadata" / "codes.parquet"
     if not metadata_fp.is_file():
-        logger.warning(f"Cannot resolve training vocabulary — no codes metadata at {metadata_fp}")
-        return
+        raise FileNotFoundError(
+            f"Cannot resolve training vocabulary — no codes metadata at {metadata_fp}.  "
+            f"EQ_predict needs this to validate task codes against the model's vocab."
+        )
     training_vocab = set(pl.read_parquet(metadata_fp, columns=["code"])["code"].to_list())
     missing = task_codes - training_vocab
     if missing:
-        logger.warning(
+        raise ValueError(
             f"{len(missing)} of {len(task_codes)} task-query codes are not in the model's training "
-            f"vocabulary and will be PAD-encoded (predictions will be near-uniform for these rows): "
+            f"vocabulary.  Out-of-vocab codes would be PAD-encoded and produce near-uniform "
+            f"probabilities; refuse rather than write misleading predictions.  Missing codes: "
             f"{sorted(missing)[:10]}{'...' if len(missing) > 10 else ''}"
         )
 
@@ -257,12 +269,19 @@ def main(cfg: DictConfig) -> None:
     output_parquet = Path(cfg.output_parquet)
     ckpt_name = cfg.get("ckpt_name")
     split = cfg.get("split", held_out_split)
+    overwrite = bool(cfg.get("overwrite", False))
 
     if split not in _SPLIT_TO_DATAMODULE_ATTRS:
         raise ValueError(
             f"split must be one of {sorted(_SPLIT_TO_DATAMODULE_ATTRS)}, got {split!r}.  "
             f"The 'train' split is disallowed because MTD's train_dataloader shuffles, "
             f"which would break the order-preserving hstack."
+        )
+
+    if output_parquet.exists() and not overwrite:
+        raise FileExistsError(
+            f"output_parquet {output_parquet} already exists.  Pass overwrite=true to replace, "
+            f"or point at a new path — EQ_predict refuses to silently clobber existing output."
         )
 
     _validate_tasks_dir(tasks_dir)
@@ -276,13 +295,26 @@ def main(cfg: DictConfig) -> None:
     dataset = getattr(D, dataset_attr)
     dataloader = getattr(D, dataloader_attr)()
 
-    _warn_out_of_vocab(set(dataset.query.unique().to_list()), train_cfg)
+    # Enforce order-preserving iteration — the ``hstack`` below assumes the dataloader
+    # yields rows in ``schema_df`` order.  MTD's val/test dataloaders use
+    # ``SequentialSampler`` by default, but asserting here turns a silent correctness
+    # bug (shuffled probs stitched to the wrong identifiers) into a loud startup error
+    # if that ever changes.
+    sampler = getattr(dataloader, "sampler", None)
+    sampler_cls = type(sampler).__name__ if sampler is not None else None
+    if sampler_cls != "SequentialSampler":
+        raise RuntimeError(
+            f"{dataloader_attr} must use SequentialSampler to preserve row order for the "
+            f"predictions hstack; got {sampler_cls!r}.  Re-check the MTD datamodule config."
+        )
+
+    _check_vocab(set(dataset.query.unique().to_list()), train_cfg)
     logger.info(f"Loaded {len(dataset)} tasks across {dataset.query.n_unique()} query codes")
 
     # Pass the split's dataloader directly — MTD's ``Datamodule`` has no
     # ``predict_dataloader``, so ``trainer.predict(datamodule=D)`` would hit the base
-    # class's ``MisconfigurationException``.  ``val_dataloader`` / ``test_dataloader``
-    # both use ``shuffle=False``.
+    # class's ``MisconfigurationException``.  The SequentialSampler check above
+    # guarantees order preservation.
     pred_batches = trainer.predict(model=model, dataloaders=dataloader, ckpt_path=None)
 
     probs = _gather_probabilities(pred_batches)

--- a/src/every_query/predict/schema.py
+++ b/src/every_query/predict/schema.py
@@ -22,7 +22,8 @@ class PredictionSchema(TaskQuerySchema):
 
     Inherits every column from :class:`every_query.data.schema.TaskQuerySchema` —
     ``subject_id``, ``prediction_time``, ``query``, ``duration_days``, plus the inherited
-    optional label columns (``boolean_value`` nullable, per ``LabelSchema``).  Adds:
+    optional label columns (``boolean_value`` nullable, per ``TaskQuerySchema``'s
+    override — ``LabelSchema`` itself declares it non-nullable).  Adds:
 
     Attributes:
         censor_prob: Model-reported probability that the row is censored (observation

--- a/src/every_query/utils/_env.py
+++ b/src/every_query/utils/_env.py
@@ -16,12 +16,16 @@ REQUIRED_ENV_VARS = (
     "FINAL_DATA_DIR",
     "WANDB_ENTITY",
 )
-# `PROCESSED` and `INTERMEDIATE` used to live here too but no Hydra config
-# interpolates `${oc.env:PROCESSED}` or `${oc.env:INTERMEDIATE}`.  Their only use is a
-# dotenv fallback inside `sample_tasks.py::_resolve_path`, which already tolerates
-# missing env vars when config values are supplied (the normal CLI path).  Keeping
-# them in the gate was pure friction: demo fixtures / `--help` invocations had to
-# set throwaway placeholder values for no actual resolution.  See #117.
+# `PROCESSED` and `INTERMEDIATE` are used by the preprocessing pipeline (the dirs it
+# writes to) and by the generate_tasks stage as dotenv fallbacks inside
+# `sample_tasks.py::_resolve_path` / `sample_evaluation_tasks.py::_resolve_path`.
+# They're not gated by this `REQUIRED_ENV_VARS` check because:
+#   1. `_resolve_path` already tolerates a missing env var when the caller supplies the
+#      path directly (the normal CLI / test path).
+#   2. No Hydra config interpolates `${oc.env:PROCESSED}` or `${oc.env:INTERMEDIATE}`,
+#      so demo fixtures / `--help` invocations don't need throwaway placeholders.
+# If you're running a full fresh-machine setup that includes preprocessing, set both
+# in `.env` (see `.env.example`).  See #117 for the history.
 
 
 def ensure_env() -> None:

--- a/tests/test_predict_cli.py
+++ b/tests/test_predict_cli.py
@@ -31,9 +31,12 @@ _VENV_BIN = str(Path(sys.executable).parent)
 # Subject lives in the ``held_out`` split of the ``simple_static_sharded_by_split``
 # testing dataset used by ``eq_preprocessed_dataset``.  Prediction time falls inside
 # 1500733's event sequence (2010-06-03).
+# Query codes must exist in the model's training vocab — ``EQ_predict`` now hard-errors
+# on out-of-vocab codes (was: warn).  These are real codes in the
+# ``simple_static_sharded_by_split`` testing dataset's vocab after preprocessing.
 _HELD_OUT_SUBJECT = 1500733
 _PRED_TIME = datetime(2010, 6, 3, 15, 0, 0)
-_QUERY_CODES = ["HR", "TEMP"]
+_QUERY_CODES = ["DISCHARGE", "DOB"]
 _DURATION_DAYS = 30.0
 
 
@@ -126,7 +129,7 @@ def test_eq_predict_preserves_input_row_order(
     """
     # Non-alphabetical query order, mixed durations — exercises the order check past
     # the alphabetical HR/TEMP happy path of the main integration test.
-    expected_queries = ["TEMP", "HR", "TEMP"]
+    expected_queries = ["DOB", "DISCHARGE", "DOB"]
     expected_durations = [60.0, 30.0, 30.0]
 
     tasks_dir = tmp_path / "tasks"


### PR DESCRIPTION
## Summary

Addresses 6 of 12 review threads on the release PR (#131) in code; the other 6 get replies on the original PR (defer / explain / question-for-owner).

### Thread-by-thread

| # | Path | Action |
|---|------|--------|
| 1 | `data/schema.py:128` | **Fix** — derive polars dtypes from `TaskQuerySchema.{col}_dtype` via `pl.from_arrow(pa.schema(...).empty_table())`, single source of truth |
| 2 | `data/dataset.py:33` | **Reply** — explain `c6018ec` (batch.subject_id/prediction_time were only used by the old predict_step output dict; new EQ_predict uses `schema_df` indexing) |
| 3 | `predict/schema.py:25` | **Fix** — docstring nit (`boolean_value` is nullable per `TaskQuerySchema`'s override, not `LabelSchema`) |
| 4 | `predict/predict.py:134` | **Fix** — `_warn_out_of_vocab` → `_check_vocab`; raises `ValueError` / `FileNotFoundError` instead of warning. Caught a real test bug: query codes `HR`/`TEMP` weren't in the simple_static_MEDS vocab (vocab has `HR//value_[...]` bucket codes); swapped to `DISCHARGE`/`DOB` |
| 5 | `predict/predict.py:185` | **Defer** — agreed, but needs a PA→PL helper; follow-up PR |
| 6 | `generate_tasks/README.md` rename | **Defer** — agreed on the inconsistency; module + config rename churns ~10 files, separate PR |
| 7 | `sample_evaluation_tasks.py:54` | **Reply** — @gkondas design question, ack only |
| 8 | `sample_evaluation_tasks.py` grid | **Defer** — file a follow-up issue for explicit `(code, duration)` tuples |
| 9 | `predict/README.md` overwrite | **Fix** — add `overwrite: false` config knob; `EQ_predict` raises `FileExistsError` on existing output unless `overwrite=true` |
| 10 | `utils/_env.py:25` | **Fix** — comment correction; `PROCESSED`/`INTERMEDIATE` ARE used by preprocessing + generate_tasks, just not gated by `REQUIRED_ENV_VARS` |
| 11 | `model/lightning_module.py:295` | **Fix** — runtime assertion that `dataloader.sampler` is `SequentialSampler`; turns the silent "MTD contract changed → predictions stitched to wrong rows" failure into a loud startup error |
| 12 | `preprocessing/__init__.py` | **Reply** — question for @mmcdermott, not my answer |

### Behavior changes callers should notice

- `EQ_predict` now **raises** on out-of-vocab query codes (was: warn + produce near-uniform predictions).
- `EQ_predict` now **raises** `FileExistsError` if `output_parquet` already exists; pass `overwrite=true` to replace.
- `EQ_predict` now **asserts** the dataloader sampler at startup (no behavior change for the in-tree val/test dataloaders, but guards against future MTD changes).

### Test plan

- [x] `pre-commit run --all-files` — clean
- [x] `pytest` (fast) — 158 passed, 1 deselected (slow training-validity)
- [x] Doctest updated for `_check_vocab`
- [ ] CI green

Base is `dev` so this flows into the open release #131 merge-path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)