### PR TITLE
Add query code filtering for training tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,22 @@ Sweep across shards with
 `python -m every_query.generate_tasks.sample_tasks -m input_shard=0,1,2,… task_shard=range(0,K)`.
 Each worker writes labeled task parquets under `$TASK_DIR/{split}/*.parquet` idempotently. Output columns conform to [`TaskQuerySchema`](src/every_query/data/schema.py) — `subject_id, prediction_time, query, duration_days, boolean_value` — where `boolean_value` is a nullable three-valued label (`null` = censored, `True` = event occurred in `[prediction_time, prediction_time + duration_days)`, `False` = observed-but-no-event).
 
+`query_codes=` is optional for training. Leave it unset/null to sample query codes from
+`$PROCESSED/metadata/codes.parquet`, or set it to an inline list / YAML path to restrict which
+codes can be sampled as queries. YAML files may be a flat list or a mapping with a `codes:`
+key. This does not remove codes from patient histories.
+
+```bash
+EQ_generate_training_tasks query_codes=/path/to/train_query_codes.yaml …
+```
+
+```yaml
+# train_query_codes.yaml
+codes:
+  - HR
+  - TEMP
+```
+
 ### 2b. Generate evaluation task labels
 
 ```bash

--- a/conftest.py
+++ b/conftest.py
@@ -182,8 +182,8 @@ def eq_preprocessed_dataset(simple_static_MEDS: Path, tmp_path_factory: pytest.T
     """Runs ``EQ_process_data do_demo=True`` against ``simple_static_MEDS``.
 
     Returns the tensorized-cohort output dir (``final/``), ready to feed into
-    ``EQ_generate_training_tasks`` and ``EQ_train`` as ``codes_dir`` and ``tensorized_cohort_dir``
-    respectively.
+    ``EQ_generate_training_tasks`` and ``EQ_train`` as ``$PROCESSED`` and
+    ``tensorized_cohort_dir`` respectively.
 
     Sibling ``intermediate/`` dir is also produced (needed as ``data_dir`` for
     ``EQ_generate_training_tasks``) and stored alongside ``final/`` — callers can reach it via
@@ -236,7 +236,6 @@ def eq_sampled_tasks_dir(eq_preprocessed_dataset: Path, tmp_path_factory: pytest
             [
                 "EQ_generate_training_tasks",
                 f"data_dir={intermediate!s}",
-                f"codes_dir={eq_preprocessed_dataset!s}",
                 f"out_dir={out_dir!s}",
                 f"split={split}",
                 "input_shard=0",
@@ -248,6 +247,7 @@ def eq_sampled_tasks_dir(eq_preprocessed_dataset: Path, tmp_path_factory: pytest
                 "min_context_per_subject=1",
                 "seed=1",
             ],
+            env={"PROCESSED": str(eq_preprocessed_dataset)},
             timeout=120.0,
         )
 

--- a/src/every_query/generate_tasks/README.md
+++ b/src/every_query/generate_tasks/README.md
@@ -40,8 +40,8 @@ Both endpoints consume:
 
 1. Event shards at `$INTERMEDIATE/data/{split}/*.parquet` (from
     [`preprocessing/`](../preprocessing/)).
-2. The query-code universe at `$PROCESSED/metadata/codes.parquet` — or an
-    explicit `codes: [...]` override on the CLI.
+2. The query-code universe at `$PROCESSED/metadata/codes.parquet` — or a CLI override:
+    `query_codes=...` for training, `codes=...` for evaluation.
 
 Training-task outputs land at `$TASK_DIR/{split}/*.parquet`; evaluation-task
 outputs land at `$TASK_DIR/eval/{split}/*.parquet`. The separate `eval/`
@@ -53,6 +53,13 @@ subdirectory keeps the two row distributions from colliding in one directory.
 # Pretraining tasks (random tasks × random contexts):
 python -m every_query.generate_tasks.sample_tasks -m \
     input_shard=0,1,2,... task_shard=range(0,K)
+
+# Restrict sampled training queries to a YAML code list:
+python -m every_query.generate_tasks.sample_tasks -m \
+    input_shard=0,1,2,... task_shard=range(0,K) \
+    query_codes=/path/to/train_query_codes.yaml
+
+# `train_query_codes.yaml` may be either a flat list or `{codes: [...]}`.
 
 # Evaluation tasks (dense grid over the held-out cohort):
 python -m every_query.generate_tasks.sample_evaluation_tasks -m \

--- a/src/every_query/generate_tasks/configs/sample_tasks_config.yaml
+++ b/src/every_query/generate_tasks/configs/sample_tasks_config.yaml
@@ -7,15 +7,20 @@
 # env-var fallback, matching the repo convention where `.env` holds machine-specific paths
 # (see `.env.example`, `tasks.py`, and `_env.py`).  Fallbacks:
 #   data_dir  -> $INTERMEDIATE   (event shards live under `{data_dir}/data/{split}/*.parquet`)
-#   codes_dir -> $PROCESSED      (query universe lives under `{codes_dir}/metadata/codes.parquet`)
 #   out_dir   -> $TASK_DIR       (labeled shards land here as {split}/*.parquet;
 #                                 no sidecars, no cache — this dir is consumable as
 #                                 MTD's task_labels_dir directly)
-# Tests can inject values directly with `data_dir=/path out_dir=/path codes_dir=/path`.
+# Query-code fallback:
+#   query_codes: null -> $PROCESSED/metadata/codes.parquet
+# Tests can inject path roots directly with `data_dir=/path out_dir=/path`.
 
 data_dir: null
-codes_dir: null
 out_dir: null
+
+# Query-code sampling universe.  Leave null to load the full vocabulary from
+# `$PROCESSED/metadata/codes.parquet`, or pass either an explicit Hydra list
+# (`query_codes=[HR,TEMP]`) or a YAML file containing a flat list / `{codes: [...]}`.
+query_codes: null
 
 split: train
 input_shard: "0" # basename (without .parquet) of the MEDS shard for this worker

--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -393,11 +393,12 @@ def _read_event_shard(file_path: str | Path) -> pl.DataFrame:
     )
 
 
-def read_query_codes(codes_or_path: list[str] | ListConfig | str | Path) -> list[str]:
-    """Resolve a query-code list — from an explicit CLI list, a metadata dir, or a codes parquet.
+def read_query_codes(codes_or_path: list[str] | ListConfig | str | Path | None) -> list[str]:
+    """Resolve a query-code list — from default metadata, an explicit list, or a file path.
 
     Accepts:
-    - an explicit list (from Hydra ``codes: [A, B, C]`` or a code-group YAML default),
+    - ``None`` (load ``$PROCESSED/metadata/codes.parquet``),
+    - an explicit list (from Hydra ``query_codes: [A, B, C]`` or a code-group YAML default),
     - a metadata root directory (``codes.parquet`` is expected at ``{dir}/metadata/codes.parquet``
       — matches the ``$PROCESSED`` layout), or
     - a direct path to a ``codes.parquet`` file.
@@ -415,14 +416,25 @@ def read_query_codes(codes_or_path: list[str] | ListConfig | str | Path) -> list
         seen: set[str] = set()
         return [c for c in codes_or_path if not (c in seen or seen.add(c))]
     if codes_or_path is None:
-        raise ValueError("codes must be a list of query codes or a path to codes.parquet")
-    p = Path(str(codes_or_path))
+        processed = os.environ.get("PROCESSED")
+        if not processed:
+            raise ValueError(
+                "query_codes is null and $PROCESSED is not set; pass query_codes=... or export "
+                "$PROCESSED so the sampler can read $PROCESSED/metadata/codes.parquet."
+            )
+        p = Path(processed)
+    else:
+        p = Path(str(codes_or_path))
     if p.suffix in {".yaml", ".yml"}:
         import yaml
 
         with open(p) as f:
             data = yaml.safe_load(f)
-        raw = data["codes"] if isinstance(data, dict) else data
+        raw = data["codes"] if isinstance(data, dict) and "codes" in data else data
+        if raw is None:
+            raise ValueError(f"{p} must contain a YAML list or a mapping with a `codes` key")
+        if not isinstance(raw, list | ListConfig):
+            raise ValueError(f"{p} must contain a list of codes, got {type(raw).__name__}")
         seen: set[str] = set()
         return [c for c in raw if not (c in seen or seen.add(c))]
     if p.is_dir():
@@ -474,7 +486,7 @@ def _labels_fp(out_dir: Path, split: str, input_shard: str, task_shard: int) -> 
 def run_worker(
     data_dir: Path,
     out_dir: Path,
-    codes_dir: Path,
+    query_codes: list[str],
     split: str,
     input_shard: str,
     task_shard: int,
@@ -488,7 +500,7 @@ def run_worker(
 ) -> Path | None:
     """Run the three-stage sampling pipeline for one worker in-memory.
 
-    The worker is a pure function of ``(data_dir, codes_dir, config, seed, split, input_shard,
+    The worker is a pure function of ``(data_dir, query_codes, config, seed, split, input_shard,
     task_shard)`` — no per-stage checkpoints on disk, no meta sidecar, no cache-validation
     protocol.  Determinism comes from :func:`derive_seed` separating the task and context
     axes; a rerun with identical inputs produces identical labels.
@@ -503,7 +515,6 @@ def run_worker(
         logger.info("Labels already exist at %s, skipping.", labels_fp)
         return None
 
-    query_codes = read_query_codes(codes_dir)
     tasks_seed = derive_seed(seed, "tasks", task_shard)
     tasks = sample_tasks(
         n=n_tasks,
@@ -546,7 +557,7 @@ def run_worker(
 def _resolve_path(cfg_value: str | None, env_var: str, name: str) -> Path:
     """Prefer an explicit cfg value; fall back to ``$env_var``; otherwise raise.
 
-    Used by ``main`` to resolve the three path roots (``data_dir``, ``out_dir``, ``codes_dir``).
+    Used by ``main`` to resolve path roots such as ``data_dir`` and ``out_dir``.
     Factored out so tests can exercise the fallback matrix without spinning up a full Hydra run.
     """
     if cfg_value is not None:
@@ -570,7 +581,8 @@ def main(cfg: DictConfig) -> None:
     Loads ``.env`` via python-dotenv before resolving paths, following the repo convention where
     ``$INTERMEDIATE`` / ``$PROCESSED`` / ``$TASK_DIR`` live in a gitignored ``.env`` file rather
     than being exported by the user.  Path fallbacks: ``cfg.data_dir`` falls back to
-    ``$INTERMEDIATE``, ``cfg.codes_dir`` to ``$PROCESSED``, ``cfg.out_dir`` to ``$TASK_DIR``.
+    ``$INTERMEDIATE`` and ``cfg.out_dir`` to ``$TASK_DIR``.  Query codes are resolved by
+    :func:`read_query_codes`, which falls back to ``$PROCESSED`` when ``cfg.query_codes`` is null.
 
     See :func:`run_worker` for the per-worker pipeline.
     """
@@ -582,12 +594,12 @@ def main(cfg: DictConfig) -> None:
 
     data_dir = _resolve_path(cfg.get("data_dir"), "INTERMEDIATE", "data_dir")
     out_dir = _resolve_path(cfg.get("out_dir"), "TASK_DIR", "out_dir")
-    codes_dir = _resolve_path(cfg.get("codes_dir"), "PROCESSED", "codes_dir")
+    query_codes = read_query_codes(cfg.get("query_codes"))
 
     run_worker(
         data_dir=data_dir,
         out_dir=out_dir,
-        codes_dir=codes_dir,
+        query_codes=query_codes,
         split=str(cfg.split),
         input_shard=str(cfg.input_shard),
         task_shard=int(cfg.task_shard),

--- a/tests/test_generate_tasks.py
+++ b/tests/test_generate_tasks.py
@@ -172,7 +172,6 @@ def test_reproducible_with_same_seed(
         [
             "EQ_generate_training_tasks",
             f"data_dir={intermediate!s}",
-            f"codes_dir={eq_preprocessed_dataset!s}",
             f"out_dir={rerun_out!s}",
             "split=train",
             "input_shard=0",
@@ -184,6 +183,7 @@ def test_reproducible_with_same_seed(
             f"min_context_per_subject={_MIN_CONTEXT_PER_SUBJECT}",
             "seed=1",
         ],
+        env={"PROCESSED": str(eq_preprocessed_dataset)},
         timeout=120.0,
     )
 
@@ -230,7 +230,6 @@ def test_n_tasks_knob_is_honored(
         [
             "EQ_generate_training_tasks",
             f"data_dir={intermediate!s}",
-            f"codes_dir={eq_preprocessed_dataset!s}",
             f"out_dir={big_out!s}",
             "split=train",
             "input_shard=0",
@@ -242,6 +241,7 @@ def test_n_tasks_knob_is_honored(
             f"min_context_per_subject={_MIN_CONTEXT_PER_SUBJECT}",
             "seed=1",  # same seed as the fixture; only n_tasks differs
         ],
+        env={"PROCESSED": str(eq_preprocessed_dataset)},
         timeout=120.0,
     )
 

--- a/tests/test_sample_tasks.py
+++ b/tests/test_sample_tasks.py
@@ -102,6 +102,53 @@ class TestPrimitives:
         with pytest.raises(ValueError):
             sample_tasks(5, synthetic_query_codes, 100, 50, seed=0)
 
+    def test_read_query_codes_uses_processed_fallback(
+        self, monkeypatch, tmp_path, synthetic_query_codes
+    ):
+        processed = tmp_path / "processed"
+        metadata_dir = processed / "metadata"
+        metadata_dir.mkdir(parents=True)
+        pl.DataFrame({"code": synthetic_query_codes}).write_parquet(metadata_dir / "codes.parquet")
+
+        monkeypatch.setenv("PROCESSED", str(processed))
+
+        assert st.read_query_codes(None) == sorted(synthetic_query_codes)
+
+    def test_read_query_codes_requires_processed_when_null(self, monkeypatch):
+        monkeypatch.delenv("PROCESSED", raising=False)
+
+        with pytest.raises(ValueError, match="query_codes is null"):
+            st.read_query_codes(None)
+
+    def test_read_query_codes_reads_codes_key_yaml(self, tmp_path):
+        codes_yaml = tmp_path / "allowed_codes.yaml"
+        codes_yaml.write_text("codes:\n  - A\n  - B\n  - A\n")
+
+        assert st.read_query_codes(codes_yaml) == ["A", "B"]
+
+    def test_read_query_codes_reads_flat_yaml_list(self, tmp_path):
+        codes_yaml = tmp_path / "allowed_codes.yaml"
+        codes_yaml.write_text("- A\n- B\n- A\n")
+
+        assert st.read_query_codes(codes_yaml) == ["A", "B"]
+
+    def test_read_query_codes_rejects_yaml_mapping_without_codes(self, tmp_path):
+        codes_yaml = tmp_path / "allowed_codes.yaml"
+        codes_yaml.write_text("query_codes:\n  - A\n  - B\n")
+
+        with pytest.raises(ValueError, match="list of codes"):
+            st.read_query_codes(codes_yaml)
+
+    def test_read_query_codes_rejects_non_list_yaml(self, tmp_path):
+        codes_yaml = tmp_path / "allowed_codes.yaml"
+        codes_yaml.write_text("codes: A\n")
+
+        with pytest.raises(ValueError, match="list of codes"):
+            st.read_query_codes(codes_yaml)
+
+    def test_read_query_codes_deduplicates_inline_list(self):
+        assert st.read_query_codes(["A", "B", "A"]) == ["A", "B"]
+
     def test_sample_contexts_returns_exactly_n_rows(self, synthetic_events):
         # Each subject has 30 events, min_context=5 leaves 26 candidates per subject.
         contexts = sample_contexts(synthetic_events, n=50, min_context_per_subject=5, seed=1)
@@ -384,20 +431,21 @@ def _write_fake_cohort(
     directories rather than the same root, so the cohort this helper writes uses:
 
         {data_dir}/data/{split}/{shard_name}.parquet     <- event shards ($INTERMEDIATE)
-        {codes_dir}/metadata/codes.parquet               <- query universe ($PROCESSED)
+        {processed_dir}/metadata/codes.parquet           <- query universe ($PROCESSED)
 
-    Returns ``(data_dir, codes_dir)`` as two distinct paths so the tests exercise the separation.
+    Returns ``(data_dir, processed_dir)`` as two distinct paths so tests can exercise the
+    separation.
     """
     data_dir = tmp_path / "intermediate"
     split_dir = data_dir / "data" / split
     split_dir.mkdir(parents=True, exist_ok=True)
     events.write_parquet(split_dir / f"{shard_name}.parquet")
 
-    codes_dir = tmp_path / "processed"
-    metadata_dir = codes_dir / "metadata"
+    processed_dir = tmp_path / "processed"
+    metadata_dir = processed_dir / "metadata"
     metadata_dir.mkdir(parents=True, exist_ok=True)
     pl.DataFrame({"code": query_codes}).write_parquet(metadata_dir / "codes.parquet")
-    return data_dir, codes_dir
+    return data_dir, processed_dir
 
 
 class TestRunWorkerPipeline:
@@ -409,11 +457,11 @@ class TestRunWorkerPipeline:
         labels) was silently globbed as a task-label by MTD downstream, breaking training.
         Catching any future re-introduction of intermediate artifacts alongside labels.
         """
-        data_dir, codes_dir = _write_fake_cohort(tmp_path, synthetic_events, synthetic_query_codes)
+        data_dir, _ = _write_fake_cohort(tmp_path, synthetic_events, synthetic_query_codes)
         out_dir = tmp_path / "out"
         labels_fp = run_worker(
             data_dir=data_dir,
-            codes_dir=codes_dir,
+            query_codes=synthetic_query_codes,
             out_dir=out_dir,
             split="train",
             input_shard="0",
@@ -439,11 +487,11 @@ class TestRunWorkerPipeline:
 
     def test_rerun_is_idempotent_noop(self, tmp_path, synthetic_events, synthetic_query_codes):
         """Second invocation with identical args returns ``None`` and leaves outputs untouched."""
-        data_dir, codes_dir = _write_fake_cohort(tmp_path, synthetic_events, synthetic_query_codes)
+        data_dir, _ = _write_fake_cohort(tmp_path, synthetic_events, synthetic_query_codes)
         out_dir = tmp_path / "out"
         kwargs = {
             "data_dir": data_dir,
-            "codes_dir": codes_dir,
+            "query_codes": synthetic_query_codes,
             "out_dir": out_dir,
             "split": "train",
             "input_shard": "0",
@@ -476,11 +524,11 @@ class TestRunWorkerPipeline:
         ``overwrite=True`` when they've changed sampling parameters.  See the
         ``test_stale_labels_on_config_change_without_overwrite`` guard below.
         """
-        data_dir, codes_dir = _write_fake_cohort(tmp_path, synthetic_events, synthetic_query_codes)
+        data_dir, _ = _write_fake_cohort(tmp_path, synthetic_events, synthetic_query_codes)
         out_dir = tmp_path / "out"
         kwargs = {
             "data_dir": data_dir,
-            "codes_dir": codes_dir,
+            "query_codes": synthetic_query_codes,
             "out_dir": out_dir,
             "split": "train",
             "input_shard": "0",
@@ -515,11 +563,11 @@ class TestRunWorkerPipeline:
         ``(query, duration_days)`` multiset — that's the full surface of what "tasks" means
         downstream.
         """
-        data_dir, codes_dir = _write_fake_cohort(tmp_path, synthetic_events, synthetic_query_codes)
+        data_dir, _ = _write_fake_cohort(tmp_path, synthetic_events, synthetic_query_codes)
         out_dir = tmp_path / "out"
         kwargs = {
             "data_dir": data_dir,
-            "codes_dir": codes_dir,
+            "query_codes": synthetic_query_codes,
             "out_dir": out_dir,
             "split": "train",
             "input_shard": "0",
@@ -548,7 +596,7 @@ class TestRunWorkerPipeline:
         each shard's worker draws independent contexts (otherwise parallelism across shards
         would be statistically wasteful).
         """
-        data_dir, codes_dir = _write_fake_cohort(
+        data_dir, _ = _write_fake_cohort(
             tmp_path, synthetic_events, synthetic_query_codes, shard_name="0"
         )
         # Write a second shard with the same events under a different basename so run_worker has
@@ -560,7 +608,7 @@ class TestRunWorkerPipeline:
         out_dir = tmp_path / "out"
         kwargs = {
             "data_dir": data_dir,
-            "codes_dir": codes_dir,
+            "query_codes": synthetic_query_codes,
             "out_dir": out_dir,
             "split": "train",
             "task_shard": 0,
@@ -604,11 +652,11 @@ class TestRunWorkerPipeline:
         This test pins that behavior so a future reviewer sees the tradeoff explicitly rather than
         discovering it via surprise in production.
         """
-        data_dir, codes_dir = _write_fake_cohort(tmp_path, synthetic_events, synthetic_query_codes)
+        data_dir, _ = _write_fake_cohort(tmp_path, synthetic_events, synthetic_query_codes)
         out_dir = tmp_path / "out"
         kwargs = {
             "data_dir": data_dir,
-            "codes_dir": codes_dir,
+            "query_codes": synthetic_query_codes,
             "out_dir": out_dir,
             "split": "train",
             "input_shard": "0",
@@ -635,23 +683,26 @@ class TestRunWorkerPipeline:
         assert regenerated is not None
         assert pl.read_parquet(regenerated).height == 32
 
-    def test_codes_dir_is_read_from_a_distinct_root(self, tmp_path, synthetic_events, synthetic_query_codes):
-        """Smoke test that codes_dir is actually read *from* codes_dir, not data_dir.
+    def test_processed_env_fallback_is_read_from_a_distinct_root(
+        self, monkeypatch, tmp_path, synthetic_events, synthetic_query_codes
+    ):
+        """Smoke test that query-code fallback reads from $PROCESSED, not data_dir.
 
         The ``.env.example`` layout has ``$INTERMEDIATE`` (event shards) and ``$PROCESSED``
         (metadata/codes.parquet) as sibling directories; the sampler must not conflate them.
-        ``_write_fake_cohort`` writes codes.parquet *only* under ``codes_dir`` — so if
-        ``run_worker`` were still reading codes from ``data_dir`` it would raise ``FileNotFoundError``.
+        ``_write_fake_cohort`` writes codes.parquet *only* under the processed dir — so if
+        ``read_query_codes(None)`` were reading from ``data_dir`` it would raise ``FileNotFoundError``.
         """
-        data_dir, codes_dir = _write_fake_cohort(tmp_path, synthetic_events, synthetic_query_codes)
-        # Precondition: codes.parquet lives *only* under codes_dir, not data_dir.
+        data_dir, processed_dir = _write_fake_cohort(tmp_path, synthetic_events, synthetic_query_codes)
+        # Precondition: codes.parquet lives *only* under the processed root, not data_dir.
         assert not (data_dir / "metadata" / "codes.parquet").exists()
-        assert (codes_dir / "metadata" / "codes.parquet").exists()
+        assert (processed_dir / "metadata" / "codes.parquet").exists()
+        monkeypatch.setenv("PROCESSED", str(processed_dir))
 
         out_dir = tmp_path / "out"
         labels_fp = run_worker(
             data_dir=data_dir,
-            codes_dir=codes_dir,
+            query_codes=st.read_query_codes(None),
             out_dir=out_dir,
             split="train",
             input_shard="0",
@@ -665,8 +716,37 @@ class TestRunWorkerPipeline:
         )
         assert labels_fp is not None
         labels = pl.read_parquet(labels_fp)
-        # The queries in the output must all come from codes.parquet under codes_dir.
+        # The queries in the output must all come from codes.parquet under $PROCESSED.
         assert set(labels["query"].to_list()) <= set(synthetic_query_codes)
+
+    def test_yaml_code_list_restricts_sampled_queries(
+        self, tmp_path, synthetic_events, synthetic_query_codes
+    ):
+        """A YAML code-list override limits the training sampler's query universe."""
+        data_dir, _ = _write_fake_cohort(tmp_path, synthetic_events, synthetic_query_codes)
+        allowed_codes = synthetic_query_codes[:2]
+        codes_yaml = tmp_path / "allowed_codes.yaml"
+        codes_yaml.write_text("codes:\n" + "\n".join(f"  - {code}" for code in allowed_codes) + "\n")
+
+        labels_fp = run_worker(
+            data_dir=data_dir,
+            query_codes=st.read_query_codes(codes_yaml),
+            out_dir=tmp_path / "out",
+            split="train",
+            input_shard="0",
+            task_shard=0,
+            seed=1,
+            n_tasks=64,
+            contexts_per_task=1,
+            duration_min=10,
+            duration_max=365,
+            min_context_per_subject=5,
+        )
+
+        assert labels_fp is not None
+        labels = pl.read_parquet(labels_fp)
+        assert set(labels["query"].to_list()) <= set(allowed_codes)
+        assert set(labels["query"].to_list())
 
 
 # ---------------------------------------------------------------------------
@@ -680,11 +760,10 @@ class TestRunWorkerPipeline:
 
 
 class TestResolvePath:
-    """``_resolve_path`` is how ``main()`` threads ``cfg.data_dir`` / ``$INTERMEDIATE`` / required.
+    """``_resolve_path`` is how ``main()`` threads explicit path roots / env fallbacks / required.
 
-    The three path roots (``data_dir``, ``codes_dir``, ``out_dir``) share this resolution logic,
-    which is why it was factored out.  Directly exercising the helper lets us pin the fallback
-    matrix without spinning up a full Hydra run per case.
+    Directly exercising the helper lets us pin the fallback matrix without spinning up a full
+    Hydra run per case.
     """
 
     def test_explicit_cfg_value_wins(self, monkeypatch):

--- a/tests/test_sample_tasks.py
+++ b/tests/test_sample_tasks.py
@@ -102,9 +102,7 @@ class TestPrimitives:
         with pytest.raises(ValueError):
             sample_tasks(5, synthetic_query_codes, 100, 50, seed=0)
 
-    def test_read_query_codes_uses_processed_fallback(
-        self, monkeypatch, tmp_path, synthetic_query_codes
-    ):
+    def test_read_query_codes_uses_processed_fallback(self, monkeypatch, tmp_path, synthetic_query_codes):
         processed = tmp_path / "processed"
         metadata_dir = processed / "metadata"
         metadata_dir.mkdir(parents=True)
@@ -596,9 +594,7 @@ class TestRunWorkerPipeline:
         each shard's worker draws independent contexts (otherwise parallelism across shards
         would be statistically wasteful).
         """
-        data_dir, _ = _write_fake_cohort(
-            tmp_path, synthetic_events, synthetic_query_codes, shard_name="0"
-        )
+        data_dir, _ = _write_fake_cohort(tmp_path, synthetic_events, synthetic_query_codes, shard_name="0")
         # Write a second shard with the same events under a different basename so run_worker has
         # something to load.
         (data_dir / "data" / "train" / "1.parquet").write_bytes(
@@ -762,8 +758,8 @@ class TestRunWorkerPipeline:
 class TestResolvePath:
     """``_resolve_path`` is how ``main()`` threads explicit path roots / env fallbacks / required.
 
-    Directly exercising the helper lets us pin the fallback matrix without spinning up a full
-    Hydra run per case.
+    Directly exercising the helper lets us pin the fallback matrix without spinning up a full Hydra run per
+    case.
     """
 
     def test_explicit_cfg_value_wins(self, monkeypatch):


### PR DESCRIPTION
## Summary
- Replace `codes_dir` config with a more flexible `query_codes` option in `sample_tasks_config.yaml` — accepts an explicit Hydra list, a YAML file (flat list or `{codes: [...]}`), or `null` to default to `\$PROCESSED/metadata/codes.parquet`.
- Move `read_query_codes` resolution out of `run_worker` and into `main`, so workers receive a resolved code list directly.
- Update tests and README to cover the new resolution paths and YAML-file input.

## Test plan
- [ ] `uv run pytest tests/test_sample_tasks.py`
- [ ] `uv run pytest tests/test_generate_tasks.py`
- [ ] Spot-check a Hydra run with `query_codes=[HR,TEMP]` and with a YAML file path
- [ ] Spot-check the `query_codes: null` fallback against `\$PROCESSED/metadata/codes.parquet`

🤖 Generated with [Claude Code](https://claude.com/claude-code)