### PR TITLE
Add prevalence metric to evaluation output

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,7 +194,7 @@ EQ_evaluate \
 	metrics_parquet="$OUTPUT_DIR/metrics.parquet"
 ```
 
-Per-`(query, duration_days)` metrics from the predictions parquet — `n_rows`, `n_occurs_labeled`, `n_positive`, `occurs_auroc` (on non-censored rows), `censor_auroc`. See [`evaluate/README.md`](src/every_query/evaluate/README.md).
+Per-`(query, duration_days)` metrics from the predictions parquet — `n_rows`, `n_occurs_labeled`, `n_positive`, `prevalence`, `occurs_auroc` (on non-censored rows), `censor_auroc`. See [`evaluate/README.md`](src/every_query/evaluate/README.md).
 
 ## Configuration
 

--- a/src/every_query/evaluate/README.md
+++ b/src/every_query/evaluate/README.md
@@ -16,7 +16,8 @@ comparison (what the old `EQ_select_model` did) moves to `paper_experiments/lead
 predict/ predictions.parquet  ──►  EQ_evaluate  ──►  metrics.parquet
 (PredictionSchema)                                  (per-(query, duration_days): n_rows,
                                                      n_occurs_labeled, n_positive,
-                                                     occurs_auroc, censor_auroc)
+                                                     occurs_auroc, censor_auroc,
+                                                     prevalence)
 ```
 
 ```bash

--- a/src/every_query/evaluate/configs/evaluate.yaml
+++ b/src/every_query/evaluate/configs/evaluate.yaml
@@ -11,7 +11,7 @@ defaults:
 predictions_parquet: ???
 
 # Required: output metrics parquet path.  One row per (query, duration_days) group
-# with columns: n_rows, n_occurs_labeled, n_positive, occurs_auroc, censor_auroc.
+# with columns: n_rows, n_occurs_labeled, n_positive, prevalence, occurs_auroc, censor_auroc.
 metrics_parquet: ???
 
 hydra:

--- a/src/every_query/evaluate/metrics.py
+++ b/src/every_query/evaluate/metrics.py
@@ -49,6 +49,10 @@ def _metrics_for_group(group_df: pl.DataFrame) -> dict[str, float | int | None]:
       (``None`` if all labels are the same class, or if every row is censored).
     - ``censor_auroc`` — AUROC of ``censor_prob`` vs. ``is_censored`` over all rows
       (``None`` if every row has the same censor status).
+
+    The ``prevalence`` column is not computed here — :func:`compute_metrics` derives it
+    on the assembled frame as ``n_positive / n_occurs_labeled`` (null when
+    ``n_occurs_labeled == 0``).
     """
     is_censored = group_df[TaskQuerySchema.boolean_value_name].is_null().to_list()
     censor_prob = group_df[PredictionSchema.censor_prob_name].to_list()
@@ -79,7 +83,10 @@ def compute_metrics(predictions: pl.DataFrame) -> pl.DataFrame:
     """Group :class:`PredictionSchema`-shaped rows by ``(query, duration_days)`` and compute metrics.
 
     Returns a dataframe with columns ``query``, ``duration_days``, ``n_rows``,
-    ``n_occurs_labeled``, ``n_positive``, ``occurs_auroc``, ``censor_auroc``.
+    ``n_occurs_labeled``, ``n_positive``, ``occurs_auroc``, ``censor_auroc``,
+    ``prevalence``.  ``prevalence`` is the positive rate among non-censored rows
+    (``n_positive / n_occurs_labeled``, null when ``n_occurs_labeled == 0``); its
+    denominator matches ``occurs_auroc``'s, so the two metrics are over the same cohort.
 
     Raises:
         ValueError: if ``predictions`` is missing any of the required input columns.
@@ -87,9 +94,10 @@ def compute_metrics(predictions: pl.DataFrame) -> pl.DataFrame:
     Examples:
         Two queries over two durations, censored rows mixed in via null
         ``boolean_value``.  Query ``A`` at duration 30 has two labeled rows with
-        differing labels (AUROC defined).  Query ``B`` at duration 30 has two labeled
-        rows both positive (AUROC undefined, null).  Every row has a censor probability,
-        so the censor AUROC is computed across the entire group.
+        differing labels (AUROC defined; prevalence 0.5).  Query ``B`` at duration 30
+        has two labeled rows both positive (AUROC undefined, null; prevalence 1.0).
+        Every row has a censor probability, so the censor AUROC is computed across
+        the entire group.
 
         >>> import polars as pl
         >>> preds = pl.DataFrame({
@@ -104,9 +112,10 @@ def compute_metrics(predictions: pl.DataFrame) -> pl.DataFrame:
         >>> out = compute_metrics(preds).sort("query")
         >>> for row in out.iter_rows(named=True):
         ...     print(f"{row['query']} n={row['n_rows']} pos={row['n_positive']} "
+        ...           f"prevalence={row['prevalence']} "
         ...           f"occurs_auroc={row['occurs_auroc']} censor_auroc={row['censor_auroc']}")
-        A n=3 pos=1 occurs_auroc=1.0 censor_auroc=1.0
-        B n=3 pos=2 occurs_auroc=None censor_auroc=1.0
+        A n=3 pos=1 prevalence=0.5 occurs_auroc=1.0 censor_auroc=1.0
+        B n=3 pos=2 prevalence=1.0 occurs_auroc=None censor_auroc=1.0
         >>> out["duration_days"].dtype
         Float32
 
@@ -118,7 +127,7 @@ def compute_metrics(predictions: pl.DataFrame) -> pl.DataFrame:
         ...     "censor_prob": pl.Float32, "occurs_prob": pl.Float32,
         ... })
         >>> compute_metrics(empty).shape
-        (0, 7)
+        (0, 8)
     """
     required = {
         TaskQuerySchema.query_name,
@@ -157,14 +166,22 @@ def compute_metrics(predictions: pl.DataFrame) -> pl.DataFrame:
                 "n_positive": pl.Int64,
                 "occurs_auroc": pl.Float64,
                 "censor_auroc": pl.Float64,
+                "prevalence": pl.Float64,
             }
         )
     # Cast the AUROC columns to Float64 explicitly — when every group has null AUROCs
     # (e.g. all single-class, or every row censored), polars would otherwise infer
     # Null dtype for those columns, producing an unstable on-disk schema where parquet
     # files from different runs have different types for the same logical column.
+    # Derive prevalence from the per-group counts so it can never drift from the
+    # n_positive / n_occurs_labeled it's defined against; null when no labeled rows.
     return pl.DataFrame(rows).with_columns(
         pl.col(TaskQuerySchema.duration_days_name).cast(pl.Float32),
         pl.col("occurs_auroc").cast(pl.Float64),
         pl.col("censor_auroc").cast(pl.Float64),
+        pl.when(pl.col("n_occurs_labeled") > 0)
+        .then(pl.col("n_positive") / pl.col("n_occurs_labeled"))
+        .otherwise(None)
+        .cast(pl.Float64)
+        .alias("prevalence"),
     )

--- a/tests/test_evaluate_cli.py
+++ b/tests/test_evaluate_cli.py
@@ -92,6 +92,7 @@ def test_evaluate_end_to_end(tmp_path: Path) -> None:
         "n_positive",
         "occurs_auroc",
         "censor_auroc",
+        "prevalence",
     }
     rows = metrics.to_dicts()
     # Query "A" has a mixed-label labeled subset ([True, False]), so occurs_auroc is defined (1.0).
@@ -103,3 +104,7 @@ def test_evaluate_end_to_end(tmp_path: Path) -> None:
     # Censor AUROC is defined for both groups (censor_prob correctly ranks censored rows higher).
     assert rows[0]["censor_auroc"] == 1.0
     assert rows[1]["censor_auroc"] == 1.0
+    # Prevalence is n_positive / n_occurs_labeled: A has 1 positive of 2 labeled (0.5),
+    # B has 2 positives of 2 labeled (1.0).
+    assert rows[0]["prevalence"] == 0.5
+    assert rows[1]["prevalence"] == 1.0


### PR DESCRIPTION
## Summary
This PR adds a `prevalence` metric to the evaluation pipeline, computing the positive rate among labeled (non-censored) rows for each query-duration group.

## Key Changes
- **New metric column**: Added `prevalence` to `compute_metrics()` output, calculated as `n_positive / n_occurs_labeled`
  - Returns `null` when `n_occurs_labeled == 0` (no labeled rows in group)
  - Denominator matches `occurs_auroc`, ensuring both metrics are computed over the same cohort
  
- **Documentation updates**:
  - Updated `_metrics_for_group()` docstring to clarify that `prevalence` is not computed at the group level but derived in `compute_metrics()`
  - Updated `compute_metrics()` docstring with detailed explanation of prevalence definition and its relationship to `occurs_auroc`
  - Updated example output to show prevalence values (0.5 for mixed labels, 1.0 for all positive)
  - Updated README diagram to include `prevalence` in output schema
  - Updated empty dataframe shape assertion from 7 to 8 columns

- **Implementation**:
  - Prevalence is derived using Polars conditional expression after assembling the metrics dataframe
  - Explicitly cast to `Float64` for schema stability (consistent with AUROC columns)
  - Prevents drift between prevalence and its definition by computing from the same `n_positive` and `n_occurs_labeled` counts

- **Tests**: Added assertions validating prevalence values (0.5 and 1.0) for the two test query groups

https://claude.ai/code/session_0175oiu2QVBY2rMzP91NJ8DE