### PR TITLE
Add save_embeddings flag to write pooled query embeddings

### DIFF
--- a/src/every_query/predict/configs/predict.yaml
+++ b/src/every_query/predict/configs/predict.yaml
@@ -39,6 +39,15 @@ split: held_out
 # same output path without this flag raises ``FileExistsError`` at startup.
 overwrite: false
 
+# Optional: also write per-row pooled query embeddings to a sibling parquet at
+# ``<output_parquet stem>.embeddings.parquet`` (e.g. ``predictions.parquet`` →
+# ``predictions.embeddings.parquet``).  The sibling carries the same TaskQuerySchema
+# identifiers as the predictions file plus a single ``embedding`` column of
+# ``fixed_size_list<float32>[hidden_size]``.  Default false.  Subject to the same
+# ``overwrite`` guard as ``output_parquet`` — re-running without ``overwrite=true``
+# raises ``FileExistsError`` at startup if the sibling already exists.
+save_embeddings: false
+
 hydra:
   output_subdir: null
   job:

--- a/src/every_query/predict/predict.py
+++ b/src/every_query/predict/predict.py
@@ -430,15 +430,13 @@ def main(cfg: DictConfig) -> None:
     logger.info(f"Wrote {out.height} predictions to {output_parquet}")
 
     if embeddings_output_parquet is not None:
-        # Prefer the runtime tensor shape (the actual data we just produced) and fall
-        # back to the model's config when there are zero batches — keeps the sidecar
-        # column typed as ``fixed_size_list<float32>[hidden_size]`` even on an empty
-        # cohort, matching the documented contract.
-        hidden_size = (
-            pred_batches[0]["query_embed"].shape[-1]
-            if pred_batches
-            else model.model.HF_model.config.hidden_size
-        )
+        # ``hidden_size`` comes from the model's own config so the sidecar's
+        # ``fixed_size_list<float32>[hidden_size]`` schema is well-defined even
+        # for a degenerate empty cohort that produces zero predict batches.
+        # The model object is already owned here (returned by ``setup_model``
+        # and passed into ``trainer.predict``), so reading the property is not
+        # additional coupling.
+        hidden_size = model.model.HF_model.config.hidden_size
         embeddings_out = identifiers.hstack(_gather_embeddings(pred_batches, hidden_size))
         embeddings_output_parquet.parent.mkdir(parents=True, exist_ok=True)
         pq.write_table(embeddings_out.to_arrow(), embeddings_output_parquet)

--- a/src/every_query/predict/predict.py
+++ b/src/every_query/predict/predict.py
@@ -38,6 +38,7 @@ from pathlib import Path
 
 import hydra
 import polars as pl
+import pyarrow as pa
 import pyarrow.parquet as pq
 import torch
 from hydra.utils import instantiate
@@ -225,6 +226,51 @@ def _gather_probabilities(pred_batches: list[dict[str, torch.Tensor]]) -> pl.Dat
     )
 
 
+_EMBEDDING_COLUMN = "embedding"
+
+
+def _gather_embeddings(pred_batches: list[dict[str, torch.Tensor]]) -> pl.DataFrame:
+    """Flatten Lightning's per-batch ``predict_step`` ``query_embed`` tensors into a one-column frame.
+
+    Mirrors :func:`_gather_probabilities`: concatenates each batch's
+    ``query_embed`` along dim 0 and returns a single-column polars frame whose
+    ``embedding`` column is backed by an arrow ``fixed_size_list<float32>[H]``,
+    where ``H`` is the model's ``hidden_size`` derived from the first batch's
+    tensor shape.  Going through ``pa.FixedSizeListArray.from_arrays`` and
+    ``pl.from_arrow`` preserves the fixed-width invariant onto the eventual
+    parquet write.
+
+    Examples:
+        Two batches of three rows each with hidden_size=4:
+
+        >>> b1 = {"query_embed": torch.arange(12, dtype=torch.float32).reshape(3, 4)}
+        >>> b2 = {"query_embed": torch.arange(12, 20, dtype=torch.float32).reshape(2, 4)}
+        >>> df = _gather_embeddings([b1, b2])
+        >>> df.height
+        5
+        >>> df.columns
+        ['embedding']
+        >>> df.to_arrow().schema.field("embedding").type
+        FixedSizeListType(fixed_size_list<item: float>[4])
+
+        Empty input round-trips as an empty list-typed frame (defensive — same
+        empty-frame pattern as ``_gather_probabilities``):
+
+        >>> _gather_embeddings([]).height
+        0
+        >>> _gather_embeddings([]).columns
+        ['embedding']
+    """
+    if not pred_batches:
+        return pl.DataFrame(schema={_EMBEDDING_COLUMN: pl.List(pl.Float32)})
+
+    embeddings = torch.cat([b["query_embed"] for b in pred_batches], dim=0)
+    hidden_size = embeddings.shape[-1]
+    flat = pa.array(embeddings.reshape(-1).numpy().astype("float32"), type=pa.float32())
+    fixed = pa.FixedSizeListArray.from_arrays(flat, hidden_size)
+    return pl.from_arrow(pa.table({_EMBEDDING_COLUMN: fixed}))
+
+
 def _identifiers_from_schema_df(schema_df: pl.DataFrame) -> pl.DataFrame:
     """Build an output identifier frame from the dataset's post-``__init__`` schema_df.
 
@@ -255,6 +301,32 @@ def _identifiers_from_schema_df(schema_df: pl.DataFrame) -> pl.DataFrame:
     return out
 
 
+def _derive_embeddings_path(output_parquet: Path) -> Path:
+    """Derive the embeddings sibling path from ``output_parquet``.
+
+    Inserts ``.embeddings`` immediately before the trailing suffix so the
+    sibling lives next to the predictions file and is easy to glob.
+
+    Examples:
+        Standard ``.parquet`` predictions path:
+
+        >>> _derive_embeddings_path(Path("/tmp/predictions.parquet"))
+        PosixPath('/tmp/predictions.embeddings.parquet')
+
+        Nested directories are preserved:
+
+        >>> _derive_embeddings_path(Path("/a/b/c/run42.parquet"))
+        PosixPath('/a/b/c/run42.embeddings.parquet')
+
+        Non-``.parquet`` suffix is preserved (defensive — the EQ_predict input
+        is always ``.parquet`` in practice, but keep the rule generic):
+
+        >>> _derive_embeddings_path(Path("predictions.pq"))
+        PosixPath('predictions.embeddings.pq')
+    """
+    return output_parquet.with_suffix(".embeddings" + output_parquet.suffix)
+
+
 _SPLIT_TO_DATAMODULE_ATTRS: dict[str, tuple[str, str]] = {
     tuning_split: ("val_dataset", "val_dataloader"),
     held_out_split: ("test_dataset", "test_dataloader"),
@@ -270,6 +342,8 @@ def main(cfg: DictConfig) -> None:
     ckpt_name = cfg.get("ckpt_name")
     split = cfg.get("split", held_out_split)
     overwrite = bool(cfg.get("overwrite", False))
+    save_embeddings = bool(cfg.get("save_embeddings", False))
+    embeddings_output_parquet = _derive_embeddings_path(output_parquet) if save_embeddings else None
 
     if split not in _SPLIT_TO_DATAMODULE_ATTRS:
         raise ValueError(
@@ -282,6 +356,13 @@ def main(cfg: DictConfig) -> None:
         raise FileExistsError(
             f"output_parquet {output_parquet} already exists.  Pass overwrite=true to replace, "
             f"or point at a new path — EQ_predict refuses to silently clobber existing output."
+        )
+
+    if embeddings_output_parquet is not None and embeddings_output_parquet.exists() and not overwrite:
+        raise FileExistsError(
+            f"embeddings sibling {embeddings_output_parquet} already exists.  Pass overwrite=true to "
+            f"replace, or point output_parquet at a new path — EQ_predict refuses to silently clobber "
+            f"existing output."
         )
 
     _validate_tasks_dir(tasks_dir)
@@ -341,6 +422,12 @@ def main(cfg: DictConfig) -> None:
     aligned = PredictionSchema.align(out.to_arrow())
     pq.write_table(aligned, output_parquet)
     logger.info(f"Wrote {out.height} predictions to {output_parquet}")
+
+    if embeddings_output_parquet is not None:
+        embeddings_out = identifiers.hstack(_gather_embeddings(pred_batches))
+        embeddings_output_parquet.parent.mkdir(parents=True, exist_ok=True)
+        pq.write_table(embeddings_out.to_arrow(), embeddings_output_parquet)
+        logger.info(f"Wrote {embeddings_out.height} embeddings to {embeddings_output_parquet}")
 
 
 if __name__ == "__main__":

--- a/src/every_query/predict/predict.py
+++ b/src/every_query/predict/predict.py
@@ -229,23 +229,26 @@ def _gather_probabilities(pred_batches: list[dict[str, torch.Tensor]]) -> pl.Dat
 _EMBEDDING_COLUMN = "embedding"
 
 
-def _gather_embeddings(pred_batches: list[dict[str, torch.Tensor]]) -> pl.DataFrame:
+def _gather_embeddings(pred_batches: list[dict[str, torch.Tensor]], hidden_size: int) -> pl.DataFrame:
     """Flatten Lightning's per-batch ``predict_step`` ``query_embed`` tensors into a one-column frame.
 
     Mirrors :func:`_gather_probabilities`: concatenates each batch's
     ``query_embed`` along dim 0 and returns a single-column polars frame whose
-    ``embedding`` column is backed by an arrow ``fixed_size_list<float32>[H]``,
-    where ``H`` is the model's ``hidden_size`` derived from the first batch's
-    tensor shape.  Going through ``pa.FixedSizeListArray.from_arrays`` and
-    ``pl.from_arrow`` preserves the fixed-width invariant onto the eventual
-    parquet write.
+    ``embedding`` column is backed by an arrow ``fixed_size_list<float32>[hidden_size]``.
+    Going through ``pa.FixedSizeListArray.from_arrays`` and ``pl.from_arrow``
+    preserves the fixed-width invariant onto the eventual parquet write.
+
+    ``hidden_size`` is required so the empty-batch case (degenerate cohort that
+    produces zero predictions) still emits a fixed-size-list-typed column on
+    disk — falling back to a variable-length ``list<float32>`` would silently
+    diverge from the documented sidecar schema.
 
     Examples:
         Two batches of three rows each with hidden_size=4:
 
         >>> b1 = {"query_embed": torch.arange(12, dtype=torch.float32).reshape(3, 4)}
         >>> b2 = {"query_embed": torch.arange(12, 20, dtype=torch.float32).reshape(2, 4)}
-        >>> df = _gather_embeddings([b1, b2])
+        >>> df = _gather_embeddings([b1, b2], hidden_size=4)
         >>> df.height
         5
         >>> df.columns
@@ -253,20 +256,23 @@ def _gather_embeddings(pred_batches: list[dict[str, torch.Tensor]]) -> pl.DataFr
         >>> df.to_arrow().schema.field("embedding").type
         FixedSizeListType(fixed_size_list<item: float>[4])
 
-        Empty input round-trips as an empty list-typed frame (defensive — same
-        empty-frame pattern as ``_gather_probabilities``):
+        Empty input still produces a fixed-size-list-typed frame so the
+        on-disk sidecar schema matches the documented contract regardless of
+        cohort size:
 
-        >>> _gather_embeddings([]).height
+        >>> empty = _gather_embeddings([], hidden_size=4)
+        >>> empty.height
         0
-        >>> _gather_embeddings([]).columns
+        >>> empty.columns
         ['embedding']
+        >>> empty.to_arrow().schema.field("embedding").type
+        FixedSizeListType(fixed_size_list<item: float>[4])
     """
-    if not pred_batches:
-        return pl.DataFrame(schema={_EMBEDDING_COLUMN: pl.List(pl.Float32)})
-
-    embeddings = torch.cat([b["query_embed"] for b in pred_batches], dim=0)
-    hidden_size = embeddings.shape[-1]
-    flat = pa.array(embeddings.reshape(-1).numpy().astype("float32"), type=pa.float32())
+    if pred_batches:
+        embeddings = torch.cat([b["query_embed"] for b in pred_batches], dim=0)
+        flat = pa.array(embeddings.reshape(-1).numpy().astype("float32"), type=pa.float32())
+    else:
+        flat = pa.array([], type=pa.float32())
     fixed = pa.FixedSizeListArray.from_arrays(flat, hidden_size)
     return pl.from_arrow(pa.table({_EMBEDDING_COLUMN: fixed}))
 
@@ -424,7 +430,16 @@ def main(cfg: DictConfig) -> None:
     logger.info(f"Wrote {out.height} predictions to {output_parquet}")
 
     if embeddings_output_parquet is not None:
-        embeddings_out = identifiers.hstack(_gather_embeddings(pred_batches))
+        # Prefer the runtime tensor shape (the actual data we just produced) and fall
+        # back to the model's config when there are zero batches — keeps the sidecar
+        # column typed as ``fixed_size_list<float32>[hidden_size]`` even on an empty
+        # cohort, matching the documented contract.
+        hidden_size = (
+            pred_batches[0]["query_embed"].shape[-1]
+            if pred_batches
+            else model.model.HF_model.config.hidden_size
+        )
+        embeddings_out = identifiers.hstack(_gather_embeddings(pred_batches, hidden_size))
         embeddings_output_parquet.parent.mkdir(parents=True, exist_ok=True)
         pq.write_table(embeddings_out.to_arrow(), embeddings_output_parquet)
         logger.info(f"Wrote {embeddings_out.height} embeddings to {embeddings_output_parquet}")

--- a/tests/test_predict_cli.py
+++ b/tests/test_predict_cli.py
@@ -20,6 +20,7 @@ from datetime import datetime
 from pathlib import Path
 
 import polars as pl
+import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 
@@ -171,4 +172,106 @@ def test_eq_predict_preserves_input_row_order(
     assert df_out["duration_days"].to_list() == expected_durations, (
         f"Output duration_days order {df_out['duration_days'].to_list()} doesn't match input "
         f"{expected_durations}"
+    )
+
+
+def test_eq_predict_save_embeddings(
+    eq_trained_model_dir: Path,
+    predict_tasks_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """``save_embeddings=true`` writes a sibling parquet with row-aligned pooled embeddings.
+
+    Covers the issue #169 acceptance: enabling the new flag produces a
+    ``<output_parquet stem>.embeddings.parquet`` sibling carrying the
+    ``TaskQuerySchema`` identifiers plus a fixed-size-list ``embedding`` column
+    whose width matches the model's ``hidden_size``.  Also verifies that the
+    sibling participates in the existing ``overwrite`` clobber-protection
+    contract.
+    """
+    output_parquet = tmp_path / "predictions.parquet"
+    embeddings_parquet = output_parquet.with_suffix(".embeddings" + output_parquet.suffix)
+
+    env = os.environ.copy()
+    env["PATH"] = _VENV_BIN + os.pathsep + env.get("PATH", "")
+
+    cmd = [
+        "EQ_predict",
+        f"model_run_dir={eq_trained_model_dir}",
+        f"tasks_dir={predict_tasks_dir}",
+        f"output_parquet={output_parquet}",
+        "save_embeddings=true",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env, timeout=300)
+    assert result.returncode == 0, (
+        f"EQ_predict failed (rc={result.returncode})\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+    # Predictions branch is unchanged — sanity-check it still landed.
+    assert output_parquet.exists(), "predictions parquet was not written"
+    PredictionSchema.align(pq.read_table(output_parquet))
+
+    # Embeddings sibling lives next to predictions at the derived path.
+    assert embeddings_parquet.exists(), (
+        f"embeddings sibling not found at {embeddings_parquet}; got dir contents: "
+        f"{sorted(p.name for p in tmp_path.iterdir())}"
+    )
+
+    emb_table = pq.read_table(embeddings_parquet)
+    schema = emb_table.schema
+
+    # TaskQuerySchema identifier columns are present.
+    expected_id_cols = {
+        TaskQuerySchema.subject_id_name,
+        TaskQuerySchema.prediction_time_name,
+        TaskQuerySchema.query_name,
+        TaskQuerySchema.duration_days_name,
+    }
+    assert expected_id_cols.issubset(set(schema.names)), (
+        f"embeddings parquet missing identifier columns; got {schema.names}"
+    )
+
+    # The ``embedding`` column is a fixed-size-list of float32 with width > 0
+    # (the demo model's hidden_size is implementation detail; assert the
+    # invariant, not the constant).
+    assert "embedding" in schema.names, f"embeddings parquet missing 'embedding' column; got {schema.names}"
+    emb_type = schema.field("embedding").type
+    assert pa.types.is_fixed_size_list(emb_type), (
+        f"embedding column must be a fixed-size-list, got {emb_type!r}"
+    )
+    assert pa.types.is_float32(emb_type.value_type), (
+        f"embedding column inner type must be float32, got {emb_type.value_type!r}"
+    )
+    assert emb_type.list_size > 0, f"embedding hidden_size must be > 0, got {emb_type.list_size}"
+
+    # Row count matches the input task count, and identifier columns match the
+    # predictions parquet row-for-row (same `_identifiers_from_schema_df` source).
+    pred_df = pl.from_arrow(pq.read_table(output_parquet))
+    emb_df = pl.from_arrow(emb_table)
+    assert emb_df.height == pred_df.height, (
+        f"embeddings row count {emb_df.height} != predictions row count {pred_df.height}"
+    )
+    for col in (
+        TaskQuerySchema.subject_id_name,
+        TaskQuerySchema.prediction_time_name,
+        TaskQuerySchema.query_name,
+        TaskQuerySchema.duration_days_name,
+    ):
+        assert emb_df[col].to_list() == pred_df[col].to_list(), (
+            f"embeddings {col} ordering doesn't match predictions {col}"
+        )
+
+    # Embeddings sibling participates in the clobber-protection contract.  The
+    # predictions check fires first when both files exist, so to isolate the
+    # embeddings check we remove predictions and re-run — embeddings should now
+    # be the file that blocks the run.
+    output_parquet.unlink()
+    assert embeddings_parquet.exists(), "embeddings sibling unexpectedly missing for clobber test"
+    rerun = subprocess.run(cmd, capture_output=True, text=True, env=env, timeout=300)
+    assert rerun.returncode != 0, "expected re-run to fail (no overwrite=true) but it succeeded"
+    assert "FileExistsError" in rerun.stderr, (
+        f"expected FileExistsError in stderr, got:\nstdout:\n{rerun.stdout}\nstderr:\n{rerun.stderr}"
+    )
+    assert str(embeddings_parquet) in rerun.stderr, (
+        f"expected embeddings path in stderr, got:\nstderr:\n{rerun.stderr}"
     )


### PR DESCRIPTION
## Summary
Adds a new `save_embeddings` configuration flag to the EQ_predict CLI that enables writing per-row pooled query embeddings to a sibling parquet file alongside the predictions output.

## Key Changes
- **New `save_embeddings` config flag** in `predict.yaml`: Optional boolean (default `false`) that controls whether embeddings are written to a sibling parquet file
- **`_gather_embeddings()` function**: Concatenates per-batch `query_embed` tensors from Lightning's `predict_step` and returns a polars DataFrame with a fixed-size-list column backed by PyArrow, preserving the fixed-width invariant through parquet serialization
- **`_derive_embeddings_path()` function**: Derives the embeddings sibling path by inserting `.embeddings` before the file suffix (e.g., `predictions.parquet` → `predictions.embeddings.parquet`)
- **Embeddings file protection**: The embeddings sibling participates in the existing `overwrite` guard — attempting to re-run without `overwrite=true` raises `FileExistsError` if the embeddings file already exists
- **Output format**: The embeddings parquet contains TaskQuerySchema identifier columns (subject_id, prediction_time, query, duration_days) plus an `embedding` column of type `fixed_size_list<float32>[hidden_size]`
- **Comprehensive test coverage**: New `test_eq_predict_save_embeddings()` test validates file creation, schema correctness, row alignment with predictions, and clobber-protection behavior

## Implementation Details
- Uses PyArrow's `FixedSizeListArray.from_arrays()` to construct the fixed-size embedding column, ensuring the width invariant is preserved through parquet writes
- Embeddings are row-aligned with predictions via the shared `identifiers` frame source
- The embeddings file is only written if `save_embeddings=true`; the predictions output is unaffected by this flag

https://claude.ai/code/session_01H9uM1WaMuZxgwd2qkKtwjr