### PR TITLE
Stream predictions to parquet instead of buffering in memory

### DIFF
--- a/src/every_query/predict/predict.py
+++ b/src/every_query/predict/predict.py
@@ -393,9 +393,7 @@ def main(cfg: DictConfig) -> None:
     # class's ``MisconfigurationException``.  The SequentialSampler check above
     # guarantees order preservation.
     try:
-        trainer.predict(
-            model=model, dataloaders=dataloader, ckpt_path=None, return_predictions=False
-        )
+        trainer.predict(model=model, dataloaders=dataloader, ckpt_path=None, return_predictions=False)
         # Success-path invariant — MTD guarantees ``schema_df`` preserves the input
         # labels frame's length + order, so the writer should have streamed one
         # prediction per schema_df row.  A mismatch is a silent invariant violation;

--- a/src/every_query/predict/predict.py
+++ b/src/every_query/predict/predict.py
@@ -356,6 +356,23 @@ def main(cfg: DictConfig) -> None:
     logger.info(f"Loading tasks from {tasks_dir} (split={split})")
 
     train_cfg, model, trainer = setup_model(model_run_dir, ckpt_name=ckpt_name)
+
+    # ``_StreamingPredictionWriter`` opens a single ``output_parquet`` and tracks a
+    # process-local offset into ``schema_df``.  Under multi-process predict (DDP /
+    # multi-device / multi-node), every rank would open the same path and start slicing
+    # ``schema_df`` from offset 0 — corrupting the parquet and mispairing probabilities
+    # with identifiers.  ``setup_model`` instantiates the trainer from the saved training
+    # config, so a model trained with ``trainer.devices > 1`` carries that strategy into
+    # predict.  Refuse loudly; predict is single-pass by design (see module docstring).
+    if trainer.world_size > 1:
+        raise RuntimeError(
+            f"EQ_predict requires single-process prediction, but the trainer instantiated from "
+            f"the training config has world_size={trainer.world_size} "
+            f"(num_devices={trainer.num_devices}, num_nodes={trainer.num_nodes}).  "
+            f"Override the run dir's resolved_config.yaml to set "
+            f"trainer.devices=1, trainer.strategy=auto, trainer.num_nodes=1 before running predict."
+        )
+
     train_cfg.datamodule.config.task_labels_dir = str(tasks_dir)
     D = instantiate(train_cfg.datamodule)
 

--- a/src/every_query/predict/predict.py
+++ b/src/every_query/predict/predict.py
@@ -323,6 +323,27 @@ class _StreamingPredictionWriter(BasePredictionWriter):
             self.close()
 
 
+def _check_single_process_trainer(trainer) -> None:
+    """Refuse multi-process predict — :class:`_StreamingPredictionWriter` assumes one rank.
+
+    The writer opens a single ``output_parquet`` and tracks a process-local offset into
+    ``schema_df``.  Under multi-process predict (DDP / multi-device / multi-node), every
+    rank would open the same path and start slicing ``schema_df`` from offset 0 —
+    corrupting the parquet and mispairing probabilities with identifiers.  ``setup_model``
+    instantiates the trainer from the saved training config, so a model trained with
+    ``trainer.devices > 1`` carries that strategy into predict.  Predict is single-pass
+    by design (see module docstring); refuse loudly rather than write corrupted output.
+    """
+    if trainer.world_size > 1:
+        raise RuntimeError(
+            f"EQ_predict requires single-process prediction, but the trainer instantiated from "
+            f"the training config has world_size={trainer.world_size} "
+            f"(num_devices={trainer.num_devices}, num_nodes={trainer.num_nodes}).  "
+            f"Override the run dir's resolved_config.yaml to set "
+            f"trainer.devices=1, trainer.strategy=auto, trainer.num_nodes=1 before running predict."
+        )
+
+
 _SPLIT_TO_DATAMODULE_ATTRS: dict[str, tuple[str, str]] = {
     tuning_split: ("val_dataset", "val_dataloader"),
     held_out_split: ("test_dataset", "test_dataloader"),
@@ -356,22 +377,7 @@ def main(cfg: DictConfig) -> None:
     logger.info(f"Loading tasks from {tasks_dir} (split={split})")
 
     train_cfg, model, trainer = setup_model(model_run_dir, ckpt_name=ckpt_name)
-
-    # ``_StreamingPredictionWriter`` opens a single ``output_parquet`` and tracks a
-    # process-local offset into ``schema_df``.  Under multi-process predict (DDP /
-    # multi-device / multi-node), every rank would open the same path and start slicing
-    # ``schema_df`` from offset 0 — corrupting the parquet and mispairing probabilities
-    # with identifiers.  ``setup_model`` instantiates the trainer from the saved training
-    # config, so a model trained with ``trainer.devices > 1`` carries that strategy into
-    # predict.  Refuse loudly; predict is single-pass by design (see module docstring).
-    if trainer.world_size > 1:
-        raise RuntimeError(
-            f"EQ_predict requires single-process prediction, but the trainer instantiated from "
-            f"the training config has world_size={trainer.world_size} "
-            f"(num_devices={trainer.num_devices}, num_nodes={trainer.num_nodes}).  "
-            f"Override the run dir's resolved_config.yaml to set "
-            f"trainer.devices=1, trainer.strategy=auto, trainer.num_nodes=1 before running predict."
-        )
+    _check_single_process_trainer(trainer)
 
     train_cfg.datamodule.config.task_labels_dir = str(tasks_dir)
     D = instantiate(train_cfg.datamodule)

--- a/src/every_query/predict/predict.py
+++ b/src/every_query/predict/predict.py
@@ -38,9 +38,11 @@ from pathlib import Path
 
 import hydra
 import polars as pl
+import pyarrow as pa
 import pyarrow.parquet as pq
 import torch
 from hydra.utils import instantiate
+from lightning.pytorch.callbacks import BasePredictionWriter
 from meds import held_out_split, tuning_split
 from omegaconf import DictConfig
 
@@ -194,37 +196,6 @@ def _check_vocab(task_codes: set[str], train_cfg: DictConfig) -> None:
         )
 
 
-def _gather_probabilities(pred_batches: list[dict[str, torch.Tensor]]) -> pl.DataFrame:
-    """Flatten Lightning's per-batch ``predict_step`` dicts into a two-column probabilities frame.
-
-    Returns ``(censor_prob, occurs_prob)`` in dataset iteration order.  Column names
-    come from :class:`PredictionSchema` so a rename on the schema flows through.
-
-    ``logits_to_probs`` does a trailing ``.squeeze()``, so a single-item batch emits a
-    0-d scalar tensor that ``torch.cat`` refuses to stack — ``reshape(-1)`` on every
-    per-batch tensor makes the concat well-defined regardless of batch size.
-    """
-    if not pred_batches:
-        return pl.DataFrame(
-            schema={
-                PredictionSchema.censor_prob_name: pl.Float32,
-                PredictionSchema.occurs_prob_name: pl.Float32,
-            }
-        )
-
-    def cat(key: str) -> pl.Series:
-        # ``PredictionSchema.{censor,occurs}_prob`` are ``pa.float32()`` — cast here
-        # so the final ``PredictionSchema.align`` doesn't have to coerce f64 → f32.
-        return pl.Series(torch.cat([b[key].reshape(-1) for b in pred_batches]).numpy()).cast(pl.Float32)
-
-    return pl.DataFrame(
-        {
-            PredictionSchema.censor_prob_name: cat("censor_probs"),
-            PredictionSchema.occurs_prob_name: cat("occurs_probs"),
-        }
-    )
-
-
 def _identifiers_from_schema_df(schema_df: pl.DataFrame) -> pl.DataFrame:
     """Build an output identifier frame from the dataset's post-``__init__`` schema_df.
 
@@ -253,6 +224,103 @@ def _identifiers_from_schema_df(schema_df: pl.DataFrame) -> pl.DataFrame:
             .alias(TaskQuerySchema.boolean_value_name)
         )
     return out
+
+
+class _StreamingPredictionWriter(BasePredictionWriter):
+    """Lightning ``BasePredictionWriter`` that streams per-batch results to a single parquet.
+
+    Each ``write_on_batch_end`` call appends one row group to ``output_parquet`` so
+    EQ_predict's CPU-memory footprint doesn't scale with cohort size — only one batch's
+    ``predict_step`` dict is alive at a time (Lightning drops it after the writer hook
+    returns when ``return_predictions=False``).
+
+    Identifiers come from slicing the dataset's pre-loaded ``schema_df`` with a running
+    offset; correctness depends on the dataloader iterating in ``schema_df`` row order,
+    which ``main()`` enforces via the ``SequentialSampler`` guard.
+
+    Partial-write semantics: ``close()`` is idempotent and is invoked from ``main()``'s
+    ``try/finally`` block, so a Python-level exception mid-stream still flushes the parquet
+    footer and leaves a valid ``PredictionSchema`` parquet covering exactly the batches that
+    completed.  Hard kills (SIGKILL) cannot be recovered — parquet has no
+    append-after-close, so single-file streaming has no defense against them.
+    """
+
+    def __init__(self, output_parquet: Path, schema_df: pl.DataFrame) -> None:
+        super().__init__(write_interval="batch")
+        self._output_parquet = output_parquet
+        self._schema_df = schema_df
+        self._writer: pq.ParquetWriter | None = None
+        self._offset: int = 0
+        self._arrow_schema: pa.Schema | None = None
+
+    def setup(self, trainer, pl_module, stage: str) -> None:
+        if stage != "predict":
+            return
+        # Pre-build the canonical arrow schema from a zero-row aligned table.  Doing
+        # this up front (rather than on the first batch) means an empty cohort still
+        # produces a valid PredictionSchema parquet — matches the pre-streaming
+        # behavior where ``_gather_probabilities`` returned an empty frame and the
+        # final ``pq.write_table`` still ran.
+        empty_ids = _identifiers_from_schema_df(self._schema_df.head(0))
+        empty_probs = pl.DataFrame(
+            schema={
+                PredictionSchema.censor_prob_name: pl.Float32,
+                PredictionSchema.occurs_prob_name: pl.Float32,
+            }
+        )
+        empty_aligned = PredictionSchema.align(empty_ids.hstack(empty_probs).to_arrow())
+        self._arrow_schema = empty_aligned.schema
+
+        self._output_parquet.parent.mkdir(parents=True, exist_ok=True)
+        self._writer = pq.ParquetWriter(self._output_parquet, schema=self._arrow_schema)
+
+    def write_on_batch_end(
+        self,
+        trainer,
+        pl_module,
+        prediction: dict[str, torch.Tensor],
+        batch_indices,
+        batch,
+        batch_idx: int,
+        dataloader_idx: int = 0,
+    ) -> None:
+        if self._writer is None:
+            raise RuntimeError(
+                "_StreamingPredictionWriter received a batch before setup() opened the "
+                "parquet writer.  This shouldn't happen in normal predict flow."
+            )
+
+        n = prediction["occurs_probs"].reshape(-1).numel()
+        if n == 0:
+            return
+
+        identifiers = _identifiers_from_schema_df(self._schema_df.slice(self._offset, n))
+        # Cast to Float32 here so the per-batch ``PredictionSchema.align`` doesn't have
+        # to coerce f64 → f32 every row group (mirrors the old ``_gather_probabilities``).
+        probs = pl.DataFrame(
+            {
+                PredictionSchema.censor_prob_name: pl.Series(
+                    prediction["censor_probs"].reshape(-1).numpy()
+                ).cast(pl.Float32),
+                PredictionSchema.occurs_prob_name: pl.Series(
+                    prediction["occurs_probs"].reshape(-1).numpy()
+                ).cast(pl.Float32),
+            }
+        )
+        aligned = PredictionSchema.align(identifiers.hstack(probs).to_arrow())
+        self._writer.write_table(aligned)
+        self._offset += n
+
+    def close(self) -> None:
+        """Idempotent close — safe to call from both Lightning's teardown and main()'s finally."""
+        if self._writer is not None:
+            self._writer.close()
+            self._writer = None
+
+    def teardown(self, trainer, pl_module, stage: str) -> None:
+        # Defense-in-depth: ``main()``'s ``try/finally`` is the primary closer.
+        if stage == "predict":
+            self.close()
 
 
 _SPLIT_TO_DATAMODULE_ATTRS: dict[str, tuple[str, str]] = {
@@ -311,36 +379,38 @@ def main(cfg: DictConfig) -> None:
     _check_vocab(set(dataset.query.unique().to_list()), train_cfg)
     logger.info(f"Loaded {len(dataset)} tasks across {dataset.query.n_unique()} query codes")
 
+    # Stream per-batch predictions to ``output_parquet`` so memory doesn't scale with
+    # cohort size.  The callback opens the parquet writer in ``setup``, appends one row
+    # group per batch in ``write_on_batch_end``, and is closed by the ``finally`` below
+    # (idempotent — Lightning's ``teardown`` also calls ``close()``).  Pairing this with
+    # ``return_predictions=False`` means Lightning drops each batch's ``predict_step``
+    # dict as soon as the writer hook returns.
+    writer = _StreamingPredictionWriter(output_parquet, dataset.schema_df)
+    trainer.callbacks.append(writer)
+
     # Pass the split's dataloader directly — MTD's ``Datamodule`` has no
     # ``predict_dataloader``, so ``trainer.predict(datamodule=D)`` would hit the base
     # class's ``MisconfigurationException``.  The SequentialSampler check above
     # guarantees order preservation.
-    pred_batches = trainer.predict(model=model, dataloaders=dataloader, ckpt_path=None)
-
-    probs = _gather_probabilities(pred_batches)
-    identifiers = _identifiers_from_schema_df(dataset.schema_df)
-
-    # MTD guarantees ``schema_df`` preserves the input labels frame's length + order
-    # (see ``get_task_seq_bounds_and_labels`` docstring), and the dataloader is
-    # ``shuffle=False`` — so ``probs`` comes back 1:1 matched with ``identifiers``.
-    # A row-count mismatch would indicate a silent invariant violation; fail loudly.
-    if probs.height != identifiers.height:
-        raise RuntimeError(
-            f"Prediction row count ({probs.height}) doesn't match dataset row count "
-            f"({identifiers.height}).  This is an MTD invariant violation — "
-            f"the dataloader should have yielded one prediction per schema_df row."
+    try:
+        trainer.predict(
+            model=model, dataloaders=dataloader, ckpt_path=None, return_predictions=False
         )
+        # Success-path invariant — MTD guarantees ``schema_df`` preserves the input
+        # labels frame's length + order, so the writer should have streamed one
+        # prediction per schema_df row.  A mismatch is a silent invariant violation;
+        # fail loudly.  On an exception path, ``writer._offset`` will legitimately be
+        # < ``schema_df.height`` (partial write) so we skip the check there.
+        if writer._offset != dataset.schema_df.height:
+            raise RuntimeError(
+                f"Prediction row count ({writer._offset}) doesn't match dataset row count "
+                f"({dataset.schema_df.height}).  This is an MTD invariant violation — "
+                f"the dataloader should have yielded one prediction per schema_df row."
+            )
+    finally:
+        writer.close()
 
-    out = identifiers.hstack(probs)
-
-    output_parquet.parent.mkdir(parents=True, exist_ok=True)
-    # Final canonicalization pass — ``align`` casts / reorders columns to match the
-    # schema's canonical arrow layout, and we write the aligned arrow table directly
-    # via pyarrow so the schema-coerced dtypes actually land on disk (a polars
-    # round-trip would re-infer types from the aligned data, which defeats the point).
-    aligned = PredictionSchema.align(out.to_arrow())
-    pq.write_table(aligned, output_parquet)
-    logger.info(f"Wrote {out.height} predictions to {output_parquet}")
+    logger.info(f"Wrote {writer._offset} predictions to {output_parquet}")
 
 
 if __name__ == "__main__":

--- a/tests/test_predict_logic.py
+++ b/tests/test_predict_logic.py
@@ -1,0 +1,156 @@
+"""Unit tests for EQ_predict internals.
+
+Complements ``test_predict_cli.py``'s subprocess integration coverage with direct,
+in-process exercise of the streaming writer and the multi-process guard.  These cover
+gaps the subprocess tests can't reach cheaply: multi-batch row-order across the writer's
+offset boundary, the empty-cohort path, and the DDP / multi-device refusal path.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+import lightning as L
+import polars as pl
+import pyarrow.parquet as pq
+import pytest
+import torch
+
+from every_query.predict.predict import (
+    _check_single_process_trainer,
+    _StreamingPredictionWriter,
+)
+from every_query.predict.schema import PredictionSchema
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _make_schema_df(n: int) -> pl.DataFrame:
+    """Build a fake ``schema_df`` shaped like MTD's post-collapse output.
+
+    Columns mirror :class:`every_query.data.dataset.EveryQueryPytorchDataset` after the
+    ``boolean_value`` → ``(censor, occurs)`` collapse: identifier columns plus
+    ``boolean_value`` (censor flag) and ``occurs`` (true outcome when not censored).
+
+    Dtypes are pinned explicitly so the ``n=0`` fixture matches what MTD actually
+    produces (parquet schema is preserved through ``head(0)`` in production); polars'
+    default inference would assign ``null`` to empty Boolean columns and break the
+    ``boolean_value`` reconstruction in ``_identifiers_from_schema_df``.
+    """
+    return pl.DataFrame(
+        {
+            "subject_id": list(range(10, 10 + n)),
+            "prediction_time": [datetime(2024, 1, 1 + i % 28) for i in range(n)],
+            "query": [["A", "B", "C"][i % 3] for i in range(n)],
+            "duration_days": [30.0 * (1 + i % 3) for i in range(n)],
+            # Alternate censor flags so boolean_value reconstruction exercises both branches.
+            "boolean_value": [i % 2 == 1 for i in range(n)],
+            "occurs": [i % 3 == 0 for i in range(n)],
+        },
+        schema_overrides={
+            "subject_id": pl.Int64,
+            "duration_days": pl.Float32,
+            "boolean_value": pl.Boolean,
+            "occurs": pl.Boolean,
+        },
+    )
+
+
+def _drive_writer(writer: _StreamingPredictionWriter, batches: list[tuple[list[float], list[float]]]) -> None:
+    """Mimic Lightning's predict lifecycle: setup → write_on_batch_end* → teardown."""
+    writer.setup(trainer=None, pl_module=None, stage="predict")
+    for batch_idx, (censor, occurs) in enumerate(batches):
+        writer.write_on_batch_end(
+            trainer=None,
+            pl_module=None,
+            prediction={
+                "censor_probs": torch.tensor(censor),
+                "occurs_probs": torch.tensor(occurs),
+            },
+            batch_indices=None,
+            batch=None,
+            batch_idx=batch_idx,
+            dataloader_idx=0,
+        )
+    writer.teardown(trainer=None, pl_module=None, stage="predict")
+
+
+def test_streaming_writer_single_batch_preserves_identifiers_and_probs(tmp_path: Path) -> None:
+    """One full-cohort batch → one row group, identifiers + probs land 1:1 in input order."""
+    schema_df = _make_schema_df(3)
+    output = tmp_path / "predictions.parquet"
+    writer = _StreamingPredictionWriter(output, schema_df)
+
+    _drive_writer(writer, [([0.1, 0.2, 0.3], [0.7, 0.6, 0.5])])
+
+    table = pq.read_table(output)
+    PredictionSchema.align(table)  # raises if non-conformant
+    df = pl.from_arrow(table)
+
+    assert df.height == 3
+    assert df["subject_id"].to_list() == [10, 11, 12]
+    # boolean_value reconstruction: censor=True → null, censor=False → occurs
+    # schema_df rows 0,1,2 have boolean_value=[F, T, F] and occurs=[T, F, F]
+    assert df["boolean_value"].to_list() == [True, None, False]
+    assert [round(x, 2) for x in df["censor_prob"].to_list()] == [0.10, 0.20, 0.30]
+    assert [round(x, 2) for x in df["occurs_prob"].to_list()] == [0.70, 0.60, 0.50]
+    assert pq.ParquetFile(output).num_row_groups == 1
+
+
+def test_streaming_writer_multi_batch_preserves_row_order_across_offset(tmp_path: Path) -> None:
+    """Multi-batch + partial-last-batch — covers the offset-tracking gap subprocess tests miss.
+
+    The CLI fixture's ``tasks.parquet`` fits in a single batch under the demo model's
+    batch_size, so the existing subprocess tests don't exercise multiple
+    ``write_on_batch_end`` calls.  This test forces 3 batches of differing sizes and
+    verifies the writer slices ``schema_df`` correctly across the boundaries.
+    """
+    schema_df = _make_schema_df(6)
+    output = tmp_path / "predictions.parquet"
+    writer = _StreamingPredictionWriter(output, schema_df)
+
+    # Three batches: 3 rows, 2 rows, 1 row (partial last batch).
+    _drive_writer(
+        writer,
+        [
+            ([0.10, 0.20, 0.30], [0.90, 0.80, 0.70]),
+            ([0.40, 0.50], [0.60, 0.55]),
+            ([0.60], [0.50]),
+        ],
+    )
+
+    df = pl.from_arrow(pq.read_table(output))
+    assert df.height == 6
+    assert df["subject_id"].to_list() == [10, 11, 12, 13, 14, 15]
+    assert [round(x, 2) for x in df["censor_prob"].to_list()] == [0.10, 0.20, 0.30, 0.40, 0.50, 0.60]
+    assert [round(x, 2) for x in df["occurs_prob"].to_list()] == [0.90, 0.80, 0.70, 0.60, 0.55, 0.50]
+    # One row group per batch — confirms streaming, not buffer-then-write.
+    assert pq.ParquetFile(output).num_row_groups == 3
+
+
+def test_streaming_writer_empty_cohort_produces_valid_empty_parquet(tmp_path: Path) -> None:
+    """Zero-row schema_df → valid PredictionSchema parquet with zero rows (matches BC)."""
+    output = tmp_path / "predictions.parquet"
+    writer = _StreamingPredictionWriter(output, _make_schema_df(0))
+
+    _drive_writer(writer, [])
+
+    assert output.exists()
+    table = pq.read_table(output)
+    PredictionSchema.align(table)
+    assert table.num_rows == 0
+
+
+def test_check_single_process_trainer_accepts_single_device() -> None:
+    """The guard is a no-op for the canonical single-device trainer config."""
+    trainer = L.Trainer(devices=1, accelerator="cpu", logger=False)
+    _check_single_process_trainer(trainer)  # no raise
+
+
+def test_check_single_process_trainer_rejects_ddp() -> None:
+    """The guard refuses any trainer whose ``world_size > 1`` (DDP / multi-device)."""
+    trainer = L.Trainer(devices=2, accelerator="cpu", strategy="ddp", logger=False)
+    with pytest.raises(RuntimeError, match=r"single-process prediction.*world_size=2"):
+        _check_single_process_trainer(trainer)


### PR DESCRIPTION
## Summary
Refactored the prediction pipeline to stream per-batch results directly to parquet instead of accumulating all predictions in memory. This eliminates memory scaling with cohort size by writing each batch as a row group immediately after prediction.

## Key Changes
- **Removed `_gather_probabilities()`**: Eliminated the function that accumulated all per-batch predictions in memory before writing to disk
- **Added `_StreamingPredictionWriter` class**: New Lightning `BasePredictionWriter` callback that:
  - Opens a parquet writer in `setup()` with the canonical schema
  - Appends one row group per batch in `write_on_batch_end()`
  - Provides idempotent `close()` for safe cleanup from both Lightning's teardown and main's finally block
  - Handles empty cohorts correctly by pre-building schema from zero-row aligned table
  - Tracks offset into `schema_df` to extract identifiers for each batch
- **Updated `main()` function**:
  - Instantiates `_StreamingPredictionWriter` and registers it as a trainer callback
  - Calls `trainer.predict()` with `return_predictions=False` so Lightning drops each batch after the writer processes it
  - Wraps prediction in try/finally to ensure writer is closed even on exceptions
  - Validates row count only on success path (partial writes are legitimate on exception paths)
  - Removed in-memory accumulation and post-hoc alignment logic

## Implementation Details
- Partial-write semantics: Python-level exceptions mid-stream still produce valid parquet with completed batches; hard kills (SIGKILL) cannot be recovered
- Correctness depends on dataloader iterating in `schema_df` row order, enforced by existing `SequentialSampler` guard
- Per-batch Float32 casting mirrors original behavior to avoid repeated f64→f32 coercion
- Added imports: `pyarrow` and `lightning.pytorch.callbacks.BasePredictionWriter`

https://claude.ai/code/session_017xxwNdPR1mzo3oZ2v4hpKf