### PR TITLE
Add optional batch_size override to EQ_predict

### DIFF
--- a/src/every_query/predict/configs/predict.yaml
+++ b/src/every_query/predict/configs/predict.yaml
@@ -48,6 +48,13 @@ overwrite: false
 # raises ``FileExistsError`` at startup if the sibling already exists.
 save_embeddings: false
 
+# Optional: override the dataloader batch size for inference.  Defaults to null,
+# which reuses the training run's ``datamodule.batch_size`` (typically 128).
+# Inference is forward-only with no gradients, so larger batches (e.g. 4–8x
+# training) usually fit on the same GPU and improve throughput.  Does not touch
+# the saved training ``resolved_config.yaml``.
+batch_size: null
+
 hydra:
   output_subdir: null
   job:

--- a/src/every_query/predict/predict.py
+++ b/src/every_query/predict/predict.py
@@ -397,6 +397,9 @@ def main(cfg: DictConfig) -> None:
     logger.info(f"Loading tasks from {tasks_dir} (split={split})")
 
     train_cfg, model, trainer = setup_model(model_run_dir, ckpt_name=ckpt_name)
+    batch_size_override = cfg.get("batch_size")
+    if batch_size_override is not None:
+        train_cfg.datamodule.batch_size = int(batch_size_override)
     train_cfg.datamodule.config.task_labels_dir = str(tasks_dir)
     D = instantiate(train_cfg.datamodule)
 

--- a/tests/test_predict_cli.py
+++ b/tests/test_predict_cli.py
@@ -175,6 +175,51 @@ def test_eq_predict_preserves_input_row_order(
     )
 
 
+def test_eq_predict_batch_size_override(
+    eq_trained_model_dir: Path,
+    predict_tasks_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """``batch_size=N`` overrides the inherited training ``datamodule.batch_size``.
+
+    Runs predict with ``batch_size=1`` (forcing per-row batches) against the same
+    fixture as the baseline test and asserts the output is still
+    ``PredictionSchema``-conformant with the expected row count, schema, and
+    bounded probabilities.  The override path mutates ``train_cfg`` in memory only;
+    ``resolved_config.yaml`` on disk is untouched.
+    """
+    output_parquet = tmp_path / "predictions.parquet"
+
+    env = os.environ.copy()
+    env["PATH"] = _VENV_BIN + os.pathsep + env.get("PATH", "")
+
+    cmd = [
+        "EQ_predict",
+        f"model_run_dir={eq_trained_model_dir}",
+        f"tasks_dir={predict_tasks_dir}",
+        f"output_parquet={output_parquet}",
+        "batch_size=1",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env, timeout=300)
+    assert result.returncode == 0, (
+        f"EQ_predict failed (rc={result.returncode})\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert output_parquet.exists(), "EQ_predict did not produce the output parquet"
+
+    table = pq.read_table(output_parquet)
+    PredictionSchema.align(table)
+
+    df = pl.from_arrow(table)
+    assert df.height == len(_QUERY_CODES), (
+        f"Expected {len(_QUERY_CODES)} prediction rows (one per query), got {df.height}"
+    )
+    for col in ("censor_prob", "occurs_prob"):
+        col_min = float(df[col].min())
+        col_max = float(df[col].max())
+        assert 0.0 <= col_min <= col_max <= 1.0, f"{col} not in [0,1]: min={col_min} max={col_max}"
+    assert set(df["query"].to_list()) == set(_QUERY_CODES)
+
+
 def test_eq_predict_save_embeddings(
     eq_trained_model_dir: Path,
     predict_tasks_dir: Path,


### PR DESCRIPTION
## Summary
- New optional `batch_size` field in `predict.yaml` (default `null` = inherit from training run's `datamodule.batch_size`).
- When set (e.g. `EQ_predict ... batch_size=512`), overrides `train_cfg.datamodule.batch_size` in memory before `instantiate(...)` — the saved `resolved_config.yaml` is left untouched.
- Motivation: inference is forward-only with no gradients, so larger batches than the training default (128) usually fit on the same GPU and improve throughput.

## Test plan
- [x] New `test_eq_predict_batch_size_override` exercises `batch_size=1` end-to-end and asserts `PredictionSchema` conformance + bounded probs.
- [x] All 4 tests in `tests/test_predict_cli.py` pass locally (default `null` path unchanged).
- [x] `pre-commit run` clean on the three modified files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)