### PR TITLE
chore: add SessionStart hook to install gcloud for web sessions

### DIFF
--- a/.claude/hooks/session-start.sh
+++ b/.claude/hooks/session-start.sh
@@ -1,0 +1,84 @@
+#!/bin/bash
+# SessionStart hook for Claude Code on the web.
+#
+# Installs the Google Cloud SDK and the repo's Python dev dependencies, and
+# authenticates to GCP if a service account key is available, so future agent
+# sessions can read from gs://every-query-runs and run the test / lint suite.
+#
+# Only runs in remote (web) sessions. Local sessions are a no-op.
+
+set -euo pipefail
+
+if [ "${CLAUDE_CODE_REMOTE:-}" != "true" ]; then
+    echo "[session-start] not a remote session, skipping."
+    exit 0
+fi
+
+PROJECT_DIR="${CLAUDE_PROJECT_DIR:-$(pwd)}"
+GCLOUD_HOME="$HOME/google-cloud-sdk"
+
+# ---------------------------------------------------------------------------
+# 1. Install the Google Cloud SDK (gcloud + gsutil) if missing.
+# ---------------------------------------------------------------------------
+if ! command -v gcloud >/dev/null 2>&1 && [ ! -x "$GCLOUD_HOME/bin/gcloud" ]; then
+    echo "[session-start] installing Google Cloud SDK into $GCLOUD_HOME"
+    TMP_TARBALL="$(mktemp --suffix=.tar.gz)"
+    curl -fsSL -o "$TMP_TARBALL" \
+        https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-cli-linux-x86_64.tar.gz
+    tar -xzf "$TMP_TARBALL" -C "$HOME"
+    rm -f "$TMP_TARBALL"
+    "$GCLOUD_HOME/install.sh" --quiet --path-update=false --usage-reporting=false \
+        --command-completion=false >/dev/null
+else
+    echo "[session-start] Google Cloud SDK already installed."
+fi
+
+# Put gcloud/gsutil on PATH for this session and all future tool invocations.
+export PATH="$GCLOUD_HOME/bin:$PATH"
+if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+    echo "export PATH=\"$GCLOUD_HOME/bin:\$PATH\"" >> "$CLAUDE_ENV_FILE"
+fi
+
+# ---------------------------------------------------------------------------
+# 2. Authenticate to GCP if a service account key was provided.
+#
+# Provide the key via one of (checked in order):
+#   * GCP_SERVICE_ACCOUNT_KEY       — full JSON contents of the key file
+#   * GOOGLE_APPLICATION_CREDENTIALS — path to a mounted key file
+#
+# Configure either as a session secret in the Claude Code web UI.
+# ---------------------------------------------------------------------------
+KEY_FILE="$HOME/.config/gcloud-service-account.json"
+mkdir -p "$(dirname "$KEY_FILE")"
+
+if [ -n "${GCP_SERVICE_ACCOUNT_KEY:-}" ]; then
+    printf '%s' "$GCP_SERVICE_ACCOUNT_KEY" > "$KEY_FILE"
+    chmod 600 "$KEY_FILE"
+    export GOOGLE_APPLICATION_CREDENTIALS="$KEY_FILE"
+fi
+
+if [ -n "${GOOGLE_APPLICATION_CREDENTIALS:-}" ] && [ -f "$GOOGLE_APPLICATION_CREDENTIALS" ]; then
+    echo "[session-start] activating service account from $GOOGLE_APPLICATION_CREDENTIALS"
+    gcloud auth activate-service-account \
+        --key-file="$GOOGLE_APPLICATION_CREDENTIALS" --quiet
+    if [ -n "${CLAUDE_ENV_FILE:-}" ]; then
+        echo "export GOOGLE_APPLICATION_CREDENTIALS=\"$GOOGLE_APPLICATION_CREDENTIALS\"" \
+            >> "$CLAUDE_ENV_FILE"
+    fi
+else
+    echo "[session-start] no GCP_SERVICE_ACCOUNT_KEY / GOOGLE_APPLICATION_CREDENTIALS found;"
+    echo "[session-start] gcloud is installed but unauthenticated. Set the secret in the"
+    echo "[session-start] Claude Code web UI to enable gs://every-query-runs access."
+fi
+
+# ---------------------------------------------------------------------------
+# 3. Install Python dev dependencies so tests and linters work.
+# ---------------------------------------------------------------------------
+if command -v uv >/dev/null 2>&1; then
+    echo "[session-start] syncing Python deps with uv"
+    (cd "$PROJECT_DIR" && uv sync --locked --group dev)
+else
+    echo "[session-start] uv not found on PATH; skipping Python dep install."
+fi
+
+echo "[session-start] done."

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,15 @@
+{
+    "$schema": "https://json.schemastore.org/claude-code-settings.json",
+    "hooks": {
+        "SessionStart": [
+            {
+                "hooks": [
+                    {
+                        "type": "command",
+                        "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/session-start.sh"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -186,7 +186,9 @@ src/every_query/paper_experiments/sample_codes/outputs/
 
 # AI
 .cursor/
-.claude/
+.claude/*
+!.claude/settings.json
+!.claude/hooks/
 CLAUDE.md
 
 # GCP analysis


### PR DESCRIPTION
## Summary
- Adds `.claude/hooks/session-start.sh` that installs the Google Cloud SDK and runs `uv sync --locked --group dev` at the start of every Claude Code on the web session.
- If `GCP_SERVICE_ACCOUNT_KEY` (raw JSON) or `GOOGLE_APPLICATION_CREDENTIALS` (path) is set as a web-session secret, the hook also activates that service account so `gsutil`/`gcloud storage` can read `gs://every-query-runs` without any further in-session setup. Absent the secret, gcloud is installed but inert — no bucket access leaks from the repo itself.
- Narrows `.gitignore` from `.claude/` to `.claude/*` with allowlists for `settings.json` and `hooks/`, so local-only Claude settings files remain ignored while the shared hook is tracked.

## How to enable bucket access for your own sessions
1. In GCP, create a service account, grant it `Storage Object Viewer` **scoped to the `every-query-runs` bucket only**, and download a JSON key.
2. In the Claude Code web UI, add a session secret named `GCP_SERVICE_ACCOUNT_KEY` whose value is the full JSON contents of that key.
3. Start a new session — `gsutil ls gs://every-query-runs` will work.

The secret is per-account; no one else who clones the repo gets bucket access from the hook alone.

## Test plan
- [x] `CLAUDE_CODE_REMOTE=true ./.claude/hooks/session-start.sh` runs cleanly locally (gcloud installs on first run, "already installed" on subsequent runs, uv sync succeeds, exits 0 with credential warning when no secret is set).
- [x] `uv run ruff check` passes on a sample file.
- [x] `uv run pytest tests/test_run_id.py` → 3 passed.
- [ ] After merge, a fresh Claude Code web session starts with `gcloud` on PATH.
- [ ] After setting `GCP_SERVICE_ACCOUNT_KEY` in the web UI, `gsutil ls gs://every-query-runs` lists objects.

https://claude.ai/code/session_01UnKxAzcbDLB92cHHEuovgJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnKxAzcbDLB92cHHEuovgJ)_