### PR TITLE
Add Stage 2 vectorized patient-context sampling (#207)

### DIFF
--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -304,7 +304,7 @@ def sample_patient_contexts(
         )
 
     # Step A — subject indices (consumed first), with replacement.
-    subject_idx = pl.Series(rng.integers(0, patient_universe_size, size=n))
+    subject_idx = rng.integers(0, patient_universe_size, size=n)
     subject_id = prediction_time_counts["subject_id"].gather(subject_idx)
     shard = prediction_time_counts["shard"].gather(subject_idx)
     n_prediction_times = prediction_time_counts["n_prediction_times"].gather(subject_idx).to_numpy()

--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -197,6 +197,142 @@ class QueryDistribution:
 
 
 # ---------------------------------------------------------------------------
+# Stage 2 (redesign): vectorized patient-context sampling
+# ---------------------------------------------------------------------------
+
+
+def sample_patient_contexts(
+    prediction_time_counts: pl.DataFrame,
+    n: int,
+    min_prediction_times_per_subject: int,
+    rng: np.random.Generator,
+) -> pl.DataFrame:
+    """Draw ``n`` patient contexts ``(subject_id, shard, prediction_time_index)`` (redesign Stage 2).
+
+    A patient context is a ``(subject_idx, prediction_time_index)`` pair; the timestamp itself is
+    resolved later (Stage 3).  Sampling is two vectorized RNG draws over the Stage 0
+    ``_prediction_time_counts`` table — whose **row position is ``subject_idx``** (the table is sorted
+    by ``subject_id``), so per-subject ``n_prediction_times`` is gathered by row index, not a dict
+    lookup.  ``patient_universe_size`` is *derived* as the table height, not passed in.
+
+    The caller owns the ``rng`` and its seed — for the redesign, seed the context axis via
+    ``np.random.default_rng(derive_seed(seed, "contexts"))``.  Draws happen in a fixed order — all
+    ``subject_idx`` (Step A), then all ``prediction_time_index`` (Step B) — so output is deterministic
+    for a fixed ``rng`` (spec invariant 5).
+
+    Args:
+        prediction_time_counts: Stage 0 summary, one row per eligible subject with columns
+            ``subject_id``, ``shard``, ``n_prediction_times``, sorted by ``subject_id`` so row
+            position equals ``subject_idx``.
+        n: Number of contexts to draw (``N = num_queries * num_contexts_per_query``).  Subjects are
+            drawn **with replacement** (``N`` typically exceeds the eligible universe; iid-ness matters
+            more than coverage, duplicate rows allowed).
+        min_prediction_times_per_subject: Minimum prior prediction times required.  Sets the draw
+            ``low``; since ``prediction_time_index`` is a zero-based rank, ``low`` selects the
+            ``(low + 1)``-th distinct timestamp with exactly ``low`` before it (spec invariant 2).
+        rng: Caller-owned NumPy generator.
+
+    Returns:
+        Length-``n`` ``DataFrame`` with columns ``(subject_id, shard, prediction_time_index)``;
+        ``subject_id``/``shard`` keep the table's dtypes and ``prediction_time_index`` is ``Int64``
+        (matches the Stage 0 ``_prediction_times`` map for the Stage 3 join).
+
+    Raises:
+        ValueError: If ``n < 0``, or ``n > 0`` while ``prediction_time_counts`` is empty, or a counts
+            row has ``n_prediction_times <= min_prediction_times_per_subject`` (a Stage 0 eligibility
+            violation ⇒ stale/corrupt counts table, which would make the Step B range empty).
+
+    Examples:
+        >>> import numpy as np
+        >>> import polars as pl
+        >>> from every_query.utils.seeds import derive_seed
+        >>> counts = pl.DataFrame(
+        ...     {
+        ...         "subject_id": [10, 20, 30],
+        ...         "shard": ["0", "0", "1"],
+        ...         "n_prediction_times": [60, 80, 120],
+        ...     }
+        ... )
+        >>> rng = np.random.default_rng(derive_seed(0, "contexts"))
+        >>> ctx = sample_patient_contexts(counts, n=100, min_prediction_times_per_subject=50, rng=rng)
+        >>> ctx.height
+        100
+        >>> ctx.columns
+        ['subject_id', 'shard', 'prediction_time_index']
+
+        Every draw lands in ``[min, n_prediction_times)`` for its subject:
+
+        >>> checked = ctx.join(counts, on="subject_id", how="left")
+        >>> bool(
+        ...     (checked["prediction_time_index"] >= 50).all()
+        ...     and (checked["prediction_time_index"] < checked["n_prediction_times"]).all()
+        ... )
+        True
+
+        Determinism — same seed yields identical output:
+
+        >>> a = sample_patient_contexts(counts, 32, 50, np.random.default_rng(derive_seed(7, "contexts")))
+        >>> b = sample_patient_contexts(counts, 32, 50, np.random.default_rng(derive_seed(7, "contexts")))
+        >>> a.equals(b)
+        True
+
+        ``n=0`` is valid and returns an empty, correctly-typed frame:
+
+        >>> sample_patient_contexts(counts, 0, 50, rng).height
+        0
+    """
+    if n < 0:
+        raise ValueError(f"n must be >= 0 (got {n})")
+
+    sid_dtype = prediction_time_counts.schema.get("subject_id", pl.Int64)
+    shard_dtype = prediction_time_counts.schema.get("shard", pl.Utf8)
+
+    if n == 0:
+        return pl.DataFrame(
+            schema={
+                "subject_id": sid_dtype,
+                "shard": shard_dtype,
+                "prediction_time_index": pl.Int64,
+            }
+        )
+
+    patient_universe_size = prediction_time_counts.height
+    if patient_universe_size == 0:
+        raise ValueError(
+            f"prediction_time_counts is empty but n={n} contexts were requested; Stage 0 should "
+            "produce a non-empty eligible subject universe"
+        )
+
+    # Step A — subject indices (consumed first), with replacement.
+    subject_idx = pl.Series(rng.integers(0, patient_universe_size, size=n))
+    subject_id = prediction_time_counts["subject_id"].gather(subject_idx)
+    shard = prediction_time_counts["shard"].gather(subject_idx)
+    n_prediction_times = prediction_time_counts["n_prediction_times"].gather(subject_idx).to_numpy()
+
+    # Stage 0 eligibility guarantees a non-empty Step B range; a violation means a stale/corrupt
+    # counts table, which would make `rng.integers(low, high)` illegal (low >= high) for some rows.
+    if not (n_prediction_times > min_prediction_times_per_subject).all():
+        raise ValueError(
+            "prediction_time_counts contains a subject with "
+            f"n_prediction_times <= min_prediction_times_per_subject ({min_prediction_times_per_subject}); "
+            "Stage 0 eligibility requires n_prediction_times >= min_prediction_times_per_subject + 1 — "
+            "the counts table is stale or corrupt and must be rebuilt from _prediction_times/"
+        )
+
+    # Step B — prediction-time indices (consumed second): one array-bounded draw, one per row in row
+    # order.  `high` exclusive ⇒ the subject's last prediction time (index n-1) is eligible.
+    prediction_time_index = rng.integers(low=min_prediction_times_per_subject, high=n_prediction_times)
+
+    return pl.DataFrame(
+        {
+            "subject_id": subject_id,
+            "shard": shard,
+            "prediction_time_index": pl.Series(prediction_time_index, dtype=pl.Int64),
+        }
+    )
+
+
+# ---------------------------------------------------------------------------
 # Pure primitives
 # ---------------------------------------------------------------------------
 

--- a/tests/test_sample_tasks.py
+++ b/tests/test_sample_tasks.py
@@ -44,6 +44,7 @@ from every_query.generate_tasks.sample_tasks import (
     resolve_training_task_paths,
     run_worker,
     sample_contexts,
+    sample_patient_contexts,
     sample_tasks,
 )
 from every_query.utils.seeds import derive_seed
@@ -312,6 +313,127 @@ class TestQueryDistribution:
     def test_rejects_unknown_distribution(self, synthetic_query_codes):
         with pytest.raises(ValueError, match="duration_distribution"):
             QueryDistribution(synthetic_query_codes, 1.0, 365.0, "normal")
+
+
+# ---------------------------------------------------------------------------
+# sample_patient_contexts (Stage 2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def prediction_time_counts() -> pl.DataFrame:
+    """A small Stage 0 ``_prediction_time_counts`` table, sorted by ``subject_id``.
+
+    Row position is ``subject_idx``; subjects span two shards with varying ``n_prediction_times``.
+    """
+    return pl.DataFrame(
+        {
+            "subject_id": [10, 20, 30, 40, 50],
+            "shard": ["0", "0", "0", "1", "1"],
+            "n_prediction_times": [60, 51, 200, 80, 120],
+        }
+    )
+
+
+class TestSamplePatientContexts:
+    """Unit tests for the redesigned Stage 2 patient-context draw (``sample_patient_contexts``)."""
+
+    def _rng(self, *parts):
+        """Build an rng seeded on the ``contexts`` axis, mirroring the redesign caller."""
+        return np.random.default_rng(derive_seed(*parts, "contexts"))
+
+    def test_shape_and_columns(self, prediction_time_counts):
+        ctx = sample_patient_contexts(
+            prediction_time_counts, n=256, min_prediction_times_per_subject=50, rng=self._rng(0)
+        )
+        assert ctx.height == 256
+        assert ctx.columns == ["subject_id", "shard", "prediction_time_index"]
+
+    def test_determinism(self, prediction_time_counts):
+        a = sample_patient_contexts(prediction_time_counts, 128, 50, self._rng(42))
+        b = sample_patient_contexts(prediction_time_counts, 128, 50, self._rng(42))
+        assert a.equals(b)
+
+    def test_different_seeds_differ(self, prediction_time_counts):
+        a = sample_patient_contexts(prediction_time_counts, 128, 50, self._rng(1))
+        b = sample_patient_contexts(prediction_time_counts, 128, 50, self._rng(2))
+        assert not a.equals(b)
+
+    def test_draw_range_invariant(self, prediction_time_counts):
+        """Every prediction_time_index lands in ``[min, n_prediction_times)`` for its subject."""
+        ctx = sample_patient_contexts(prediction_time_counts, 5000, 50, self._rng(7))
+        checked = ctx.join(prediction_time_counts, on="subject_id", how="left")
+        assert (checked["prediction_time_index"] >= 50).all()
+        assert (checked["prediction_time_index"] < checked["n_prediction_times"]).all()
+
+    def test_last_prediction_time_is_reachable(self, prediction_time_counts):
+        """The subject's last index (n_prediction_times - 1) is eligible (high is exclusive)."""
+        # subject 20 has the tightest range: [50, 51) ⇒ only index 50 == n_prediction_times - 1.
+        ctx = sample_patient_contexts(prediction_time_counts, 5000, 50, self._rng(3))
+        sub20 = ctx.filter(pl.col("subject_id") == 20)
+        assert sub20.height > 0
+        assert (sub20["prediction_time_index"] == 50).all()
+        # Across all subjects, some draw reaches the last eligible index.
+        checked = ctx.join(prediction_time_counts, on="subject_id", how="left")
+        assert (checked["prediction_time_index"] == checked["n_prediction_times"] - 1).any()
+
+    def test_subject_shard_mapping_is_consistent(self, prediction_time_counts):
+        """Every (subject_id, shard) pair in the output matches the fixture (no cross-wiring)."""
+        ctx = sample_patient_contexts(prediction_time_counts, 2000, 50, self._rng(9))
+        pairs = set(zip(ctx["subject_id"].to_list(), ctx["shard"].to_list(), strict=True))
+        truth = set(
+            zip(
+                prediction_time_counts["subject_id"].to_list(),
+                prediction_time_counts["shard"].to_list(),
+                strict=True,
+            )
+        )
+        assert pairs <= truth
+
+    def test_with_replacement_allows_n_above_universe(self, prediction_time_counts):
+        """N may far exceed the eligible universe; sampling is with replacement."""
+        n = 10 * prediction_time_counts.height
+        ctx = sample_patient_contexts(prediction_time_counts, n, 50, self._rng(0))
+        assert ctx.height == n
+
+    def test_n_zero_returns_typed_empty(self, prediction_time_counts):
+        ctx = sample_patient_contexts(prediction_time_counts, 0, 50, self._rng(0))
+        assert ctx.height == 0
+        assert ctx.columns == ["subject_id", "shard", "prediction_time_index"]
+        assert ctx.schema["subject_id"] == prediction_time_counts.schema["subject_id"]
+        assert ctx.schema["shard"] == prediction_time_counts.schema["shard"]
+        assert ctx.schema["prediction_time_index"] == pl.Int64
+
+    def test_rejects_negative_n(self, prediction_time_counts):
+        with pytest.raises(ValueError, match="n must be"):
+            sample_patient_contexts(prediction_time_counts, -1, 50, self._rng(0))
+
+    def test_rejects_empty_counts_when_n_positive(self):
+        empty = pl.DataFrame(
+            schema={"subject_id": pl.Int64, "shard": pl.Utf8, "n_prediction_times": pl.Int64}
+        )
+        with pytest.raises(ValueError, match="empty"):
+            sample_patient_contexts(empty, 10, 50, self._rng(0))
+
+    def test_rejects_ineligible_subject(self):
+        """A counts row violating Stage 0 eligibility (n <= min) raises (stale-table guard)."""
+        bad = pl.DataFrame(
+            {"subject_id": [1, 2], "shard": ["0", "0"], "n_prediction_times": [60, 50]}
+        )
+        with pytest.raises(ValueError, match="stale or corrupt"):
+            sample_patient_contexts(bad, 100, 50, self._rng(0))
+
+    def test_subject_axis_consumed_before_time_axis(self, prediction_time_counts):
+        """Invariant 5: Step A (subject_idx) is consumed before Step B (prediction_time_index).
+
+        With the same seed, the subject_id/shard columns of an ``n`` draw are the prefix of an
+        ``n + k`` draw — the subject axis is drawn fully first, so growing N only appends.
+        """
+        small = sample_patient_contexts(prediction_time_counts, 32, 50, self._rng(11))
+        large = sample_patient_contexts(prediction_time_counts, 64, 50, self._rng(11))
+        assert small.select(["subject_id", "shard"]).equals(
+            large.head(32).select(["subject_id", "shard"])
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_sample_tasks.py
+++ b/tests/test_sample_tasks.py
@@ -417,9 +417,7 @@ class TestSamplePatientContexts:
 
     def test_rejects_ineligible_subject(self):
         """A counts row violating Stage 0 eligibility (n <= min) raises (stale-table guard)."""
-        bad = pl.DataFrame(
-            {"subject_id": [1, 2], "shard": ["0", "0"], "n_prediction_times": [60, 50]}
-        )
+        bad = pl.DataFrame({"subject_id": [1, 2], "shard": ["0", "0"], "n_prediction_times": [60, 50]})
         with pytest.raises(ValueError, match="stale or corrupt"):
             sample_patient_contexts(bad, 100, 50, self._rng(0))
 
@@ -431,9 +429,7 @@ class TestSamplePatientContexts:
         """
         small = sample_patient_contexts(prediction_time_counts, 32, 50, self._rng(11))
         large = sample_patient_contexts(prediction_time_counts, 64, 50, self._rng(11))
-        assert small.select(["subject_id", "shard"]).equals(
-            large.head(32).select(["subject_id", "shard"])
-        )
+        assert small.select(["subject_id", "shard"]).equals(large.head(32).select(["subject_id", "shard"]))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Implement `sample_patient_contexts`, the redesigned Stage 2 of the task sampler (epic #202). It draws N = num_queries * num_contexts_per_query patient contexts as two vectorized RNG draws over the Stage 0 `_prediction_time_counts` table (row position = subject_idx):

- Step A: subject_idx = rng.integers(0, patient_universe_size, size=N) with replacement; gather subject_id/shard/n_prediction_times by row index.
- Step B: one array-bounded rng.integers(low=min_prediction_times_per_subject, high=n_prediction_times[subject_idx]) — exactly one draw per row.

The single RNG is consumed in fixed order (all subject_idx, then all prediction_time_index) for determinism (spec invariant 5). Output is a length-N frame (subject_id, shard, prediction_time_index) with prediction_time_index typed Int64 to match the Stage 0 map for the Stage 3 join. Guards reject n < 0, an empty universe with n > 0, and a stale counts table (n_prediction_times <= min). The legacy event-based `sample_contexts` is left untouched (still used by the legacy pipeline and tests).

Adds TestSamplePatientContexts covering shape, determinism, draw-range invariant, subject/shard mapping, with-replacement, typed empty, input validation, and RNG consumption order.


Claude-Session: https://claude.ai/code/session_01J29LY8NXEtSGPBNpR8XRvD