### PR TITLE
fix(env): validate resolved Hydra config, not blind env-var presence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,37 +3,42 @@
 # Copy this file to `.env` and fill in values for your machine:
 #     cp .env.example .env
 #
-# Both Python (via python-dotenv) and the SLURM batch scripts source this file,
-# so editing `.env` should be the only thing required to move the project to a
-# new machine.
+# These are *fallbacks / conveniences*.  Every EQ CLI also accepts the
+# corresponding path as a direct Hydra argument — when you pass the argument,
+# the env var is unused.  `.env` exists so you don't have to retype machine
+# paths on every invocation.  Both Python (via python-dotenv) and the SLURM
+# batch scripts source this file.
+#
+# `EQ_train` validates the *resolved* config after Hydra composition (see #184):
+# if every path is passed on the CLI, no env var here is required.
 
 # --- Paths -------------------------------------------------------------------
 
-# Absolute path to this repo on the current machine.
-PROJECT_DIR="/path/to/EveryQuery"
-
-# Root of the MEDS cohort. The INTERMEDIATE / PROCESSED dirs below are written
-# here by the preprocessing pipeline.
+# Root of the MEDS cohort.  The INTERMEDIATE / PROCESSED dirs below are derived
+# from it; preprocessing writes into them.
 DATA_DIR="/path/to/MIMIC_MEDS/MEDS_cohort"
 
-RAW="${DATA_DIR}"
+# Event shards written by preprocessing; consumed by
+# EQ_generate_{training,evaluation}_tasks as the `data_dir` fallback.
 INTERMEDIATE="${DATA_DIR}/intermediate"
-INTERMEDIATE_DIR="${INTERMEDIATE}"   # duplicate; kept for backward compatibility
+
+# Code metadata + tensorized cohort written by EQ_process_data.  PROCESSED is the
+# `codes_dir` fallback for the generate_tasks CLIs; FINAL_DATA_DIR backs
+# EQ_train's `datamodule.config.tensorized_cohort_dir`.
 PROCESSED="${DATA_DIR}/processed"
 FINAL_DATA_DIR="${PROCESSED}"
 
-# Where task parquet files live / are written.
+# Where task parquet files live / are written.  Backs EQ_train's
+# `datamodule.config.task_labels_dir` and the generate_tasks `out_dir` fallback.
 TASK_DIR="/path/to/eq_stuff/tasks"
 
-# Only needed for the `aces_to_eq` conversion pipeline. Leave unset otherwise.
+# Where EQ_train writes run dirs + checkpoints (${OUTPUT_DIR}/<run-id>/).
+OUTPUT_DIR="/path/to/results"
+
+# Only needed for the `aces_to_eq` conversion pipeline.  Leave unset otherwise.
 # ACES_SHARDS_DIR="/path/to/eic_stuff/make_index_dfs/task_configs"
 
-# Where training outputs and checkpoints land. Hydra creates
-# ${OUTPUT_DIR}/outputs/<date>/<time>/ run dirs underneath.
-SAVE_DIR="${PROJECT_DIR}/results/"
-OUTPUT_DIR="${PROJECT_DIR}/results"
-
 # --- Weights & Biases --------------------------------------------------------
-# `wandb` itself also picks these up automatically.
+# Only needed when EQ_train uses the default WandbLogger.  Disable wandb entirely
+# with `EQ_train ... trainer.logger=false`, in which case this is not required.
 WANDB_ENTITY="your-wandb-entity"
-WANDB_PROJECT="EveryQuery"

--- a/conftest.py
+++ b/conftest.py
@@ -165,18 +165,6 @@ def run_and_check(cmd: list[str], *, env: dict[str, str] | None = None, timeout:
     return result
 
 
-# Placeholder values for the ``ensure_env()`` gate in ``utils/_env.py``.  The demo Hydra configs
-# do not interpolate any of these env vars, so the actual values are inert — they exist purely
-# to let the gate pass on a clean CI machine with no ``.env`` file.
-ENSURE_ENV_PLACEHOLDERS: dict[str, str] = {
-    "PROJECT_DIR": "/tmp",
-    "OUTPUT_DIR": "/tmp",
-    "TASK_DIR": "/tmp",
-    "FINAL_DATA_DIR": "/tmp",
-    "WANDB_ENTITY": "test",
-}
-
-
 @pytest.fixture(scope="session")
 def eq_preprocessed_dataset(simple_static_MEDS: Path, tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Runs ``EQ_process_data do_demo=True`` against ``simple_static_MEDS``.
@@ -275,7 +263,6 @@ def eq_trained_model_dir(
             f"datamodule.config.tensorized_cohort_dir={eq_preprocessed_dataset!s}",
             f"datamodule.config.task_labels_dir={eq_sampled_tasks_dir!s}",
         ],
-        env=ENSURE_ENV_PLACEHOLDERS,
         timeout=300.0,
     )
     return output_dir

--- a/src/every_query/train/train.py
+++ b/src/every_query/train/train.py
@@ -186,14 +186,114 @@ def find_checkpoint_path(output_dir: Path) -> Path | None:
 
 
 def _init_env() -> None:
-    """Validate required env vars and configure thread counts for polars/OMP."""
-    from every_query.utils._env import ensure_env
+    """Load ``.env`` and configure thread counts for polars/OMP.
 
-    ensure_env()
+    Env-var *validation* is config-aware and happens in :func:`validate_training_config`
+    once Hydra has composed the config — a CLI path override means the backing env var
+    need not be set at all.  See #184.
+    """
+    from every_query.utils._env import load_env
+
+    load_env()
     num_cpus = int(os.environ.get("SLURM_CPUS_PER_TASK", os.cpu_count() or 1))
     threads_per_file = max(1, num_cpus // 10)
     os.environ["POLARS_MAX_THREADS"] = str(threads_per_file)
     os.environ["OMP_NUM_THREADS"] = str(threads_per_file)
+
+
+def _is_wandb_logger(logger_cfg: Any) -> bool:
+    """True if a resolved ``trainer.logger`` entry is a WandB logger config.
+
+    Examples:
+        >>> from omegaconf import OmegaConf
+        >>> wandb = OmegaConf.create({"_target_": "pytorch_lightning.loggers.wandb.WandbLogger"})
+        >>> _is_wandb_logger(wandb)
+        True
+        >>> _is_wandb_logger(OmegaConf.create({"_target_": "lightning.pytorch.loggers.CSVLogger"}))
+        False
+        >>> _is_wandb_logger(False)
+        False
+        >>> _is_wandb_logger(None)
+        False
+    """
+    if isinstance(logger_cfg, DictConfig):
+        return "WandbLogger" in str(logger_cfg.get("_target_", ""))
+    return False
+
+
+def validate_training_config(cfg: DictConfig) -> None:
+    """Validate the *resolved* training config after Hydra composition.
+
+    Replaces the old blind ``REQUIRED_ENV_VARS`` presence gate (see #184).  A CLI
+    override can supply any of these paths without the backing env var being set, so we
+    check the resolved config *values* rather than env-var presence.
+    ``OmegaConf.select`` with ``throw_on_resolution_failure=False`` turns an unset
+    ``${oc.env:...}`` interpolation into ``None`` rather than a cryptic
+    ``InterpolationResolutionError`` mid-run.
+
+    Raises:
+        SystemExit: with every problem found, if the resolved config is invalid.
+
+    Examples:
+        A fully-specified config with existing input dirs and a disabled logger passes:
+
+        >>> import tempfile
+        >>> from omegaconf import OmegaConf
+        >>> with tempfile.TemporaryDirectory() as d:
+        ...     cfg = OmegaConf.create({
+        ...         "output_dir": d,
+        ...         "datamodule": {"config": {"tensorized_cohort_dir": d, "task_labels_dir": d}},
+        ...         "trainer": {"logger": False},
+        ...     })
+        ...     validate_training_config(cfg)  # no error
+
+        A missing input directory raises ``SystemExit`` naming the offending key:
+
+        >>> cfg = OmegaConf.create({
+        ...     "output_dir": "/tmp",
+        ...     "datamodule": {"config": {"tensorized_cohort_dir": "/no/such/dir/xyz",
+        ...                               "task_labels_dir": "/tmp"}},
+        ...     "trainer": {"logger": False},
+        ... })
+        >>> validate_training_config(cfg)
+        Traceback (most recent call last):
+            ...
+        SystemExit: ...
+    """
+    errors: list[str] = []
+
+    # Read inputs — must resolve to existing directories.
+    for key, env_hint in (
+        ("datamodule.config.tensorized_cohort_dir", "FINAL_DATA_DIR"),
+        ("datamodule.config.task_labels_dir", "TASK_DIR"),
+    ):
+        value = OmegaConf.select(cfg, key, throw_on_resolution_failure=False)
+        if value is None:
+            errors.append(f"{key} is unset — pass {key}=... on the CLI or export ${env_hint}.")
+        elif not Path(value).is_dir():
+            errors.append(f"{key}={value!r} does not exist or is not a directory.")
+
+    # Write target — must resolve; training creates it, so don't require pre-existence.
+    output_dir = OmegaConf.select(cfg, "output_dir", throw_on_resolution_failure=False)
+    if output_dir is None:
+        errors.append("output_dir is unset — pass output_dir=... on the CLI or export $OUTPUT_DIR.")
+
+    # WandB entity — required only when the trainer actually uses a WandB logger.
+    logger_cfg = OmegaConf.select(cfg, "trainer.logger", throw_on_resolution_failure=False)
+    logger_entries = logger_cfg if isinstance(logger_cfg, ListConfig) else [logger_cfg]
+    for entry in logger_entries:
+        if _is_wandb_logger(entry):
+            entity = OmegaConf.select(entry, "entity", throw_on_resolution_failure=False)
+            if not entity:
+                errors.append(
+                    "trainer.logger is a WandbLogger but `entity` is unset — export "
+                    "$WANDB_ENTITY, pass trainer.logger.entity=..., or disable wandb "
+                    "with trainer.logger=false."
+                )
+
+    if errors:
+        bullet = "\n  - ".join(errors)
+        raise SystemExit(f"Invalid training configuration (see #184):\n  - {bullet}")
 
 
 CONFIGS = str(files("every_query") / "train" / "configs")
@@ -202,6 +302,7 @@ CONFIGS = str(files("every_query") / "train" / "configs")
 @hydra.main(version_base="1.3", config_path=CONFIGS, config_name="config.yaml")
 def main(cfg: DictConfig) -> float | None:
     _init_env()
+    validate_training_config(cfg)
 
     if not isinstance(cfg.query.codes, ListConfig):
         raise ValueError("query.codes must be a list")

--- a/src/every_query/utils/_env.py
+++ b/src/every_query/utils/_env.py
@@ -1,42 +1,21 @@
-"""Load .env and validate that required environment variables are set.
+"""Load ``.env`` so machine-specific paths reach Hydra ``${oc.env:...}`` interpolations.
 
-Imported early by both train.py and tasks.py so that a missing .env on a fresh machine surfaces a single clear
-error rather than a mid-run KeyError or Hydra InterpolationResolutionError.
+This module deliberately does *not* validate env-var presence.  A CLI override —
+``EQ_train datamodule.config.tensorized_cohort_dir=/path`` — supplies a path without the
+backing env var ever being set, so a blind presence check would reject valid runs.
+Validation of the *resolved* config (do the input directories exist? is a wandb entity
+set when the wandb logger is actually active?) happens after Hydra composition, in
+:func:`every_query.train.train.validate_training_config`.  See #184 for the history.
 """
-
-import os
-import sys
 
 from dotenv import load_dotenv
 
-REQUIRED_ENV_VARS = (
-    "PROJECT_DIR",
-    "OUTPUT_DIR",
-    "TASK_DIR",
-    "FINAL_DATA_DIR",
-    "WANDB_ENTITY",
-)
-# `PROCESSED` and `INTERMEDIATE` are used by the preprocessing pipeline (the dirs it
-# writes to) and by the generate_tasks stage as dotenv fallbacks inside
-# `sample_tasks.py::_resolve_path` / `sample_evaluation_tasks.py::_resolve_path`.
-# They're not gated by this `REQUIRED_ENV_VARS` check because:
-#   1. `_resolve_path` already tolerates a missing env var when the caller supplies the
-#      path directly (the normal CLI / test path).
-#   2. No Hydra config interpolates `${oc.env:PROCESSED}` or `${oc.env:INTERMEDIATE}`,
-#      so demo fixtures / `--help` invocations don't need throwaway placeholders.
-# If you're running a full fresh-machine setup that includes preprocessing, set both
-# in `.env` (see `.env.example`).  See #117 for the history.
 
+def load_env() -> None:
+    """Load ``.env`` into ``os.environ`` so ``${oc.env:...}`` interpolations can resolve.
 
-def ensure_env() -> None:
+    A thin wrapper over :func:`dotenv.load_dotenv` — it neither requires nor validates
+    any specific variable.  Config-aware path/identity validation lives in
+    :func:`every_query.train.train.validate_training_config` (see #184).
+    """
     load_dotenv()
-    missing = [v for v in REQUIRED_ENV_VARS if not os.environ.get(v)]
-    if missing:
-        joined = ", ".join(missing)
-        print(
-            f"ERROR: required environment variables not set: {joined}\n"
-            "Copy .env.example to .env and fill in machine-specific paths, "
-            "or export these variables before running.",
-            file=sys.stderr,
-        )
-        sys.exit(1)

--- a/tests/test_generate_evaluation_tasks_cli.py
+++ b/tests/test_generate_evaluation_tasks_cli.py
@@ -20,7 +20,7 @@ from typing import TYPE_CHECKING
 import polars as pl
 import pyarrow.parquet as pq
 
-from conftest import ENSURE_ENV_PLACEHOLDERS, run_and_check
+from conftest import run_and_check
 from every_query.data.schema import TaskQuerySchema
 
 if TYPE_CHECKING:
@@ -55,7 +55,6 @@ def test_eq_generate_evaluation_tasks_end_to_end(
             f"durations=[{','.join(str(d) for d in durations)}]",
             "seed=42",
         ],
-        env=ENSURE_ENV_PLACEHOLDERS,
         timeout=120.0,
     )
 
@@ -119,7 +118,6 @@ def test_eq_generate_evaluation_tasks_deterministic(
     for out in (out_a, out_b):
         run_and_check(
             ["EQ_generate_evaluation_tasks", f"out_dir={out!s}", *common_args],
-            env=ENSURE_ENV_PLACEHOLDERS,
             timeout=120.0,
         )
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 import torch
 from omegaconf import OmegaConf
 
-from conftest import ENSURE_ENV_PLACEHOLDERS, run_and_check
+from conftest import run_and_check
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -151,7 +151,6 @@ def test_resume_actually_loads_checkpoint_state(
             "do_resume=True",
             f"trainer.max_steps={starting_step}",
         ],
-        env=ENSURE_ENV_PLACEHOLDERS,
         timeout=300.0,
     )
     _, noop_ckpt = _highest_step_checkpoint(resume_dir)
@@ -183,7 +182,6 @@ def test_resume_actually_loads_checkpoint_state(
             "do_resume=True",
             "trainer.max_steps=4",
         ],
-        env=ENSURE_ENV_PLACEHOLDERS,
         timeout=300.0,
     )
     _, resumed_ckpt = _highest_step_checkpoint(resume_dir)

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -14,6 +14,13 @@ import pytest
 _VENV_BIN = str(Path(sys.executable).parent)
 
 
+# Env vars `ensure_env()` used to gate on, before #184 replaced the blind presence
+# check with config-aware ``validate_training_config``.  ``_demo_train.yaml`` passes
+# every path on the CLI and sets ``trainer.logger: false``, so none of these are
+# needed — `_run_train_subprocess` scrubs them by default to prove that.
+_FORMERLY_GATED_ENV_VARS = ("PROJECT_DIR", "OUTPUT_DIR", "TASK_DIR", "FINAL_DATA_DIR", "WANDB_ENTITY")
+
+
 def _run_train_subprocess(
     task_labels_dir: Path,
     tensorized_cohort_dir: Path,
@@ -23,14 +30,17 @@ def _run_train_subprocess(
     do_overwrite: bool = True,
     extra_overrides: list[str] | None = None,
 ) -> subprocess.CompletedProcess:
-    """Run ``python -m every_query.train.train`` as a subprocess with the demo config."""
+    """Run ``python -m every_query.train.train`` as a subprocess with the demo config.
+
+    No path env vars are set — the demo config + CLI overrides supply every path, and
+    #184 made `EQ_train` validate the *resolved* config rather than env-var presence.
+    Any of the formerly-gated vars inherited from the test runner's environment are
+    scrubbed so this stays an honest "CLI-only, zero env vars" exercise.
+    """
     env = os.environ.copy()
     env["PATH"] = _VENV_BIN + os.pathsep + env.get("PATH", "")
-    # Provide dummy env vars so ensure_env() passes in the subprocess.
-    # Hydra CLI overrides control the actual paths used by the test.
-    for var in ("PROJECT_DIR", "OUTPUT_DIR", "TASK_DIR", "FINAL_DATA_DIR"):
-        env.setdefault(var, str(output_dir))
-    env.setdefault("WANDB_ENTITY", "test")
+    for var in _FORMERLY_GATED_ENV_VARS:
+        env.pop(var, None)
 
     overrides = [
         f"output_dir={output_dir}",
@@ -228,4 +238,39 @@ class TestTrainResumeRejectsStructuralDrift:
         )
         assert "max_seq_len" in drifted.stderr, (
             f"Expected error to name 'max_seq_len', got:\n{drifted.stderr}"
+        )
+
+
+class TestTrainConfigValidation:
+    """``EQ_train`` validates the *resolved* config, not env-var presence (#184).
+
+    ``TestTrainCliRuns`` already proves the happy path runs with **zero** path env
+    vars set (``_run_train_subprocess`` scrubs ``_FORMERLY_GATED_ENV_VARS``, and
+    ``_demo_train.yaml`` sets ``trainer.logger: false`` so no ``WANDB_ENTITY`` is
+    needed).  These tests cover the rejection path: a path that *is* supplied but
+    doesn't point at a real directory must fail early with a clear message.
+    """
+
+    def test_missing_cohort_dir_rejected(self, task_labels_dir, tmp_path_factory) -> None:
+        output_dir = tmp_path_factory.mktemp("cli_bad_cohort")
+        bogus_cohort = output_dir / "does_not_exist_cohort"
+        result = _run_train_subprocess(task_labels_dir, bogus_cohort, output_dir)
+        assert result.returncode != 0, (
+            f"Expected a nonexistent tensorized_cohort_dir to be rejected, but the run "
+            f"succeeded.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert "tensorized_cohort_dir" in result.stderr, (
+            f"Expected the error to name 'tensorized_cohort_dir', got:\n{result.stderr}"
+        )
+
+    def test_missing_task_labels_dir_rejected(self, tensorized_cohort_dir, tmp_path_factory) -> None:
+        output_dir = tmp_path_factory.mktemp("cli_bad_tasks")
+        bogus_tasks = output_dir / "does_not_exist_tasks"
+        result = _run_train_subprocess(bogus_tasks, tensorized_cohort_dir, output_dir)
+        assert result.returncode != 0, (
+            f"Expected a nonexistent task_labels_dir to be rejected, but the run "
+            f"succeeded.\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+        )
+        assert "task_labels_dir" in result.stderr, (
+            f"Expected the error to name 'task_labels_dir', got:\n{result.stderr}"
         )

--- a/tests/training_validity/test_training_validity.py
+++ b/tests/training_validity/test_training_validity.py
@@ -17,7 +17,7 @@ import pytest
 from meds import DatasetMetadataSchema, train_split, tuning_split
 from meds_testing_helpers.dataset import MEDSDataset
 
-from conftest import ENSURE_ENV_PLACEHOLDERS, run_and_check
+from conftest import run_and_check
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -248,7 +248,6 @@ def oracle_trained_model_dir(
             "trainer.val_check_interval=1000",
             "lightning_module.optimizer.lr=1e-3",
         ],
-        env=ENSURE_ENV_PLACEHOLDERS,
         timeout=1800.0,
     )
     return output_dir
@@ -293,7 +292,6 @@ def test_trained_model_learns_occurs_and_censor(
             f"output_parquet={predictions_parquet!s}",
             f"split={tuning_split}",
         ],
-        env=ENSURE_ENV_PLACEHOLDERS,
         timeout=600.0,
     )
 
@@ -305,7 +303,6 @@ def test_trained_model_learns_occurs_and_censor(
             f"predictions_parquet={predictions_parquet!s}",
             f"metrics_parquet={metrics_parquet!s}",
         ],
-        env=ENSURE_ENV_PLACEHOLDERS,
         timeout=60.0,
     )
     metrics = pl.read_parquet(metrics_parquet).sort(["query", "duration_days"])


### PR DESCRIPTION
## Summary

Closes #184. Replaces `ensure_env()`'s blind env-var **presence** gate with config-aware validation of the **resolved** Hydra config.

The old gate (`REQUIRED_ENV_VARS`, run unconditionally at the top of `EQ_train`) had three problems:

- **`PROJECT_DIR`** was required but read by nothing — pure theater.
- **`FINAL_DATA_DIR` / `TASK_DIR` / `OUTPUT_DIR`** were required even when the backing Hydra node was overridden on the CLI. OmegaConf interpolations are lazy, so `${oc.env:FINAL_DATA_DIR}` is never read once you override `datamodule.config.tensorized_cohort_dir=...` — but the gate ran first and didn't know that, so you had to export junk values to clear it.
- **`WANDB_ENTITY`** was required even with `trainer.logger=false`.

## What changed

- **`utils/_env.py`** — `ensure_env()` → `load_env()`; now only `load_dotenv()` (still needed so `.env` values reach the lazy `${oc.env:...}` interpolations). `REQUIRED_ENV_VARS` removed.
- **`train/train.py`** — new `validate_training_config(cfg)`, called from `main()` after Hydra composition. Uses `OmegaConf.select(..., throw_on_resolution_failure=False)` so an unset `${oc.env:...}` resolves to `None` instead of a cryptic `InterpolationResolutionError` mid-run. Validates:
  - `tensorized_cohort_dir` / `task_labels_dir` resolve to **existing directories** (read inputs).
  - `output_dir` resolves to a **non-empty path** (write target — training creates it, so no pre-existence requirement).
  - wandb `entity` is set **only when** the trainer actually uses a `WandbLogger` (`_is_wandb_logger` helper) — `trainer.logger=false` skips the check entirely.
  - All problems are collected into one `SystemExit` so you see every issue at once.
- **`.env.example`** — dropped dead vars (`PROJECT_DIR`, `SAVE_DIR`, `RAW`, `INTERMEDIATE_DIR`, `WANDB_PROJECT`); reworded so each remaining var is documented as a CLI-overridable fallback.
- **tests** — `test_train_cli.py` now scrubs the formerly-gated env vars before every subprocess run (proving a CLI-only `EQ_train` needs **zero** env vars) and adds `TestTrainConfigValidation` covering the rejection path (bad `tensorized_cohort_dir` / `task_labels_dir`). Removed the now-dead `ENSURE_ENV_PLACEHOLDERS` scaffolding from `conftest.py` and its 8 usages across 3 test files.

## Net effect

- A fully CLI-driven `EQ_train` needs **zero** env vars.
- An `.env`-driven run still gets a clear **early** error if a path is missing or wrong — same intent as the old gate, just validating the right thing.
- `trainer.logger=false` no longer needs a phantom `WANDB_ENTITY`.

## Design note

The issue proposed null-defaulting the `${oc.env:...}` interpolations in `config.yaml`. `OmegaConf.select(..., throw_on_resolution_failure=False)` is strictly better — it turns an unresolvable interpolation into `None` at the validation site with **no `config.yaml` change needed**, avoiding the `None/<run_id>/` footgun that null-defaulting the `output_dir` composite would create.

## Test plan

- [x] `train.py` doctests (`_is_wandb_logger`, `validate_training_config` happy + rejection paths) pass.
- [x] `test_train_cli.py` — existing CLI tests pass with env vars scrubbed; new `TestTrainConfigValidation` rejection tests pass.
- [x] Full non-slow suite green locally (165 passed).
