### PR TITLE
Remove train-code manual selection from training config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,12 +181,6 @@ cython_debug/
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 #.idea/
 
-src/every_query/evaluate/conf/eval_codes/
-src/every_query/predict/external_tasks/query_codes/
-
-# Generated train code YAMLs
-src/every_query/train_codes/
-
 src/every_query/evaluate/outputs/
 
 # AI

--- a/README.md
+++ b/README.md
@@ -211,21 +211,6 @@ env vars when CLI config values are supplied).
 gated vars to `${oc.env:VAR,???}` / `${oc.env:VAR,default}` form (Hydra-native required
 or optional-with-fallback) and eventually retire `ensure_env()` entirely.
 
-### Known gotcha: code-group YAMLs
-
-`train/configs/config.yaml`, `evaluate/conf/eval_config.yaml`, and
-`evaluate/conf/gen_tasks_config.yaml` all pull a default `{train,eval}_codes/<hash>.yaml`
-that is (a) generated out-of-band and (b) explicitly `.gitignore`d — so a fresh clone
-can't compose them. Workaround until [#64](https://github.com/payalchandak/EveryQuery/issues/64)
-lands:
-
-- Pass `--config-dir=/path/to/your/codes_dir code_group_name=...`, or
-- Generate them locally via
-    `python -m every_query.paper_experiments.sample_codes.sample_train_codes` (note: currently
-    has a hardcoded MIMIC path — #85 will parameterize it).
-
-The smoke-test fixture in `tests/test_cli_smoke.py` shows the minimal shape of each file.
-
 ## Development
 
 ```bash

--- a/src/every_query/train/README.md
+++ b/src/every_query/train/README.md
@@ -9,9 +9,10 @@ Training stage of the EveryQuery pipeline. Home of the `EQ_train` console script
     `python -m every_query.train.train`. Hydra-based: all knobs overridable on the CLI.
 - **`configs/`** — shipped Hydra configs for the training stage.
     - `config.yaml` — default production config (ModernBERT encoder, AdamW, wandb
-        logger, early-stopping on tuning/loss). `query.codes` is sourced from a
-        `train_codes` compose-group default (see #64 and #92 for the planned move
-        to `query.codes: ???` once the eval-side configs can be reworked together).
+        logger, early-stopping on tuning/loss). Training has no query-codes knob:
+        the set of queried codes is determined by whatever `EQ_generate_training_tasks`
+        wrote into the task-labels parquet at `$TASK_DIR`. Code filtering happens
+        upstream in preprocessing.
     - `fast_config.yaml` — speed-tuned override bundle that inherits `config.yaml` and
         shrinks `max_seq_len`, bumps batch size, etc. Targeted at tokenization-sweep
         runs that fit in ~5 minutes on one L40S.

--- a/src/every_query/train/configs/_demo_train.yaml
+++ b/src/every_query/train/configs/_demo_train.yaml
@@ -14,11 +14,6 @@ do_overwrite: true
 do_resume: false
 seed: 1
 
-query:
-  codes:
-    - "HR"
-    - "TEMP"
-
 datamodule:
   _target_: meds_torchdata.extensions.lightning_datamodule.Datamodule
   data_class: every_query.data.dataset.EveryQueryPytorchDataset

--- a/src/every_query/train/configs/config.yaml
+++ b/src/every_query/train/configs/config.yaml
@@ -1,14 +1,10 @@
 defaults:
   - _self_
-  - train_codes: 10000_ID__8db2be6fadf8
 
 output_dir: ${oc.env:OUTPUT_DIR}/${run_id:}/
 do_overwrite: true
 do_resume: false
 seed: 140799
-
-query:
-  codes: ${train_codes.codes}
 
 datamodule:
   _target_: meds_torchdata.extensions.lightning_datamodule.Datamodule
@@ -53,7 +49,7 @@ trainer:
   _target_: lightning.pytorch.trainer.Trainer
   logger:
     _target_: pytorch_lightning.loggers.wandb.WandbLogger
-    name: "queries=${list_len:${query.codes}}_${run_id:}"
+    name: "${run_id:}"
     save_dir: "${trainer.default_root_dir}/loggers"
     offline: False
     id: null # pass correct id to resume experiment!
@@ -62,9 +58,6 @@ trainer:
     log_model: False # upload lightning ckpts
     prefix: "" # a string to put at the beginning of metric keys
     entity: ${oc.env:WANDB_ENTITY}
-    config:
-      query_codes: ${train_codes.codes}
-      num_query_codes: ${list_len:${train_codes.codes}}
   callbacks:
     _target_: __main__.values_as_list
     learning_rate_monitor:

--- a/src/every_query/train/resume_check.py
+++ b/src/every_query/train/resume_check.py
@@ -36,6 +36,14 @@ ALLOWED_DIFFERENCE_KEYS = {
     "trainer.callbacks.early_stopping.patience",
 }
 
+LEGACY_REMOVED_KEYS = {
+    # Top-level keys that once lived in the training config but have since been removed.
+    # Stripped from a resumed run's saved config before diffing so older run dirs
+    # stay resumable after the key is gone.  "query" was a code-list knob
+    # removed in #64; see plan for context.
+    "query",
+}
+
 STR_ENUM_PARAMS = {
     "seq_sampling_strategy": SubsequenceSamplingStrategy,
     "padding_side": PaddingSide,
@@ -159,8 +167,9 @@ def validate_resume_directory(output_dir: Path, cfg: DictConfig) -> None:
     "Matters" = any key not listed in ``ALLOWED_DIFFERENCE_KEYS``.  The allow-list covers lifecycle
     flags (``do_resume``, ``do_overwrite``), path fields that legitimately differ between runs, local
     performance knobs, and training-schedule overrides that are reasonable to bump on resume.  Any
-    structural drift (model hyperparameters, dataset shape, seed, query codes) raises ``ValueError``
-    with a per-key message.
+    structural drift (model hyperparameters, dataset shape, seed) raises ``ValueError``
+    with a per-key message.  Top-level keys in ``LEGACY_REMOVED_KEYS`` are stripped from the
+    saved config before diffing so runs started before the key was removed remain resumable.
 
     Args:
         output_dir: The run directory being resumed from.
@@ -177,6 +186,10 @@ def validate_resume_directory(output_dir: Path, cfg: DictConfig) -> None:
     old_cfg = OmegaConf.load(old_cfg_fp)
     old_cfg = OmegaConf.to_container(old_cfg, resolve=True)
     new_cfg = OmegaConf.to_container(cfg, resolve=True)
+
+    for legacy_key in LEGACY_REMOVED_KEYS:
+        old_cfg.pop(legacy_key, None)
+        new_cfg.pop(legacy_key, None)
 
     differences = diff_configs(new_cfg, old_cfg)
 

--- a/src/every_query/train/train.py
+++ b/src/every_query/train/train.py
@@ -12,7 +12,7 @@ import torch
 from hydra.utils import instantiate
 from lightning.pytorch import seed_everything
 from MEDS_transforms.configs.utils import OmegaConfResolver
-from omegaconf import DictConfig, ListConfig, OmegaConf
+from omegaconf import DictConfig, OmegaConf
 
 from every_query.train.resume_check import validate_resume_directory
 
@@ -202,9 +202,6 @@ CONFIGS = str(files("every_query") / "train" / "configs")
 @hydra.main(version_base="1.3", config_path=CONFIGS, config_name="config.yaml")
 def main(cfg: DictConfig) -> float | None:
     _init_env()
-
-    if not isinstance(cfg.query.codes, ListConfig):
-        raise ValueError("query.codes must be a list")
 
     if cfg.do_overwrite and cfg.do_resume:
         logger.warning(

--- a/tests/test_cli_smoke.py
+++ b/tests/test_cli_smoke.py
@@ -22,32 +22,14 @@ import pytest
 
 _VENV_BIN = str(Path(sys.executable).parent)
 
-# (console_script, extra_args) — extras inject a smoke code-group for configs
-# whose defaults pull an out-of-tree YAML (``EQ_train``'s ``train_codes``
-# default group is the only one that needs this today).
-_ENTRYPOINTS: list[tuple[str, list[str]]] = [
-    ("EQ_process_data", []),
-    ("EQ_train", ["train_codes=smoke"]),
-    ("EQ_generate_training_tasks", []),
-    ("EQ_generate_evaluation_tasks", []),
-    ("EQ_predict", []),
-    ("EQ_evaluate", []),
+_ENTRYPOINTS: list[str] = [
+    "EQ_process_data",
+    "EQ_train",
+    "EQ_generate_training_tasks",
+    "EQ_generate_evaluation_tasks",
+    "EQ_predict",
+    "EQ_evaluate",
 ]
-
-
-@pytest.fixture(scope="module")
-def smoke_config_dir(tmp_path_factory) -> Path:
-    """Temp Hydra search dir supplying an empty ``train_codes`` group.
-
-    Only ``EQ_train`` pulls a gitignored default (``train_codes/<hash>.yaml``)
-    today; the other CLIs either take explicit params (``EQ_predict``,
-    ``EQ_evaluate``, ``EQ_generate_evaluation_tasks``) or have self-contained
-    defaults (``EQ_process_data``, ``EQ_generate_training_tasks``).
-    """
-    d = tmp_path_factory.mktemp("eq_smoke_cfg")
-    (d / "train_codes").mkdir()
-    (d / "train_codes" / "smoke.yaml").write_text("codes: []\n")
-    return d
 
 
 @pytest.fixture(scope="module")
@@ -58,10 +40,10 @@ def cli_env() -> dict[str, str]:
     return env
 
 
-@pytest.mark.parametrize(("script", "extra_args"), _ENTRYPOINTS, ids=[e[0] for e in _ENTRYPOINTS])
-def test_entrypoint_help(script, extra_args, cli_env, smoke_config_dir):
+@pytest.mark.parametrize("script", _ENTRYPOINTS)
+def test_entrypoint_help(script, cli_env):
     """``<script> --help`` exits 0."""
-    cmd = [script, f"--config-dir={smoke_config_dir}", *extra_args, "--help"]
+    cmd = [script, "--help"]
     result = subprocess.run(cmd, capture_output=True, text=True, env=cli_env, timeout=60)
     assert result.returncode == 0, (
         f"{script} --help failed (rc={result.returncode})\n"

--- a/tests/test_resume_check.py
+++ b/tests/test_resume_check.py
@@ -2,12 +2,15 @@
 
 from __future__ import annotations
 
-from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pytest
 from omegaconf import OmegaConf
 
 from every_query.train.resume_check import LEGACY_REMOVED_KEYS, validate_resume_directory
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 
 def _write_cfg(path: Path, **overrides) -> None:
@@ -20,9 +23,8 @@ def _write_cfg(path: Path, **overrides) -> None:
 
 
 def test_resume_ignores_legacy_query_stanza(tmp_path: Path) -> None:
-    """An old run dir whose saved config still carries a top-level ``query`` stanza must resume
-    cleanly after #64 removed the field.
-    """
+    """An old run dir whose saved config still carries a top-level ``query`` stanza must resume cleanly after
+    #64 removed the field."""
     assert "query" in LEGACY_REMOVED_KEYS
 
     saved = tmp_path / "config.yaml"

--- a/tests/test_resume_check.py
+++ b/tests/test_resume_check.py
@@ -1,0 +1,54 @@
+"""Unit tests for ``every_query.train.resume_check.validate_resume_directory``."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from omegaconf import OmegaConf
+
+from every_query.train.resume_check import LEGACY_REMOVED_KEYS, validate_resume_directory
+
+
+def _write_cfg(path: Path, **overrides) -> None:
+    base = {
+        "seed": 140799,
+        "datamodule": {"config": {"max_seq_len": 256}},
+    }
+    base.update(overrides)
+    OmegaConf.save(OmegaConf.create(base), path)
+
+
+def test_resume_ignores_legacy_query_stanza(tmp_path: Path) -> None:
+    """An old run dir whose saved config still carries a top-level ``query`` stanza must resume
+    cleanly after #64 removed the field.
+    """
+    assert "query" in LEGACY_REMOVED_KEYS
+
+    saved = tmp_path / "config.yaml"
+    _write_cfg(saved, query={"codes": ["A", "B", "C"]})
+
+    new_cfg = OmegaConf.create(
+        {
+            "seed": 140799,
+            "datamodule": {"config": {"max_seq_len": 256}},
+        }
+    )
+
+    validate_resume_directory(tmp_path, new_cfg)
+
+
+def test_resume_rejects_non_legacy_drift(tmp_path: Path) -> None:
+    """A structural mismatch outside the allow-list / legacy set must still raise."""
+    saved = tmp_path / "config.yaml"
+    _write_cfg(saved, query={"codes": ["A"]})
+
+    new_cfg = OmegaConf.create(
+        {
+            "seed": 42,  # drifted
+            "datamodule": {"config": {"max_seq_len": 256}},
+        }
+    )
+
+    with pytest.raises(ValueError, match="seed"):
+        validate_resume_directory(tmp_path, new_cfg)

--- a/tests/training_validity/test_training_validity.py
+++ b/tests/training_validity/test_training_validity.py
@@ -229,7 +229,6 @@ def oracle_trained_model_dir(
             f"output_dir={output_dir!s}",
             f"datamodule.config.tensorized_cohort_dir={oracle_preprocessed!s}",
             f"datamodule.config.task_labels_dir={oracle_dataset['task_labels_dir']!s}",
-            f"query.codes=[{_TARGET_CODE}]",
             "datamodule.batch_size=16",
             "datamodule.config.max_seq_len=128",
             "lightning_module.model.config_overrides.hidden_size=128",


### PR DESCRIPTION
## Summary
- Drop the `query.codes` / `train_codes` compose-group knob from the training config; the queried-code set now comes from the task-labels parquet written by `EQ_generate_training_tasks` (upstream preprocessing).
- Simplify `wandb` run naming and drop the `num_query_codes`/`query_codes` wandb config fields.
- Extend `resume_check` with a `LEGACY_REMOVED_KEYS` allow-list (starting with `query`) so run dirs started before this change stay resumable.
- Add `tests/test_resume_check.py` covering the legacy-key stripping path; trim now-obsolete assertions in `tests/test_cli_smoke.py`.

## Test plan
- [ ] \`uv run pre-commit run --all-files\` (green locally)
- [ ] \`uv run pytest tests/test_resume_check.py tests/test_cli_smoke.py -v\`
- [ ] Full test suite in CI
- [ ] Spot-check: resume a pre-#64 run dir and confirm no \`query\` drift error
- [ ] Spot-check: fresh \`EQ_train\` run succeeds and W&B run name uses the new \`\${run_id}\` form

🤖 Generated with [Claude Code](https://claude.com/claude-code)