### PR TITLE
fix(config): use fully-qualified target for trainer callbacks

### DIFF
--- a/src/every_query/train/configs/config.yaml
+++ b/src/every_query/train/configs/config.yaml
@@ -59,7 +59,7 @@ trainer:
     prefix: "" # a string to put at the beginning of metric keys
     entity: ${oc.env:WANDB_ENTITY}
   callbacks:
-    _target_: __main__.values_as_list
+    _target_: every_query.train.train.values_as_list
     learning_rate_monitor:
       _target_: lightning.pytorch.callbacks.LearningRateMonitor
     model_checkpoint:


### PR DESCRIPTION
## Summary
- Replace `__main__.values_as_list` with `every_query.train.train.values_as_list` in `src/every_query/train/configs/config.yaml` so Hydra can resolve the target under the installed `EQ_train` console script (not just `python -m every_query.train.train`).
- Matches the pattern already used in `_demo_train.yaml`.

Fixes #158.

## Test plan
- [ ] `uv run EQ_train --help` succeeds (no `InstantiationException` for `trainer.callbacks`)
- [ ] `uv run python -m every_query.train.train --help` still works (regression check)
- [ ] Short cluster-side `EQ_train` run confirms training starts

🤖 Generated with [Claude Code](https://claude.com/claude-code)