### PR TITLE
feat(deps): upgrade meds-torch-data to 0.9

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,15 +19,15 @@ classifiers = [
     "Operating System :: OS Independent",
 ]
 dependencies = [
-  "polars~=1.30.0",
+  "polars>=1.35,<2",
   "pyarrow==21.0.0",
   "hydra-core==1.3.2",
   "numpy==2.3.3",
   "meds==0.4.0",
   "filelock==3.19.1",
   "pytest==8.4.2",
-  "meds-transforms==0.5.3",
-  "meds-torch-data[lightning]~=0.7.0",
+  "meds-transforms>=0.6.7,<0.7",
+  "meds-torch-data[lightning]~=0.9.0",
   "transformers>=4.48.0",
   "torch==2.8.0",
   "torchmetrics==1.8.2",

--- a/src/every_query/data/dataset.py
+++ b/src/every_query/data/dataset.py
@@ -269,12 +269,17 @@ class QueryData(NamedTuple):
 
 
 class EveryQueryPytorchDataset(MEDSPytorchDataset):
+    EXTRA_LABEL_COLS: ClassVar[tuple[str, ...]] = ("occurs", "query", "duration_days")
+
     @classmethod
     def get_task_seq_bounds_and_labels(cls, label_df: pl.DataFrame, schema_df: pl.DataFrame) -> pl.DataFrame:
         """Returns the event-level allowed input sequence boundaries and labels for each task sample.
 
-        This function is guaranteed to output an index of the same order and length as `label_df`. Subjects
-        not present in `schema_df` will be included in the output, with null labels and indices.
+        Delegates to the upstream implementation (memory-efficient `join_asof`-based) and then
+        hstacks EveryQuery's task-specific annotation columns (`occurs`, `query`, `duration_days`)
+        onto the result. Alignment relies on the upstream guarantee that surviving rows are
+        returned in `label_df` input order; we semi-filter `label_df` to the same surviving
+        subject set so row `i` of `base` corresponds to row `i` of `surviving`.
 
         Args:
             label_df: The DataFrame containing the task labels, in the MEDS Label DF schema.
@@ -282,44 +287,18 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
 
         Returns:
             A copy of the labels DataFrame, restricted to included subjects, with the appropriate end indices
-            for each task sample. Labels will be present if the `cls.LABEL_COL` is present in the input.
+            for each task sample. Labels will be present if the `cls.LABEL_COL` is present in the input,
+            along with any EveryQuery annotation columns present in `label_df`.
         """
-
-        end_idx_expr = (
-            pl.col(DataSchema.time_name)
-            .search_sorted(pl.col(LabelSchema.prediction_time_name), side="right")
-            .last()
-            .alias(cls.END_IDX)
-        )
-
-        group_cols = ["_row", DataSchema.subject_id_name, LabelSchema.prediction_time_name]
-        out_cols = [DataSchema.subject_id_name, cls.END_IDX, LabelSchema.prediction_time_name]
-
-        label_names = label_df.collect_schema().names()
-
-        if cls.LABEL_COL in label_names:
-            group_cols.append(cls.LABEL_COL)
-            out_cols.append(cls.LABEL_COL)
-
-        # Include pass-through task annotations if present
-        if "occurs" in label_names:
-            group_cols.append("occurs")
-            out_cols.append("occurs")
-        if "query" in label_names:
-            group_cols.append("query")
-            out_cols.append("query")
-        if "duration_days" in label_names:
-            group_cols.append("duration_days")
-            out_cols.append("duration_days")
-
-        return (
-            label_df.join(schema_df, on=DataSchema.subject_id_name, how="inner", maintain_order="left")
-            .with_row_index("_row")
-            .explode(DataSchema.time_name)
-            .group_by(group_cols, maintain_order=True)
-            .agg(end_idx_expr)
-            .select(out_cols)
-        )
+        base = super().get_task_seq_bounds_and_labels(label_df, schema_df)
+        extras = [c for c in cls.EXTRA_LABEL_COLS if c in label_df.collect_schema().names()]
+        if not extras:
+            return base
+        sid = DataSchema.subject_id_name
+        # Upstream guarantees input-order preservation for surviving rows (inner-join on subject_id).
+        # hstack-align the extras by semi-filtering label_df to the same surviving row set.
+        surviving = label_df.join(schema_df.lazy().select(sid).unique().collect(), on=sid, how="semi")
+        return base.hstack(surviving.select(extras))
 
     def __init__(self, cfg: MEDSTorchDataConfig, split: str):
         super().__init__(cfg, split)

--- a/src/every_query/preprocessing/__main__.py
+++ b/src/every_query/preprocessing/__main__.py
@@ -53,7 +53,7 @@ def main(cfg: DictConfig):
 
         pipeline_config_fp = (CONFIGS / "_reshard_data.yaml") if cfg.do_reshard else (CONFIGS / "_data.yaml")
         _run_stage(
-            ["MEDS_transform-pipeline", f"pipeline_config_fp={pipeline_config_fp!s}"],
+            ["MEDS_transform-pipeline", str(pipeline_config_fp)],
             env=env,
         )
 

--- a/tests/test_task_seq_bounds.py
+++ b/tests/test_task_seq_bounds.py
@@ -1,0 +1,108 @@
+"""Unit tests for ``EveryQueryPytorchDataset.get_task_seq_bounds_and_labels``.
+
+Guards against silent misalignment between the upstream-computed end indices
+and the EveryQuery-specific annotation columns (``occurs``, ``query``,
+``duration_days``) that the subclass hstacks onto the result.
+"""
+
+from datetime import datetime
+
+import polars as pl
+from meds import DataSchema, LabelSchema
+
+from every_query.data.dataset import EveryQueryPytorchDataset
+
+
+def _schema_df() -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            DataSchema.subject_id_name: [1, 2, 3],
+            DataSchema.time_name: [
+                [datetime(2020, 1, 1), datetime(2020, 1, 2), datetime(2020, 1, 3)],
+                [datetime(2020, 1, 1), datetime(2020, 1, 5)],
+                [datetime(2020, 1, 10)],
+            ],
+        }
+    )
+
+
+class TestExtraColumnAlignment:
+    def test_extras_align_to_original_label_rows(self):
+        label_df = pl.DataFrame(
+            {
+                DataSchema.subject_id_name: [1, 1, 2, 3, 99],
+                LabelSchema.prediction_time_name: [
+                    datetime(2020, 1, 2),
+                    datetime(2020, 1, 3),
+                    datetime(2020, 1, 5),
+                    datetime(2020, 1, 10),
+                    datetime(2020, 1, 1),
+                ],
+                "boolean_value": [True, False, True, False, True],
+                "occurs": [10, 20, 30, 40, 50],
+                "query": [101, 102, 103, 104, 105],
+                "duration_days": [1.0, 2.0, 3.0, 4.0, 5.0],
+            }
+        )
+
+        result = EveryQueryPytorchDataset.get_task_seq_bounds_and_labels(label_df, _schema_df())
+
+        # Subject 99 is absent from schema_df → inner-join semantics drop it.
+        assert result.height == 4
+        assert set(result.columns) >= {
+            DataSchema.subject_id_name,
+            LabelSchema.prediction_time_name,
+            EveryQueryPytorchDataset.END_IDX,
+            "boolean_value",
+            "occurs",
+            "query",
+            "duration_days",
+        }
+
+        # For each surviving row, the extras must match the row in label_df with the
+        # same (subject_id, prediction_time).
+        label_lookup = {
+            (row[DataSchema.subject_id_name], row[LabelSchema.prediction_time_name]): row
+            for row in label_df.iter_rows(named=True)
+        }
+        for out_row in result.iter_rows(named=True):
+            key = (out_row[DataSchema.subject_id_name], out_row[LabelSchema.prediction_time_name])
+            expected = label_lookup[key]
+            assert out_row["occurs"] == expected["occurs"]
+            assert out_row["query"] == expected["query"]
+            assert out_row["duration_days"] == expected["duration_days"]
+            assert out_row["boolean_value"] == expected["boolean_value"]
+
+    def test_no_extras_passes_through(self):
+        label_df = pl.DataFrame(
+            {
+                DataSchema.subject_id_name: [1, 2],
+                LabelSchema.prediction_time_name: [datetime(2020, 1, 2), datetime(2020, 1, 5)],
+                "boolean_value": [True, False],
+            }
+        )
+
+        result = EveryQueryPytorchDataset.get_task_seq_bounds_and_labels(label_df, _schema_df())
+
+        assert result.height == 2
+        assert "occurs" not in result.columns
+        assert "query" not in result.columns
+        assert "duration_days" not in result.columns
+
+    def test_partial_extras(self):
+        label_df = pl.DataFrame(
+            {
+                DataSchema.subject_id_name: [1, 2],
+                LabelSchema.prediction_time_name: [datetime(2020, 1, 2), datetime(2020, 1, 5)],
+                "boolean_value": [True, False],
+                "query": [7, 8],
+            }
+        )
+
+        result = EveryQueryPytorchDataset.get_task_seq_bounds_and_labels(label_df, _schema_df())
+
+        assert "query" in result.columns
+        assert "occurs" not in result.columns
+        assert "duration_days" not in result.columns
+        by_sid = {r[DataSchema.subject_id_name]: r["query"] for r in result.iter_rows(named=True)}
+        assert by_sid == {1: 7, 2: 8}

--- a/uv.lock
+++ b/uv.lock
@@ -509,10 +509,10 @@ requires-dist = [
     { name = "ipykernel", specifier = ">=7.2.0" },
     { name = "lightning", specifier = "==2.5.5" },
     { name = "meds", specifier = "==0.4.0" },
-    { name = "meds-torch-data", extras = ["lightning"], specifier = "~=0.7.0" },
-    { name = "meds-transforms", specifier = "==0.5.3" },
+    { name = "meds-torch-data", extras = ["lightning"], specifier = "~=0.9.0" },
+    { name = "meds-transforms", specifier = ">=0.6.7,<0.7" },
     { name = "numpy", specifier = "==2.3.3" },
-    { name = "polars", specifier = "~=1.30.0" },
+    { name = "polars", specifier = ">=1.35,<2" },
     { name = "pyarrow", specifier = "==21.0.0" },
     { name = "pytest", specifier = "==8.4.2" },
     { name = "scikit-learn", specifier = ">=1.6.0" },
@@ -1033,7 +1033,7 @@ wheels = [
 
 [[package]]
 name = "meds-torch-data"
-version = "0.7.0"
+version = "0.9.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "hydra-core" },
@@ -1046,10 +1046,11 @@ dependencies = [
     { name = "polars" },
     { name = "pytest" },
     { name = "torch" },
+    { name = "yaml-to-disk", extra = ["parquet"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/0d/52/83c74bd33fa30e1d825c927443f955d11d1cbe21becd5a3776ef8cc3a2e1/meds_torch_data-0.7.0.tar.gz", hash = "sha256:a69690fe9fe808cdc35fc25535972546cb403bdf9eb12f7e83f71029c9900442", size = 258165, upload-time = "2026-04-16T12:51:42.237Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/6c/a72f955423bc529c2be3417c0e9957ecc9c3e5b1d74e09a158a63c97c2f1/meds_torch_data-0.9.0.tar.gz", hash = "sha256:25a64087546aa833f8e78223f9bc4955409f9e2761ffa69360784abfa8f24dd7", size = 274552, upload-time = "2026-04-21T01:30:34.708Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/63/b3/18e73362053923a587f800edc1bcc9191bd64b25ddba8e9f6bf0a0598962/meds_torch_data-0.7.0-py3-none-any.whl", hash = "sha256:9a0ef17fa7ab66088bdcb136875ee755878c3b96e392b6099923a44a4f82f643", size = 70882, upload-time = "2026-04-16T12:51:40.551Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/e8/8e2c0f41a6c615f0938300fbe930974dee514711200c35d9b3f6977372c3/meds_torch_data-0.9.0-py3-none-any.whl", hash = "sha256:3b9506eca150931da8b8a706a5e6a059f074caa639c7a58585396749088353ec", size = 92346, upload-time = "2026-04-21T01:30:32.91Z" },
 ]
 
 [package.optional-dependencies]
@@ -1059,7 +1060,7 @@ lightning = [
 
 [[package]]
 name = "meds-transforms"
-version = "0.5.3"
+version = "0.6.7"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "filelock" },
@@ -1071,10 +1072,11 @@ dependencies = [
     { name = "pretty-print-directory" },
     { name = "pyarrow" },
     { name = "pytest" },
+    { name = "yaml-to-disk" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/77/52/e9bc9ece29db1d9bd0b7a9c3d581557b529cad0ebabbc55bb1a1365ae9db/meds_transforms-0.5.3.tar.gz", hash = "sha256:832f607b60ae81f919beee6b200e4cb7259781f08536766853ef06fe55948ed6", size = 332567, upload-time = "2025-06-06T20:08:03.304Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b4/19/407efdafc8adbb8385495579934d88fdf8c5c8373fc2e76026fe0b54e26d/meds_transforms-0.6.7.tar.gz", hash = "sha256:8c957a5743d7e53b2262d3898356feb7c2ebcb3236b5b10156ef5c44c2774149", size = 589647, upload-time = "2026-04-18T14:45:25.291Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/01/7522f825fd26e82fbc394be44718a16925d6983ca8481a08bbf74f8c67fd/meds_transforms-0.5.3-py3-none-any.whl", hash = "sha256:bb8e4cb65470d669de99bea813c64ec9c46d3b8b749fd0445f0261da46f2912d", size = 200632, upload-time = "2025-06-06T20:08:01.669Z" },
+    { url = "https://files.pythonhosted.org/packages/40/19/55d217de368c7fb643f89f7ef312092740c24c189f75ec28d7c68b0b1dbd/meds_transforms-0.6.7-py3-none-any.whl", hash = "sha256:ce4b458f9e26e31a3e1fe7000769bb7be5b3bf58c3ba0da071d639a6a4a013c0", size = 219935, upload-time = "2026-04-18T14:45:23.714Z" },
 ]
 
 [[package]]
@@ -1178,15 +1180,15 @@ wheels = [
 
 [[package]]
 name = "nested-ragged-tensors"
-version = "0.1"
+version = "0.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
     { name = "safetensors" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/36/b5/6910630f2756934657401f5588d78b91afddbe3a5d0af1319866596e1bbe/nested_ragged_tensors-0.1.tar.gz", hash = "sha256:991f8da5fbabca3986b3c6b70007944116bb189ddd5cb8c3de5a3e218093e615", size = 24261159, upload-time = "2024-11-07T21:23:09.309Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/8f/d93d1380cbfa89f0c6406636080a8dfc271a374c9aaf82b4e31611bd108e/nested_ragged_tensors-0.3.0.tar.gz", hash = "sha256:eeb0db59981d5bcc67ac1a16231593ef9ac267b5bc64ca311fab7460c7d7eca2", size = 24365067, upload-time = "2026-04-20T21:22:38.229Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/67/9d/08c3dd6db4d22a84a42f8cceb6289a70d49183a2d14635ce4dafa237d07b/nested_ragged_tensors-0.1-py3-none-any.whl", hash = "sha256:c7a22a43cdc53172c7608fa64f50e21fb628cff73866702dfc27ad05e1a3c40c", size = 18270, upload-time = "2024-11-07T21:23:06.943Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/5a/e1a90df81cd3ff9440891e8f8ffad29838725fe791c772295e255f25100b/nested_ragged_tensors-0.3.0-py3-none-any.whl", hash = "sha256:0cb2d1dc23fcd9b04c9258625427eb00d1ef0d6d168255814a2e29d28f87aca7", size = 28473, upload-time = "2026-04-20T21:22:35.516Z" },
 ]
 
 [[package]]
@@ -1477,16 +1479,30 @@ wheels = [
 
 [[package]]
 name = "polars"
-version = "1.30.0"
+version = "1.40.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/b6/8dbdf626c0705a57f052708c9fc0860ffc2aa97955930d5faaf6a66fcfd3/polars-1.30.0.tar.gz", hash = "sha256:dfe94ae84a5efd9ba74e616e3e125b24ca155494a931890a8f17480737c4db45", size = 4668318, upload-time = "2025-05-21T13:33:24.175Z" }
+dependencies = [
+    { name = "polars-runtime-32" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d9/1b/eea7d6fe6daafc1d784cc0f76c729b28051837ccb2d51ae64a0a3f798142/polars-1.40.0.tar.gz", hash = "sha256:711dd50dcbc35ba42a2625fcadc2a1349e2e9abf48e35631bdabafb90d89874b", size = 732943, upload-time = "2026-04-18T05:25:26.077Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/40/48/e9b2cb379abcc9f7aff2e701098fcdb9fe6d85dc4ad4cec7b35d39c70951/polars-1.30.0-cp39-abi3-macosx_10_12_x86_64.whl", hash = "sha256:4c33bc97c29b7112f0e689a2f8a33143973a3ff466c70b25c7fd1880225de6dd", size = 35704342, upload-time = "2025-05-21T13:32:22.996Z" },
-    { url = "https://files.pythonhosted.org/packages/36/ca/f545f61282f75eea4dfde4db2944963dcd59abd50c20e33a1c894da44dad/polars-1.30.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:e3d05914c364b8e39a5b10dcf97e84d76e516b3b1693880bf189a93aab3ca00d", size = 32459857, upload-time = "2025-05-21T13:32:27.728Z" },
-    { url = "https://files.pythonhosted.org/packages/76/20/e018cd87d7cb6f8684355f31f4e193222455a6e8f7b942f4a2934f5969c7/polars-1.30.0-cp39-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1a52af3862082b868c1febeae650af8ae8a2105d2cb28f0449179a7b44f54ccf", size = 36267243, upload-time = "2025-05-21T13:32:31.796Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/e7/b88b973021be07b13d91b9301cc14392c994225ef5107a32a8ffd3fd6424/polars-1.30.0-cp39-abi3-manylinux_2_24_aarch64.whl", hash = "sha256:ffb3ef133454275d4254442257c5f71dd6e393ce365c97997dadeb6fa9d6d4b5", size = 33416871, upload-time = "2025-05-21T13:32:35.077Z" },
-    { url = "https://files.pythonhosted.org/packages/dd/7c/d46d4381adeac537b8520b653dc30cb8b7edbf59883d71fbb989e9005de1/polars-1.30.0-cp39-abi3-win_amd64.whl", hash = "sha256:c26b633a9bd530c5fc09d317fca3bb3e16c772bd7df7549a9d8ec1934773cc5d", size = 36363630, upload-time = "2025-05-21T13:32:38.286Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/b5/5056d0c12aadb57390d0627492bef8b1abf3549474abb9ae0fd4e2bfa885/polars-1.30.0-cp39-abi3-win_arm64.whl", hash = "sha256:476f1bde65bc7b4d9f80af370645c2981b5798d67c151055e58534e89e96f2a8", size = 32643590, upload-time = "2025-05-21T13:32:42.107Z" },
+    { url = "https://files.pythonhosted.org/packages/b4/ad/d5ed79269b7fe59a3dbbfbdbecbe1e59a0b56e38d36491e57d2bfb5846c1/polars-1.40.0-py3-none-any.whl", hash = "sha256:60b1d677ca363e2fc6fdea8c3d16c0653fd52cc37f0249e0f29d9536d5aa45ef", size = 828012, upload-time = "2026-04-18T05:23:39.055Z" },
+]
+
+[[package]]
+name = "polars-runtime-32"
+version = "1.40.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fb/b2/eae6c1b3d16c7a64ff382f557985ff939cce13455e8c9d056ab8e1e0fc87/polars_runtime_32-1.40.0.tar.gz", hash = "sha256:e31bff8bd37492c714e155e2e1429ac2d9ddf2dd6ec6474cc1cc70ac0b2bd6af", size = 2935285, upload-time = "2026-04-18T05:25:28.038Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b0/e4/2325689d2af4f9e70699ff98e8a2543707bebc34af78a5fe0e654107d9ed/polars_runtime_32-1.40.0-cp310-abi3-macosx_10_12_x86_64.whl", hash = "sha256:cab3ac7ff5bc9e0f4b3b146015569e9417cf0eaff8d3fb71004d73d67b6f09c7", size = 52092528, upload-time = "2026-04-18T05:23:42.341Z" },
+    { url = "https://files.pythonhosted.org/packages/19/a6/82157b19c5c40b2c1ed0493b87b9eaf9b4863cdedca5575ee083488b45ba/polars_runtime_32-1.40.0-cp310-abi3-macosx_11_0_arm64.whl", hash = "sha256:d29624c75c4049253300786d00882fce620b3677ce495ebc4199292de8c2ba02", size = 46365073, upload-time = "2026-04-18T05:23:46.7Z" },
+    { url = "https://files.pythonhosted.org/packages/85/b5/5c4f1f2545f56c664cc57bbdd1aa66fcfcb129aa137ed72cc81d58eb480f/polars_runtime_32-1.40.0-cp310-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:a034dc0d8481fc1ca0456ab33e98e53a4c6d6cc6a2edb36246cc81c936b925dc", size = 50250561, upload-time = "2026-04-18T05:23:51.316Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/51/cb5eb75394f39c0ec14fddcc9b11adb707e1f28224a552ecbfa72d39b61b/polars_runtime_32-1.40.0-cp310-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:70e78c2f13a54a9d92ae30d2625bda759173cc4867ad6a39f85f140058d899c6", size = 56243695, upload-time = "2026-04-18T05:23:55.932Z" },
+    { url = "https://files.pythonhosted.org/packages/16/3a/be1437c0fbecbb07d81b151456089c3cf054eea5a791f849ed39b67611ca/polars_runtime_32-1.40.0-cp310-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1843272c0ef49f4a07435888f0059eca08ec16ab9880219c457195a081df0281", size = 50427843, upload-time = "2026-04-18T05:24:00.159Z" },
+    { url = "https://files.pythonhosted.org/packages/be/c7/ea6449a2161816a13ed1d8aa02177d5a0594e011f0df5ddd2fad8e5bf20e/polars_runtime_32-1.40.0-cp310-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:081237dba07f15d61fc151825f203165480e9503ebe72a474a8c99aa78021962", size = 54153077, upload-time = "2026-04-18T05:24:05.066Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/1a/0b239138afe8b80a1a0b4c95db3884e6afbbe82ec3318918ab03bc57f231/polars_runtime_32-1.40.0-cp310-abi3-win_amd64.whl", hash = "sha256:a916040e0b7f461ce987e4551fed9eea5914b4fbb5af907b1d9e80db71fadeb5", size = 51822748, upload-time = "2026-04-18T05:24:09.384Z" },
+    { url = "https://files.pythonhosted.org/packages/06/ce/c16ef8fd3030b7342032b040fab21a42f6fee57e47ee7f41e2f1a1e36f01/polars_runtime_32-1.40.0-cp310-abi3-win_arm64.whl", hash = "sha256:719c64eecde24a95aa3599eb9c8efc98c1499bab7ef9c01cbbe8939cd583e654", size = 45819617, upload-time = "2026-04-18T05:24:13.214Z" },
 ]
 
 [[package]]
@@ -2719,6 +2735,11 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/f5/f0/fc5fb39b2800b639e927d847fecc23bc120170d2593d248aca89ab94d512/yaml_to_disk-0.0.4.tar.gz", hash = "sha256:58c707afdc65b2398a4a0a3564f1bc44be8a906e9cb6eb9a588a465413964426", size = 22763, upload-time = "2026-04-10T23:02:13.157Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/df/f9/a593dcac68bd8769dc65025562ec88a6b92e7d65cc8f6c275bfc46c58d47/yaml_to_disk-0.0.4-py3-none-any.whl", hash = "sha256:0dc5a541327733c605067bfabe9da51239837243ef213a97b82da1ac8d16fbd2", size = 19751, upload-time = "2026-04-10T23:02:11.984Z" },
+]
+
+[package.optional-dependencies]
+parquet = [
+    { name = "pyarrow" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Two commits, conceptually coupled:

1. **Bump** `meds-torch-data` `0.7.0` → `0.9.0`, with forced transitive upgrades: `meds-transforms` → `0.6.7`, `polars` → `1.35+`, `nested-ragged-tensors` → `0.3.0`. Adapt to the new `MEDS_transform-pipeline` CLI in `MEDS_transforms` 0.6.x (switched from Hydra `key=value` to argparse; `pipeline_config_fp` is now positional).
2. **Adopt** the memory-efficient upstream `get_task_seq_bounds_and_labels` (new in MTD 0.8.1, first available to us via this bump). Previously our override reimplemented the old O(labels × events) explode-based logic; now we delegate to `super()` and `hstack` EveryQuery's pass-through annotations (`occurs`, `query`, `duration_days`) onto the surviving rows. Behavior-equivalent (both use inner-join, both drop missing subjects) but memory-safe on skewed cohorts.

## Context

Supersedes stale commits on `tokenization-sweep` (215 commits behind `main`; the file paths that branch edited no longer exist after the main refactor, so a rebase/merge is not viable):
- `31d8431` "upgraded to new meds-torch-data" → redone in commit 1 of this PR
- `71e34fa` "using meds-torch-data's get_task_seq_bounds_and_labels() directly" → ported in commit 2 of this PR, with import path adjusted for `every_query.data.dataset`

## Test plan

- [x] `uv sync --locked --group dev` resolves cleanly
- [x] `uv run pytest --ignore=docs` → **161 passed, 0 failed** (158 existing + 3 new alignment tests in `tests/test_task_seq_bounds.py`)
- [x] `MEDS_transforms.configs.utils.OmegaConfResolver` still imports (only direct `MEDS_transforms` usage in the repo, `src/every_query/train/train.py:14`)
- [x] Existing alignment guard `tests/test_predict_cli.py::test_eq_predict_preserves_input_row_order` still green — confirms the hstack alignment holds on real multi-query/duration predict data
- [ ] End-to-end sanity check on the cluster (MTD 0.9 now defaults `persistent_workers=True` when `num_workers > 0` — worth a spot-check on a real training run)

🤖 Generated with [Claude Code](https://claude.com/claude-code)