### PR TITLE
Artifact layout: two disjoint, never-nested roots (#204)

### DIFF
--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -462,7 +462,15 @@ def _unique_tmp_path(fp: Path) -> Path:
 
 
 def _atomic_write_parquet(df: pl.DataFrame, fp: Path) -> None:
-    """Write ``df`` to ``fp`` atomically via a unique sibling tmpfile + ``os.replace``."""
+    """Write ``df`` to ``fp`` atomically via a unique sibling tmpfile + ``os.replace``.
+
+    The temp is always a *sibling* of ``fp`` (``_unique_tmp_path`` uses ``dir=fp.parent``) because
+    ``os.replace`` requires the temp and the final path to share a filesystem.  This is the spec's
+    one exception to the two-root layout (invariant 7): when Stage 4 writes a
+    :func:`final_output_path`, the hidden ``.{shard}.parquet.tmp.*`` temp lands in the final-output
+    split dir, not the artifacts root (which may be a different mount).  It is hidden and does not
+    end in ``.parquet``, so a ``{split}/*.parquet`` glob of the final root never sees it.
+    """
     tmp = _unique_tmp_path(fp)
     try:
         df.write_parquet(tmp)
@@ -620,6 +628,77 @@ def resolve_training_task_paths() -> tuple[Path, Path, Path]:
     training_task_artifacts_dir = default_artifacts_dir(training_tasks_dir)
 
     return path_to_data, training_tasks_dir, training_task_artifacts_dir
+
+
+# ---------------------------------------------------------------------------
+# Redesign (issue #204): artifact layout — two disjoint, never-nested roots
+# ---------------------------------------------------------------------------
+#
+# Every redesigned stage reads/writes against exactly two roots (spec invariant 7):
+#
+#   training_tasks_dir/{split}/{shard}.parquet            <- final outputs ONLY (Stage 4)
+#   training_task_artifacts_dir/{split}/                  <- all intermediates
+#       _prediction_time_counts.parquet                   <- Stage 0 summary
+#       _prediction_times/{shard}.parquet                 <- Stage 0 map
+#       _index/{shard}.parquet                            <- Stage 3 index
+#
+# The two roots are disjoint and never nested (guaranteed by ``default_artifacts_dir``'s sibling
+# rule), so cleanup is a single ``rm -rf`` of the artifacts root that *cannot* touch the dataset —
+# no bespoke cleanup helper needed.  These are pure path functions (no I/O, no mkdir) — the writing
+# stages create parents at write time via the atomic helpers, same as the legacy pipeline.
+#
+# The intermediate entry names are ``_``-prefixed and centralized here so (a) Stages 0/3 and any
+# consumer resolve identical paths with no string drift and (b) the "final root holds nothing but
+# {shard}.parquet" invariant stays auditable from one place.
+
+PREDICTION_TIME_COUNTS_NAME = "_prediction_time_counts.parquet"
+PREDICTION_TIMES_DIRNAME = "_prediction_times"
+INDEX_DIRNAME = "_index"
+
+
+def final_output_path(training_tasks_dir: Path, split: str, shard: str) -> Path:
+    """Stage 4 final per-shard output: ``training_tasks_dir/{split}/{shard}.parquet``.
+
+    The final-output root holds **nothing but** these files at rest — no ``_``-prefixed entries —
+    so its split dir is directly glob-consumable as ``{split}/*.parquet`` (spec invariant 7).  The
+    only transient siblings are Stage 4's hidden atomic-write temps, which exist solely mid-write;
+    see :func:`_atomic_write_parquet`.
+
+    Examples:
+        >>> final_output_path(Path("/x/tasks"), "train", "0")
+        PosixPath('/x/tasks/train/0.parquet')
+    """
+    return training_tasks_dir / split / f"{shard}.parquet"
+
+
+def prediction_time_counts_path(training_task_artifacts_dir: Path, split: str) -> Path:
+    """Stage 0 subject-level summary: ``{artifacts}/{split}/_prediction_time_counts.parquet``.
+
+    Examples:
+        >>> prediction_time_counts_path(Path("/x/tasks_artifacts"), "train")
+        PosixPath('/x/tasks_artifacts/train/_prediction_time_counts.parquet')
+    """
+    return training_task_artifacts_dir / split / PREDICTION_TIME_COUNTS_NAME
+
+
+def prediction_times_path(training_task_artifacts_dir: Path, split: str, shard: str) -> Path:
+    """Stage 0 canonical map partition: ``{artifacts}/{split}/_prediction_times/{shard}.parquet``.
+
+    Examples:
+        >>> prediction_times_path(Path("/x/tasks_artifacts"), "train", "0")
+        PosixPath('/x/tasks_artifacts/train/_prediction_times/0.parquet')
+    """
+    return training_task_artifacts_dir / split / PREDICTION_TIMES_DIRNAME / f"{shard}.parquet"
+
+
+def index_path(training_task_artifacts_dir: Path, split: str, shard: str) -> Path:
+    """Stage 3 partitioned index: ``{artifacts}/{split}/_index/{shard}.parquet``.
+
+    Examples:
+        >>> index_path(Path("/x/tasks_artifacts"), "train", "0")
+        PosixPath('/x/tasks_artifacts/train/_index/0.parquet')
+    """
+    return training_task_artifacts_dir / split / INDEX_DIRNAME / f"{shard}.parquet"
 
 
 CONFIGS = str(files("every_query") / "generate_tasks" / "configs")

--- a/tests/test_sample_tasks.py
+++ b/tests/test_sample_tasks.py
@@ -33,6 +33,10 @@ from every_query.generate_tasks.sample_tasks import (
     compute_max_time_per_subject,
     default_artifacts_dir,
     evaluate_index_df,
+    final_output_path,
+    index_path,
+    prediction_time_counts_path,
+    prediction_times_path,
     resolve_training_task_paths,
     run_worker,
     sample_contexts,
@@ -976,3 +980,58 @@ class TestRedesignConfigFile:
         # Superseded knobs must not leak into the redesign surface.
         for legacy in ("min_context_per_subject", "num_workers", "num_codes", "n_tasks"):
             assert legacy not in cfg
+
+
+class TestArtifactLayout:
+    """Issue #204: the two-root, never-nested on-disk layout every stage resolves against.
+
+    Pure path functions (no I/O), so they map roots+split+shard to the spec's fixed locations.  The
+    contract under test: the final-output root holds *only* ``{shard}.parquet`` while every
+    intermediate lands under the disjoint artifacts root with its ``_``-prefixed name (invariant 7).
+    """
+
+    TASKS = Path("/x/tasks")
+    ARTS = Path("/x/tasks_artifacts")
+
+    def test_final_output_path(self):
+        assert final_output_path(self.TASKS, "train", "0") == Path("/x/tasks/train/0.parquet")
+
+    def test_prediction_time_counts_path(self):
+        assert prediction_time_counts_path(self.ARTS, "train") == Path(
+            "/x/tasks_artifacts/train/_prediction_time_counts.parquet"
+        )
+
+    def test_prediction_times_path(self):
+        assert prediction_times_path(self.ARTS, "train", "0") == Path(
+            "/x/tasks_artifacts/train/_prediction_times/0.parquet"
+        )
+
+    def test_index_path(self):
+        assert index_path(self.ARTS, "train", "0") == Path("/x/tasks_artifacts/train/_index/0.parquet")
+
+    def test_final_root_split_dir_holds_only_shard_parquets(self):
+        # The final-output split dir must be directly glob-consumable as `{split}/*.parquet`: no
+        # `_`-prefixed entries (those all live under the artifacts root). Asserting on the name keeps
+        # the "nothing but {shard}.parquet" invariant auditable.
+        name = final_output_path(self.TASKS, "train", "0").name
+        assert name == "0.parquet"
+        assert not name.startswith("_")
+
+    def test_every_intermediate_is_under_the_artifacts_root_not_the_dataset(self):
+        # Invariant 7: no intermediate may resolve inside the final-output root.
+        intermediates = [
+            prediction_time_counts_path(self.ARTS, "train"),
+            prediction_times_path(self.ARTS, "train", "0"),
+            index_path(self.ARTS, "train", "0"),
+        ]
+        for p in intermediates:
+            assert self.ARTS in p.parents
+            assert self.TASKS not in p.parents
+
+    def test_default_artifacts_root_is_disjoint_so_rm_rf_cannot_touch_dataset(self):
+        # The sibling default (from #203) is what makes `rm -rf {artifacts}` safe: the artifacts root
+        # is neither equal to nor nested under the dataset root, and vice versa.
+        arts = default_artifacts_dir(self.TASKS)
+        assert arts != self.TASKS
+        assert self.TASKS not in arts.parents
+        assert arts not in self.TASKS.parents


### PR DESCRIPTION
Closes #204. Part of #202.

Establishes the two-root on-disk layout (spec invariant 7) that every redesigned stage resolves against, layered on #203's `resolve_training_task_paths()` / `default_artifacts_dir()`. Purely additive — pure path functions, no I/O; the legacy pipeline is untouched.

## What's here
- **Centralized intermediate names** (`PREDICTION_TIME_COUNTS_NAME`, `PREDICTION_TIMES_DIRNAME`, `INDEX_DIRNAME`) so Stages 0/3 resolve identical paths with no string drift.
- `final_output_path()` — Stage 4 output `training_tasks_dir/{split}/{shard}.parquet`. The final root holds **nothing but** `{shard}.parquet`, so `{split}/*.parquet` is directly glob-consumable.
- `prediction_time_counts_path()`, `prediction_times_path()`, `index_path()` — all intermediates under `training_task_artifacts_dir`.
- **Atomic-write temp exception documented** in `_atomic_write_parquet`: Stage 4 temps are siblings of the final target (`os.replace` same-filesystem rule), hidden and not `.parquet`-suffixed, so the final-root glob never sees them.

## Deliberately omitted
No `cleanup_task_artifacts` helper — the two roots are disjoint by construction (sibling default), so cleanup stays a single `rm -rf` of the artifacts root.

## Tests
- `TestArtifactLayout`: path map + disjointness / no-`_`-prefix invariants.
- Full `tests/test_sample_tasks.py`: 59 passed; doctests: 6 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)