### PR TITLE
Add frozen dataclasses for redesigned task sampler (#188)

### DIFF
--- a/src/every_query/generate_tasks/datastructures.py
+++ b/src/every_query/generate_tasks/datastructures.py
@@ -1,0 +1,112 @@
+"""Frozen dataclasses the redesigned task sampler is built on.
+
+These four immutable value types are the stable contract shared by the redesigned
+sampler's pure stage functions (``sample_queries``, ``sample_patient_contexts``,
+``match_queries_and_contexts``, ``compute_labels`` — see
+``task-sampling-design.md``):
+
+- :class:`QuerySpec` — one sampled query/task (replaces the old ``TaskSpec`` in
+  ``sample_tasks.py``).
+- :class:`QueryDistribution` — the distribution queries are drawn from.
+- :class:`PatientContext` — one sampled ``(subject_id, prediction_time)`` context.
+- :class:`ContextDistribution` — eligibility + replacement policy for contexts.
+
+All are ``@dataclass(frozen=True)`` so they are hashable and safe to use as iid
+samples (the sampler deliberately allows duplicate ``QuerySpec`` / ``PatientContext``
+values — the repeats *are* the sample — so value equality and hashing must behave).
+"""
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+# How ``QuerySpec.duration_days`` is drawn over ``[min_duration_days, max_duration_days]``.
+# Plain string Literals (rather than an Enum) so Hydra/YAML configs can pass the value
+# through directly without enum coercion. Spelling matches the design doc.
+DurationDistribution = Literal["uniform", "log-uniform"]
+
+_LEGAL_DURATION_DISTRIBUTIONS = ("uniform", "log-uniform")
+
+
+@dataclass(frozen=True)
+class QuerySpec:
+    """A single pre-training query/task: one query code and one prediction-window duration (in days).
+
+    Replaces the old ``TaskSpec``. ``duration_days`` is a ``float`` (continuous horizon)
+    to match ``TaskQuerySchema.duration_days`` (``float32``).
+    """
+
+    code: str
+    duration_days: float
+
+
+@dataclass(frozen=True)
+class QueryDistribution:
+    """Distribution that provides samples of queries for EQ training.
+
+    A sample is a single :class:`QuerySpec`, i.e. a ``(code, duration_days)`` tuple. The
+    ``code`` is drawn **uniformly** over ``codes`` (no per-code weighting); only the
+    duration draw is configurable.
+
+    Note on field order: the design doc lists ``min_duration_days`` before the required
+    ``max_duration_days``, but a dataclass cannot place a required field after a defaulted
+    one, so the defaulted fields are moved last here. Construct with keywords to avoid
+    confusion.
+    """
+
+    codes: list[str]  # QuerySpec.code is drawn uniformly at random from this list
+    max_duration_days: float  # upper bound of the duration draw
+    min_duration_days: float = 1.0  # lower bound (default 1 day; must be > 0 so log-uniform is well-defined)
+    # how QuerySpec.duration_days is drawn over [min_duration_days, max_duration_days]
+    duration_days_distribution: DurationDistribution = "log-uniform"
+
+    def __post_init__(self) -> None:
+        if not self.codes:
+            raise ValueError("codes must be non-empty")
+        if self.min_duration_days <= 0:
+            raise ValueError(
+                f"min_duration_days must be > 0 (got {self.min_duration_days}); "
+                "log-uniform needs positive bounds"
+            )
+        if self.max_duration_days < self.min_duration_days:
+            raise ValueError(
+                f"max_duration_days ({self.max_duration_days}) must be >= "
+                f"min_duration_days ({self.min_duration_days})"
+            )
+        if self.duration_days_distribution not in _LEGAL_DURATION_DISTRIBUTIONS:
+            raise ValueError(
+                f"duration_days_distribution must be one of {_LEGAL_DURATION_DISTRIBUTIONS} "
+                f"(got {self.duration_days_distribution!r})"
+            )
+
+
+@dataclass(frozen=True)
+class PatientContext:
+    """A single patient context: one subject and the prediction time that cuts off observable history.
+
+    Everything *at or before* ``prediction_time`` is model input; the label is evaluated
+    over the window *strictly after* ``prediction_time``. The inclusive cutoff matches
+    ``meds-torch-data``'s loader (backward ``join_asof``, ``time <= prediction_time``), so
+    the event at the cutoff is fed to the model and the input/label boundary partitions the
+    timeline with no overlap and no gap.
+    """
+
+    subject_id: int
+    prediction_time: datetime
+
+
+@dataclass(frozen=True)
+class ContextDistribution:
+    """Eligibility + replacement policy for sampling patient contexts.
+
+    A sample from the distribution is a single :class:`PatientContext`, i.e. a
+    ``(subject_id, prediction_time)`` tuple drawn from the eligible ``(subject, event-time)``
+    pairs in the dataset.
+    """
+
+    min_context_events: int  # a (subject, time) pair is eligible only once the subject has >= this many prior events
+    with_replacement: bool  # True for PT, so N*M may exceed the number of eligible pairs
+
+    def __post_init__(self) -> None:
+        if self.min_context_events < 0:
+            raise ValueError(f"min_context_events must be >= 0 (got {self.min_context_events})")

--- a/src/every_query/generate_tasks/datastructures.py
+++ b/src/every_query/generate_tasks/datastructures.py
@@ -44,14 +44,9 @@ class QuerySpec:
 class QueryDistribution:
     """Distribution that provides samples of queries for EQ training.
 
-    A sample is a single :class:`QuerySpec`, i.e. a ``(code, duration_days)`` tuple. The
+    A sample is a `QuerySpec` instance, i.e. a ``(code, duration_days)`` tuple. The
     ``code`` is drawn **uniformly** over ``codes`` (no per-code weighting); only the
     duration draw is configurable.
-
-    Note on field order: the design doc lists ``min_duration_days`` before the required
-    ``max_duration_days``, but a dataclass cannot place a required field after a defaulted
-    one, so the defaulted fields are moved last here. Construct with keywords to avoid
-    confusion.
     """
 
     codes: list[str]  # QuerySpec.code is drawn uniformly at random from this list

--- a/tests/test_datastructures.py
+++ b/tests/test_datastructures.py
@@ -1,0 +1,141 @@
+"""Unit tests for the redesigned task sampler's frozen dataclasses (issue #188)."""
+
+import dataclasses
+from datetime import datetime
+
+import pytest
+
+from every_query.generate_tasks.datastructures import (
+    ContextDistribution,
+    PatientContext,
+    QueryDistribution,
+    QuerySpec,
+)
+
+
+# ---------------------------------------------------------------------------
+# Construction + field round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_query_spec_construction():
+    q = QuerySpec(code="ICD//I10", duration_days=30.0)
+    assert q.code == "ICD//I10"
+    assert q.duration_days == 30.0
+
+
+def test_query_distribution_construction():
+    d = QueryDistribution(
+        codes=["A", "B"],
+        max_duration_days=365.0,
+        min_duration_days=2.0,
+        duration_days_distribution="uniform",
+    )
+    assert d.codes == ["A", "B"]
+    assert d.max_duration_days == 365.0
+    assert d.min_duration_days == 2.0
+    assert d.duration_days_distribution == "uniform"
+
+
+def test_patient_context_construction():
+    pt = datetime(2023, 1, 1)
+    c = PatientContext(subject_id=7, prediction_time=pt)
+    assert c.subject_id == 7
+    assert c.prediction_time == pt
+
+
+def test_context_distribution_construction():
+    c = ContextDistribution(min_context_events=5, with_replacement=True)
+    assert c.min_context_events == 5
+    assert c.with_replacement is True
+
+
+# ---------------------------------------------------------------------------
+# Defaults
+# ---------------------------------------------------------------------------
+
+
+def test_query_distribution_defaults():
+    d = QueryDistribution(codes=["A"], max_duration_days=365.0)
+    assert d.min_duration_days == 1.0
+    assert d.duration_days_distribution == "log-uniform"
+
+
+# ---------------------------------------------------------------------------
+# Frozen / immutable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "obj, field, value",
+    [
+        (QuerySpec("A", 1.0), "code", "B"),
+        (QueryDistribution(["A"], 365.0), "max_duration_days", 1.0),
+        (PatientContext(1, datetime(2023, 1, 1)), "subject_id", 2),
+        (ContextDistribution(1, True), "with_replacement", False),
+    ],
+)
+def test_frozen(obj, field, value):
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        setattr(obj, field, value)
+
+
+# ---------------------------------------------------------------------------
+# Equality + hashability (duplicates are allowed and must compare/hash equal)
+# ---------------------------------------------------------------------------
+
+
+def test_query_spec_equality_and_hash():
+    a = QuerySpec("A", 30.0)
+    b = QuerySpec("A", 30.0)
+    assert a == b
+    assert hash(a) == hash(b)
+    assert len({a, b}) == 1
+
+
+def test_patient_context_equality_and_hash():
+    pt = datetime(2023, 1, 1)
+    a = PatientContext(1, pt)
+    b = PatientContext(1, pt)
+    assert a == b
+    assert hash(a) == hash(b)
+
+
+# ---------------------------------------------------------------------------
+# Validation (all raise ValueError)
+# ---------------------------------------------------------------------------
+
+
+def test_empty_codes_raises():
+    with pytest.raises(ValueError, match="codes must be non-empty"):
+        QueryDistribution(codes=[], max_duration_days=365.0)
+
+
+@pytest.mark.parametrize("bad_min", [0.0, -1.0])
+def test_nonpositive_min_duration_raises(bad_min):
+    with pytest.raises(ValueError, match="min_duration_days must be > 0"):
+        QueryDistribution(codes=["A"], max_duration_days=365.0, min_duration_days=bad_min)
+
+
+def test_max_below_min_raises():
+    with pytest.raises(ValueError, match="must be >= min_duration_days"):
+        QueryDistribution(codes=["A"], max_duration_days=5.0, min_duration_days=10.0)
+
+
+def test_bad_duration_distribution_raises():
+    with pytest.raises(ValueError, match="duration_days_distribution must be one of"):
+        QueryDistribution(
+            codes=["A"],
+            max_duration_days=365.0,
+            duration_days_distribution="gaussian",  # type: ignore[arg-type]
+        )
+
+
+def test_negative_min_context_events_raises():
+    with pytest.raises(ValueError, match="min_context_events must be >= 0"):
+        ContextDistribution(min_context_events=-1, with_replacement=False)
+
+
+def test_max_equal_min_is_valid():
+    d = QueryDistribution(codes=["A"], max_duration_days=10.0, min_duration_days=10.0)
+    assert d.max_duration_days == d.min_duration_days


### PR DESCRIPTION
## Summary
Adds the four foundational frozen dataclasses the redesigned task sampler is built on (epic #187):

- `QuerySpec(code, duration_days)` — replaces the old `TaskSpec`
- `QueryDistribution(codes, max_duration_days, min_duration_days=1.0, duration_days_distribution="log-uniform")` — code drawn uniformly; only the duration draw is configurable
- `PatientContext(subject_id, prediction_time)`
- `ContextDistribution(min_context_events, with_replacement)`

All `@dataclass(frozen=True)` with `__post_init__` validation. Lives in the new module `every_query/generate_tasks/datastructures.py`; the upcoming stage functions (#189–#192) import from it.

## Notes
- `duration_days_distribution` is typed `Literal["uniform", "log-uniform"]` (config-friendly).
- `QueryDistribution` field order differs from the design doc: the required `max_duration_days` is placed ahead of the defaulted `min_duration_days` because a dataclass can't put a required field after a defaulted one. Documented in the docstring; construct with keywords.
- Old `sample_tasks.py` / `TaskSpec` left untouched (swapped out later in #193).

## Testing
`tests/test_datastructures.py` — 18 tests covering construction, defaults, frozen-ness, equality/hashability, and every validation path. All pass (`uv run pytest tests/test_datastructures.py`).

Closes #188.

🤖 Generated with [Claude Code](https://claude.com/claude-code)