### PR TITLE
feat: add occurs_loss_weight hyperparameter

### DIFF
--- a/src/every_query/model/model.py
+++ b/src/every_query/model/model.py
@@ -281,6 +281,7 @@ class EveryQueryModel(torch.nn.Module):
         model_name: str = "answerdotai/ModernBERT-base",
         num_hidden_layers: int | None = None,
         config_overrides: dict[str, Any] | None = None,
+        occurs_loss_weight: float = 0.5,
     ):
         super().__init__()
 
@@ -334,6 +335,7 @@ class EveryQueryModel(torch.nn.Module):
         )
         self.duration_embed = MLP(layers=[1, 64, self.HF_model.config.hidden_size], dropout_prob=0)
         self.criterion = torch.nn.BCEWithLogitsLoss()
+        self.occurs_loss_weight = occurs_loss_weight
 
         self.do_demo = do_demo
         if self.do_demo:
@@ -348,6 +350,7 @@ class EveryQueryModel(torch.nn.Module):
             "model_name": model_name,
             "num_hidden_layers": self.HF_model_config.num_hidden_layers,
             "config_overrides": dict(config_overrides) if config_overrides else None,
+            "occurs_loss_weight": self.occurs_loss_weight,
         }
 
     @property
@@ -618,7 +621,7 @@ class EveryQueryModel(torch.nn.Module):
         occurs_logits = self.occurs_mlp(query_embed)
         occurs_loss = self._get_loss(occurs_logits, batch.occurs, mask=~batch.censor)
 
-        loss = censor_loss + occurs_loss
+        loss = self.occurs_loss_weight * occurs_loss + (1 - self.occurs_loss_weight) * censor_loss
 
         outputs = EveryQueryOutput(
             last_hidden_state=outputs.last_hidden_state if self.do_demo else None,

--- a/src/every_query/train/configs/config.yaml
+++ b/src/every_query/train/configs/config.yaml
@@ -29,6 +29,7 @@ lightning_module:
     do_grad_ckpt: false
     mlp_dropout: 0.1
     num_hidden_layers: 22
+    occurs_loss_weight: 0.5
   optimizer:
     _target_: torch.optim.AdamW
     _partial_: true

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -53,7 +53,9 @@ class TestModelForwardShape:
     def test_loss_decomposes(self, demo_model, sample_batch):
         loss, outputs = demo_model(sample_batch)
         assert outputs.censor_loss.isfinite() and outputs.occurs_loss.isfinite()
-        assert torch.allclose(loss, outputs.censor_loss + outputs.occurs_loss)
+        w = demo_model.occurs_loss_weight
+        expected = w * outputs.occurs_loss + (1 - w) * outputs.censor_loss
+        assert torch.allclose(loss, expected)
 
 
 # ── test_model_backward ─────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Analysis in #139 showed that censor and occurs losses operate at different scales during training, and that early stopping on the combined `tuning/loss` can be dominated by the censor component. Matt suggested downweighting censor loss significantly during training to improve occurs prediction quality.

This PR adds a single mixing parameter `occurs_loss_weight` (float in [0,1], default 0.5) to `EveryQueryModel`. The training loss becomes:

```
loss = occurs_loss_weight * occurs_loss + (1 - occurs_loss_weight) * censor_loss
```

- **Default (0.5)**: both losses receive equal weight (backward compatible behavior)
- **occurs_loss_weight > 0.5**: upweights occurs loss relative to censor loss
- Example: `occurs_loss_weight=0.91` gives ~10x occurs vs censor weighting

### Changes

- `src/every_query/model/model.py`: added `occurs_loss_weight` parameter to `EveryQueryModel.__init__`, stored on the model, included in `hparams`, and used in `_forward` loss computation
- `src/every_query/train/configs/config.yaml`: added `occurs_loss_weight: 0.5` to model config block
- `tests/test_training.py`: updated `test_loss_decomposes` to use the weighted formula