### PR TITLE
Stage 1: QueryDistribution dataclass (code + float-duration draws) (#206)

### DIFF
--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -192,8 +192,7 @@ class QueryDistribution:
         selected_codes = codes[code_indices]
 
         return [
-            QuerySpec(code=c, duration_days=float(d))
-            for c, d in zip(selected_codes, durations)
+            QuerySpec(code=c, duration_days=float(d)) for c, d in zip(selected_codes, durations, strict=True)
         ]
 
 

--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -188,9 +188,12 @@ class QueryDistribution:
         else:  # "uniform"
             durations = rng.uniform(self.min_duration, self.max_duration, size=num_queries)
 
+        codes = np.array(self.query_codes, dtype=object)
+        selected_codes = codes[code_indices]
+
         return [
-            QuerySpec(code=self.query_codes[int(code_indices[i])], duration_days=float(durations[i]))
-            for i in range(num_queries)
+            QuerySpec(code=c, duration_days=float(d))
+            for c, d in zip(selected_codes, durations)
         ]
 
 

--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -56,6 +56,144 @@ class TaskSpec:
     duration_days: int
 
 
+@dataclass(frozen=True)
+class QuerySpec:
+    """A single sampled query: one code and one float prediction-window duration (in days).
+
+    The redesign's Stage 1 output (see ``redesign-spec.md``).  Unlike the legacy :class:`TaskSpec`,
+    ``duration_days`` is a **float** — durations are not rounded to whole days.
+    """
+
+    code: str
+    duration_days: float
+
+
+@dataclass(frozen=True)
+class QueryDistribution:
+    """The Stage 1 query distribution: owns both the code draw and the duration draw.
+
+    Stage 1 of the redesigned sampler is just ``query_dist.sample(num_queries, rng)``.  Code-universe
+    resolution stays **outside** this dataclass (the caller runs :func:`read_query_codes` and passes the
+    result in), so the dataclass does no file I/O.
+
+    Args:
+        query_codes: Already-resolved code universe (one code per query).  ``query_universe_size`` is
+            derived as ``len(query_codes)``.
+        min_duration: Lower duration bound in days (must be > 0).
+        max_duration: Upper duration bound in days (must be >= ``min_duration``).
+        duration_distribution: ``"uniform"`` or ``"log-uniform"``.  Log-uniform preferentially samples
+            shorter durations.
+
+    Examples:
+        >>> import numpy as np
+        >>> dist = QueryDistribution(["A", "B", "C"], min_duration=1.0, max_duration=365.0,
+        ...                          duration_distribution="log-uniform")
+        >>> dist.query_universe_size
+        3
+        >>> specs = dist.sample(5, np.random.default_rng(0))
+        >>> len(specs)
+        5
+        >>> all(s.code in {"A", "B", "C"} for s in specs)
+        True
+        >>> all(1.0 <= s.duration_days <= 365.0 for s in specs)
+        True
+
+        Durations are floats, not rounded to whole days:
+
+        >>> any(s.duration_days != round(s.duration_days) for s in specs)
+        True
+
+        Determinism — same seed yields identical output:
+
+        >>> from every_query.utils.seeds import derive_seed
+        >>> seed = derive_seed(42, "queries")
+        >>> a = dist.sample(3, np.random.default_rng(seed))
+        >>> b = dist.sample(3, np.random.default_rng(seed))
+        >>> a == b
+        True
+
+        ``num_queries=0`` is valid and returns an empty list:
+
+        >>> dist.sample(0, np.random.default_rng(0))
+        []
+    """
+
+    query_codes: list[str]
+    min_duration: float
+    max_duration: float
+    duration_distribution: str
+
+    _VALID_DISTRIBUTIONS = ("uniform", "log-uniform")
+
+    def __post_init__(self) -> None:
+        if not self.query_codes:
+            raise ValueError("query_codes must be non-empty")
+        if self.min_duration <= 0:
+            raise ValueError(
+                f"min_duration must be > 0 (got {self.min_duration}); durations must be positive days "
+                "and log-uniform needs positive bounds"
+            )
+        if self.max_duration < self.min_duration:
+            raise ValueError(
+                f"max_duration ({self.max_duration}) must be >= min_duration ({self.min_duration})"
+            )
+        if self.duration_distribution not in self._VALID_DISTRIBUTIONS:
+            raise ValueError(
+                f"duration_distribution must be one of {self._VALID_DISTRIBUTIONS} "
+                f"(got {self.duration_distribution!r})"
+            )
+
+    @property
+    def query_universe_size(self) -> int:
+        """Number of distinct query codes (``len(query_codes)``)."""
+        return len(self.query_codes)
+
+    @classmethod
+    def from_config(cls, cfg: DictConfig, query_codes: list[str]) -> "QueryDistribution":
+        """Build from a Hydra config plus a caller-resolved ``query_codes`` list.
+
+        Reads ``min_duration``, ``max_duration``, and ``duration_distribution`` from ``cfg``.  Code
+        resolution via :func:`read_query_codes` stays outside this dataclass (no file I/O here).
+        """
+        return cls(
+            query_codes=query_codes,
+            min_duration=float(cfg.min_duration),
+            max_duration=float(cfg.max_duration),
+            duration_distribution=str(cfg.duration_distribution),
+        )
+
+    def sample(self, num_queries: int, rng: np.random.Generator) -> list[QuerySpec]:
+        """Draw ``num_queries`` iid :class:`QuerySpec` s.
+
+        Codes are uniform over ``[0, query_universe_size)``; durations are drawn over
+        ``[min_duration, max_duration]`` per ``duration_distribution`` as **floats** (no rounding).
+
+        The caller owns the ``rng`` and its seed — for the redesign, seed the query axis via
+        ``np.random.default_rng(derive_seed(seed, "queries"))``.  Draws happen in a fixed order (codes
+        then durations) so output is deterministic for a fixed ``rng``.
+
+        Raises:
+            ValueError: If ``num_queries < 0``.
+        """
+        if num_queries < 0:
+            raise ValueError(f"num_queries must be >= 0 (got {num_queries})")
+        if num_queries == 0:
+            return []
+
+        code_indices = rng.integers(0, self.query_universe_size, size=num_queries)
+        if self.duration_distribution == "log-uniform":
+            durations = np.exp(
+                rng.uniform(np.log(self.min_duration), np.log(self.max_duration), size=num_queries)
+            )
+        else:  # "uniform"
+            durations = rng.uniform(self.min_duration, self.max_duration, size=num_queries)
+
+        return [
+            QuerySpec(code=self.query_codes[int(code_indices[i])], duration_days=float(durations[i]))
+            for i in range(num_queries)
+        ]
+
+
 # ---------------------------------------------------------------------------
 # Pure primitives
 # ---------------------------------------------------------------------------

--- a/tests/test_sample_tasks.py
+++ b/tests/test_sample_tasks.py
@@ -18,16 +18,20 @@ Structure:
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
+import numpy as np
 import polars as pl
 import pytest
 import torch
 from meds import train_split
 from meds_torchdata.config import MEDSTorchDataConfig
+from omegaconf import OmegaConf
 
 from every_query.data.dataset import EveryQueryPytorchDataset
 from every_query.data.schema import TaskQuerySchema
 from every_query.generate_tasks import sample_tasks as st
 from every_query.generate_tasks.sample_tasks import (
+    QueryDistribution,
+    QuerySpec,
     TaskSpec,
     build_index_df,
     compute_max_time_per_subject,
@@ -230,6 +234,84 @@ class TestPrimitives:
             subj_max = synthetic_events.filter(pl.col("subject_id") == subj)["time"].max()
             row = max_df.filter(pl.col("subject_id") == subj).row(0, named=True)
             assert row["max_time"] == subj_max
+
+
+# ---------------------------------------------------------------------------
+# QueryDistribution (Stage 1)
+# ---------------------------------------------------------------------------
+
+
+class TestQueryDistribution:
+    """Unit tests for the redesigned Stage 1 query draw (``QueryDistribution``)."""
+
+    def _rng(self, *parts):
+        """Build an rng seeded on the ``queries`` axis, mirroring the redesign caller."""
+        return np.random.default_rng(derive_seed(*parts, "queries"))
+
+    def test_query_universe_size_is_derived(self, synthetic_query_codes):
+        dist = QueryDistribution(synthetic_query_codes, 1.0, 365.0, "log-uniform")
+        assert dist.query_universe_size == len(synthetic_query_codes)
+
+    def test_from_config_builds_expected_dataclass(self, synthetic_query_codes):
+        cfg = OmegaConf.create(
+            {"min_duration": 1, "max_duration": 731, "duration_distribution": "log-uniform"}
+        )
+        dist = QueryDistribution.from_config(cfg, query_codes=synthetic_query_codes)
+        assert dist == QueryDistribution(synthetic_query_codes, 1.0, 731.0, "log-uniform")
+        assert isinstance(dist.min_duration, float) and isinstance(dist.max_duration, float)
+
+    def test_sample_determinism(self, synthetic_query_codes):
+        dist = QueryDistribution(synthetic_query_codes, 1.0, 365.0, "log-uniform")
+        a = dist.sample(32, self._rng(42))
+        b = dist.sample(32, self._rng(42))
+        assert a == b
+
+    def test_sample_different_seeds_differ(self, synthetic_query_codes):
+        dist = QueryDistribution(synthetic_query_codes, 1.0, 365.0, "log-uniform")
+        a = dist.sample(32, self._rng(1))
+        b = dist.sample(32, self._rng(2))
+        assert a != b
+
+    @pytest.mark.parametrize("distribution", ["uniform", "log-uniform"])
+    def test_sample_respects_bounds(self, synthetic_query_codes, distribution):
+        dist = QueryDistribution(synthetic_query_codes, 10.0, 100.0, distribution)
+        specs = dist.sample(256, self._rng(7))
+        assert all(isinstance(s, QuerySpec) for s in specs)
+        assert all(s.code in synthetic_query_codes for s in specs)
+        assert all(10.0 <= s.duration_days <= 100.0 for s in specs)
+
+    @pytest.mark.parametrize("distribution", ["uniform", "log-uniform"])
+    def test_durations_are_unrounded_floats(self, synthetic_query_codes, distribution):
+        """Durations stay float — the intentional divergence from legacy whole-day quantization."""
+        dist = QueryDistribution(synthetic_query_codes, 1.0, 731.0, distribution)
+        specs = dist.sample(64, self._rng(3))
+        assert all(isinstance(s.duration_days, float) for s in specs)
+        assert any(s.duration_days != round(s.duration_days) for s in specs)
+
+    def test_sample_zero_returns_empty(self, synthetic_query_codes):
+        dist = QueryDistribution(synthetic_query_codes, 1.0, 365.0, "uniform")
+        assert dist.sample(0, self._rng(0)) == []
+
+    def test_sample_rejects_negative_num_queries(self, synthetic_query_codes):
+        dist = QueryDistribution(synthetic_query_codes, 1.0, 365.0, "uniform")
+        with pytest.raises(ValueError, match="num_queries"):
+            dist.sample(-1, self._rng(0))
+
+    def test_rejects_empty_query_codes(self):
+        with pytest.raises(ValueError, match="query_codes"):
+            QueryDistribution([], 1.0, 365.0, "uniform")
+
+    def test_rejects_nonpositive_min_duration(self, synthetic_query_codes):
+        with pytest.raises(ValueError, match="min_duration"):
+            QueryDistribution(synthetic_query_codes, 0.0, 365.0, "uniform")
+
+    def test_rejects_inverted_bounds(self, synthetic_query_codes):
+        with pytest.raises(ValueError, match="max_duration"):
+            QueryDistribution(synthetic_query_codes, 100.0, 50.0, "uniform")
+
+    def test_rejects_unknown_distribution(self, synthetic_query_codes):
+        with pytest.raises(ValueError, match="duration_distribution"):
+            QueryDistribution(synthetic_query_codes, 1.0, 365.0, "normal")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implements **Stage 1** of the task-sampler redesign (epic #202): replaces the legacy `TaskSpec`/`sample_tasks` query draw with a `QueryDistribution` dataclass that owns both the code draw and the duration draw.

## Changes
`src/every_query/generate_tasks/sample_tasks.py`:
- **`QuerySpec`** — frozen dataclass: `code: str`, `duration_days: float`.
- **`QueryDistribution(query_codes, min_duration, max_duration, uniform|log-uniform)`**:
  - `__post_init__` validation (non-empty codes, `min_duration > 0`, `max >= min`, valid distribution).
  - `query_universe_size` derived as `len(query_codes)` (no `num_codes` knob).
  - `from_config(cfg, query_codes)` — reads the #203 config keys; code resolution via `read_query_codes()` stays **outside** the dataclass (no file I/O).
  - `sample(num_queries, rng)` — draws codes then durations in fixed order; **float durations, no rounding/clipping**. Caller seeds the query axis via `derive_seed(seed, "queries")`.

`tests/test_sample_tasks.py`: new `TestQueryDistribution` class (determinism, bounds, both distribution modes, the unrounded-float guard, `from_config`, validation errors).

## Scope / isolation
- Added **alongside** the legacy `TaskSpec`/`sample_tasks` (nothing removed) — those are still wired into the current worker path and get removed when Stage 3 (#208) rewires the driver. This keeps the PR non-breaking.
- Branched off `dev-task-sampler`, so it has #203/#204 but **not** Stage 0 (#205, in review) — fully isolated from that PR.

## Note
Float durations intentionally diverge from legacy whole-day quantization — a given seed won't reproduce legacy `duration_days`/labels.

## Verification
- `uv run pytest tests/test_sample_tasks.py -k QueryDistribution` → 14 passed
- `uv run pytest --doctest-modules src/every_query/generate_tasks/sample_tasks.py` → 7 passed
- Legacy `TestPrimitives` → 23 passed; `ruff check`/`format` clean

Part of #202. Closes #206.

🤖 Generated with [Claude Code](https://claude.com/claude-code)