### PR TITLE
Stage 3: resolve prediction times, zip queries, write partitioned ind…

### DIFF
--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -1330,9 +1330,7 @@ def build_index(
     # rather than materializing every shard's frame up front.
     for shard_key, shard_group in combined.group_by("shard"):
         (shard_name,) = shard_key
-        pt_map = pl.read_parquet(
-            prediction_times_path(training_task_artifacts_dir, split, str(shard_name))
-        )
+        pt_map = pl.read_parquet(prediction_times_path(training_task_artifacts_dir, split, str(shard_name)))
 
         # Guard against silent all-null joins from join-key dtype drift between the Stage 2
         # contexts and the Stage 0 map (e.g. Int64 vs UInt32 ``subject_id``). A mismatch is an

--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -1326,8 +1326,10 @@ def build_index(
     # One ``read_parquet`` per shard is deliberate: the map is read exactly once and the driver
     # holds only the current shard's payload-free map, keeping memory flat as shard count grows.
     # Caching every shard's map would trade that guarantee away for no IO win within a single call.
-    for shard_group in combined.partition_by("shard"):
-        shard_name = shard_group["shard"][0]
+    # ``group_by`` (not ``partition_by``) for the same reason — it streams one group at a time
+    # rather than materializing every shard's frame up front.
+    for shard_key, shard_group in combined.group_by("shard"):
+        (shard_name,) = shard_key
         pt_map = pl.read_parquet(
             prediction_times_path(training_task_artifacts_dir, split, str(shard_name))
         )

--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -1328,7 +1328,7 @@ def build_index(
     # Caching every shard's map would trade that guarantee away for no IO win within a single call.
     # ``group_by`` (not ``partition_by``) for the same reason — it streams one group at a time
     # rather than materializing every shard's frame up front.
-    
+
     # Sort to make order that shards are processed deterministic
     combined = combined.sort("shard")
     for shard_key, shard_group in combined.group_by("shard"):

--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -1320,23 +1320,46 @@ def build_index(
         TaskQuerySchema.duration_days_name,
     ]
 
+    join_keys = ["subject_id", "prediction_time_index"]
+
     n_shards = 0
-    for (shard_name,), shard_group in combined.group_by("shard"):
+    # One ``read_parquet`` per shard is deliberate: the map is read exactly once and the driver
+    # holds only the current shard's payload-free map, keeping memory flat as shard count grows.
+    # Caching every shard's map would trade that guarantee away for no IO win within a single call.
+    for shard_group in combined.partition_by("shard"):
+        shard_name = shard_group["shard"][0]
         pt_map = pl.read_parquet(
             prediction_times_path(training_task_artifacts_dir, split, str(shard_name))
         )
+
+        # Guard against silent all-null joins from join-key dtype drift between the Stage 2
+        # contexts and the Stage 0 map (e.g. Int64 vs UInt32 ``subject_id``). A mismatch is an
+        # upstream bug, so fail loudly rather than papering over it with a cast.
+        for key in join_keys:
+            ctx_dtype, map_dtype = shard_group.schema[key], pt_map.schema[key]
+            if ctx_dtype != map_dtype:
+                raise ValueError(
+                    f"Join key {key!r} dtype mismatch: contexts has {ctx_dtype}, the "
+                    f"_prediction_times map has {map_dtype}. A mismatch silently produces null "
+                    "prediction_times; fix the dtype upstream."
+                )
+
         joined = shard_group.join(
             pt_map,
-            on=["subject_id", "prediction_time_index"],
+            on=join_keys,
             how="left",
         ).rename({"time": TaskQuerySchema.prediction_time_name})
 
-        null_count = joined[TaskQuerySchema.prediction_time_name].null_count()
-        if null_count > 0:
+        # Left-join-then-raise (rather than an inner join that silently drops rows) keeps the
+        # failure explicit and debuggable. The join is total by design — same eligibility bound
+        # as Stage 2 — so any null is a hard error, and a small sample helps pinpoint the cause.
+        null_rows = joined.filter(pl.col(TaskQuerySchema.prediction_time_name).is_null())
+        if null_rows.height > 0:
+            sample = null_rows.select(join_keys).head(5).to_dicts()
             raise ValueError(
-                f"Shard {shard_name}: {null_count} contexts have null prediction_time after join. "
-                "The _prediction_times map may be stale or contexts reference invalid "
-                "(subject_id, prediction_time_index) pairs."
+                f"Shard {shard_name}: {null_rows.height} contexts have null prediction_time "
+                "after join. The _prediction_times map may be stale or contexts reference invalid "
+                f"(subject_id, prediction_time_index) pairs. Sample of offending rows: {sample}"
             )
 
         _atomic_write_parquet(

--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -1243,6 +1243,116 @@ def build_prediction_times(
     return eligible.height
 
 
+# ---------------------------------------------------------------------------
+# Redesign (issue #208): Stage 3 — resolve prediction times and build index
+# ---------------------------------------------------------------------------
+#
+# Stage 3 is the single index-resolution point (spec invariant 3): it zips Stage 1 queries with
+# Stage 2 contexts, resolves ``prediction_time_index → prediction_time`` per shard via the Stage 0
+# ``_prediction_times/`` map, and writes the partitioned ``_index/{shard}.parquet`` files that
+# Stage 4 consumes directly.  Stage 4 never resolves indices — it receives timestamps.
+
+
+def build_index(
+    queries: list[QuerySpec],
+    contexts: pl.DataFrame,
+    training_task_artifacts_dir: Path,
+    split: str,
+    num_contexts_per_query: int,
+) -> None:
+    """Stage 3: zip queries with contexts, resolve prediction times, write partitioned index.
+
+    ``np.repeat`` s the Stage 1 queries ``num_contexts_per_query`` times and zips them with the
+    Stage 2 contexts (length ``len(queries) * num_contexts_per_query``).  For each shard, joins
+    against the Stage 0 ``_prediction_times/{shard}.parquet`` map on
+    ``(subject_id, prediction_time_index)`` to resolve the timestamp, then writes
+    ``_index/{shard}.parquet`` with columns
+    ``["subject_id", "prediction_time", "query", "duration_days"]``.
+
+    The join is **per shard** (not one global join) so the driver holds only one shard's
+    payload-free map at a time, keeping memory flat.  The join is total (same eligibility as
+    Stage 2's bound) — a null ``prediction_time`` after the join is a hard error.
+
+    Args:
+        queries: Stage 1 output — ``num_queries`` :class:`QuerySpec` instances.
+        contexts: Stage 2 output — ``(subject_id, shard, prediction_time_index)`` frame of
+            length ``len(queries) * num_contexts_per_query``.
+        training_task_artifacts_dir: Intermediate-artifacts root.
+        split: Dataset split name (e.g. ``"train"``).
+        num_contexts_per_query: Number of patient contexts per query (the ``M`` multiplier).
+
+    Raises:
+        ValueError: If ``contexts.height != len(queries) * num_contexts_per_query``, or if
+            any context fails to resolve a prediction time (null after join).
+    """
+    n_queries = len(queries)
+    expected = n_queries * num_contexts_per_query
+
+    if contexts.height != expected:
+        raise ValueError(
+            f"contexts.height ({contexts.height}) must equal "
+            f"len(queries) * num_contexts_per_query ({n_queries} * {num_contexts_per_query} = {expected})"
+        )
+
+    if n_queries == 0 or contexts.height == 0:
+        return
+
+    query_col = pl.Series(
+        TaskQuerySchema.query_name,
+        np.repeat([q.code for q in queries], num_contexts_per_query),
+        dtype=pl.Utf8,
+    )
+    duration_col = pl.Series(
+        TaskQuerySchema.duration_days_name,
+        np.repeat([q.duration_days for q in queries], num_contexts_per_query).astype(np.float32),
+        dtype=pl.Float32,
+    )
+    combined = contexts.with_columns(query_col, duration_col)
+
+    index_dir = training_task_artifacts_dir / split / INDEX_DIRNAME
+    if index_dir.exists():
+        shutil.rmtree(index_dir)
+
+    output_cols = [
+        TaskQuerySchema.subject_id_name,
+        TaskQuerySchema.prediction_time_name,
+        TaskQuerySchema.query_name,
+        TaskQuerySchema.duration_days_name,
+    ]
+
+    n_shards = 0
+    for (shard_name,), shard_group in combined.group_by("shard"):
+        pt_map = pl.read_parquet(
+            prediction_times_path(training_task_artifacts_dir, split, str(shard_name))
+        )
+        joined = shard_group.join(
+            pt_map,
+            on=["subject_id", "prediction_time_index"],
+            how="left",
+        ).rename({"time": TaskQuerySchema.prediction_time_name})
+
+        null_count = joined[TaskQuerySchema.prediction_time_name].null_count()
+        if null_count > 0:
+            raise ValueError(
+                f"Shard {shard_name}: {null_count} contexts have null prediction_time after join. "
+                "The _prediction_times map may be stale or contexts reference invalid "
+                "(subject_id, prediction_time_index) pairs."
+            )
+
+        _atomic_write_parquet(
+            joined.select(output_cols),
+            index_path(training_task_artifacts_dir, split, str(shard_name)),
+        )
+        n_shards += 1
+
+    logger.info(
+        "Stage 3: wrote partitioned index for split=%s (%d rows across %d shards).",
+        split,
+        contexts.height,
+        n_shards,
+    )
+
+
 CONFIGS = str(files("every_query") / "generate_tasks" / "configs")
 
 

--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -1328,6 +1328,9 @@ def build_index(
     # Caching every shard's map would trade that guarantee away for no IO win within a single call.
     # ``group_by`` (not ``partition_by``) for the same reason — it streams one group at a time
     # rather than materializing every shard's frame up front.
+    
+    # Sort to make order that shards are processed deterministic
+    combined = combined.sort("shard")
     for shard_key, shard_group in combined.group_by("shard"):
         (shard_name,) = shard_key
         pt_map = pl.read_parquet(prediction_times_path(training_task_artifacts_dir, split, str(shard_name)))

--- a/tests/test_sample_tasks.py
+++ b/tests/test_sample_tasks.py
@@ -1526,6 +1526,26 @@ class TestStage3:
         with pytest.raises(ValueError, match="null prediction_time"):
             build_index(queries, contexts, artifacts_dir, "train", num_contexts_per_query=1)
 
+    def test_null_error_includes_offending_sample(self, stage0_env):
+        _, artifacts_dir = stage0_env
+        queries = [QuerySpec("ICD//A", 5.0)]
+        contexts = self._make_contexts([1], ["0"], [999])
+        with pytest.raises(ValueError, match=r"Sample of offending rows.*999"):
+            build_index(queries, contexts, artifacts_dir, "train", num_contexts_per_query=1)
+
+    def test_join_key_dtype_mismatch_raises(self, stage0_env):
+        _, artifacts_dir = stage0_env
+        queries = [QuerySpec("ICD//A", 5.0)]
+        # ``prediction_time_index`` as UInt32 mismatches the Stage 0 map's Int64 — a silent
+        # all-null join without the dtype guard.
+        contexts = pl.DataFrame({
+            "subject_id": [1],
+            "shard": ["0"],
+            "prediction_time_index": pl.Series([3], dtype=pl.UInt32),
+        })
+        with pytest.raises(ValueError, match="dtype mismatch"):
+            build_index(queries, contexts, artifacts_dir, "train", num_contexts_per_query=1)
+
     def test_empty_queries(self, stage0_env):
         _, artifacts_dir = stage0_env
         contexts = pl.DataFrame(

--- a/tests/test_sample_tasks.py
+++ b/tests/test_sample_tasks.py
@@ -1442,10 +1442,12 @@ class TestStage3:
         path_to_data = _write_split_shards(
             tmp_path,
             {
-                "0": pl.concat([
-                    _subject_events(1, 5, base=self.BASE),
-                    _subject_events(2, 4, base=self.BASE),
-                ]),
+                "0": pl.concat(
+                    [
+                        _subject_events(1, 5, base=self.BASE),
+                        _subject_events(2, 4, base=self.BASE),
+                    ]
+                ),
                 "1": _subject_events(3, 4, base=self.BASE),
             },
         )
@@ -1454,17 +1456,21 @@ class TestStage3:
         return path_to_data, artifacts_dir
 
     def _make_contexts(self, subject_ids, shards, indices):
-        return pl.DataFrame({
-            "subject_id": subject_ids,
-            "shard": shards,
-            "prediction_time_index": pl.Series(indices, dtype=pl.Int64),
-        })
+        return pl.DataFrame(
+            {
+                "subject_id": subject_ids,
+                "shard": shards,
+                "prediction_time_index": pl.Series(indices, dtype=pl.Int64),
+            }
+        )
 
     def test_basic_columns_and_row_count(self, stage0_env):
         _, artifacts_dir = stage0_env
         queries = [QuerySpec("ICD//A", 30.5), QuerySpec("ICD//B", 60.0)]
         contexts = self._make_contexts(
-            [1, 1, 1, 1], ["0", "0", "0", "0"], [2, 3, 2, 4],
+            [1, 1, 1, 1],
+            ["0", "0", "0", "0"],
+            [2, 3, 2, 4],
         )
         build_index(queries, contexts, artifacts_dir, "train", num_contexts_per_query=2)
 
@@ -1479,7 +1485,9 @@ class TestStage3:
         _, artifacts_dir = stage0_env
         queries = [QuerySpec("ICD//X", 10.0)]
         contexts = self._make_contexts(
-            [1, 3], ["0", "1"], [3, 3],
+            [1, 3],
+            ["0", "1"],
+            [3, 3],
         )
         build_index(queries, contexts, artifacts_dir, "train", num_contexts_per_query=2)
 
@@ -1493,11 +1501,7 @@ class TestStage3:
     def test_prediction_time_resolution_correctness(self, stage0_env):
         _, artifacts_dir = stage0_env
         pt_map = pl.read_parquet(prediction_times_path(artifacts_dir, "train", "0"))
-        s1_times = (
-            pt_map.filter(pl.col("subject_id") == 1)
-            .sort("prediction_time_index")["time"]
-            .to_list()
-        )
+        s1_times = pt_map.filter(pl.col("subject_id") == 1).sort("prediction_time_index")["time"].to_list()
 
         queries = [QuerySpec("ICD//A", 7.0)]
         contexts = self._make_contexts([1, 1], ["0", "0"], [2, 4])
@@ -1511,7 +1515,9 @@ class TestStage3:
         _, artifacts_dir = stage0_env
         queries = [QuerySpec("ICD//FIRST", 10.0), QuerySpec("ICD//SECOND", 20.0)]
         contexts = self._make_contexts(
-            [1, 1, 2, 2], ["0", "0", "0", "0"], [3, 4, 3, 3],
+            [1, 1, 2, 2],
+            ["0", "0", "0", "0"],
+            [3, 4, 3, 3],
         )
         build_index(queries, contexts, artifacts_dir, "train", num_contexts_per_query=2)
 
@@ -1538,11 +1544,13 @@ class TestStage3:
         queries = [QuerySpec("ICD//A", 5.0)]
         # ``prediction_time_index`` as UInt32 mismatches the Stage 0 map's Int64 — a silent
         # all-null join without the dtype guard.
-        contexts = pl.DataFrame({
-            "subject_id": [1],
-            "shard": ["0"],
-            "prediction_time_index": pl.Series([3], dtype=pl.UInt32),
-        })
+        contexts = pl.DataFrame(
+            {
+                "subject_id": [1],
+                "shard": ["0"],
+                "prediction_time_index": pl.Series([3], dtype=pl.UInt32),
+            }
+        )
         with pytest.raises(ValueError, match="dtype mismatch"):
             build_index(queries, contexts, artifacts_dir, "train", num_contexts_per_query=1)
 

--- a/tests/test_sample_tasks.py
+++ b/tests/test_sample_tasks.py
@@ -34,8 +34,8 @@ from every_query.generate_tasks.sample_tasks import (
     QueryDistribution,
     QuerySpec,
     TaskSpec,
-    build_index,
     _clean_stale_temps,
+    build_index,
     build_index_df,
     build_prediction_times,
     compute_max_time_per_subject,
@@ -1592,6 +1592,8 @@ class TestStage3:
 
         idx = pl.read_parquet(index_path(artifacts_dir, "train", "0"))
         assert idx.schema["duration_days"] == pl.Float32
+
+
 # ---------------------------------------------------------------------------
 # Stage 4: per-shard labeling worker
 # ---------------------------------------------------------------------------

--- a/tests/test_sample_tasks.py
+++ b/tests/test_sample_tasks.py
@@ -34,6 +34,7 @@ from every_query.generate_tasks.sample_tasks import (
     QueryDistribution,
     QuerySpec,
     TaskSpec,
+    build_index,
     build_index_df,
     build_prediction_times,
     compute_max_time_per_subject,
@@ -1422,3 +1423,142 @@ class TestStage0:
 
         counts = pl.read_parquet(prediction_time_counts_path(artifacts_dir, "train"))
         assert dict(zip(counts["subject_id"], counts["n_prediction_times"], strict=True)) == {1: 3}
+
+
+class TestStage3:
+    """Issue #208: Stage 3 zips queries with contexts, resolves prediction_time, writes _index/.
+
+    Fixture: two shards — shard "0" has subjects 1 (5 times) and 2 (4 times), shard "1" has
+    subject 3 (4 times).  ``min_prediction_times_per_subject=2`` so all three are eligible
+    (``n_prediction_times >= 3``).
+    """
+
+    BASE = datetime(2020, 1, 1)
+    MIN = 2
+
+    @pytest.fixture
+    def stage0_env(self, tmp_path: Path) -> tuple[Path, Path]:
+        """Run Stage 0 and return ``(path_to_data, artifacts_dir)``."""
+        path_to_data = _write_split_shards(
+            tmp_path,
+            {
+                "0": pl.concat([
+                    _subject_events(1, 5, base=self.BASE),
+                    _subject_events(2, 4, base=self.BASE),
+                ]),
+                "1": _subject_events(3, 4, base=self.BASE),
+            },
+        )
+        artifacts_dir = tmp_path / "tasks_artifacts"
+        build_prediction_times(path_to_data, artifacts_dir, "train", self.MIN)
+        return path_to_data, artifacts_dir
+
+    def _make_contexts(self, subject_ids, shards, indices):
+        return pl.DataFrame({
+            "subject_id": subject_ids,
+            "shard": shards,
+            "prediction_time_index": pl.Series(indices, dtype=pl.Int64),
+        })
+
+    def test_basic_columns_and_row_count(self, stage0_env):
+        _, artifacts_dir = stage0_env
+        queries = [QuerySpec("ICD//A", 30.5), QuerySpec("ICD//B", 60.0)]
+        contexts = self._make_contexts(
+            [1, 1, 1, 1], ["0", "0", "0", "0"], [2, 3, 2, 4],
+        )
+        build_index(queries, contexts, artifacts_dir, "train", num_contexts_per_query=2)
+
+        idx = pl.read_parquet(index_path(artifacts_dir, "train", "0"))
+        assert idx.height == 4
+        assert idx.columns == ["subject_id", "prediction_time", "query", "duration_days"]
+        assert idx.schema["prediction_time"] == pl.Datetime("us")
+        assert idx.schema["duration_days"] == pl.Float32
+        assert idx["prediction_time"].null_count() == 0
+
+    def test_multi_shard_partitioning(self, stage0_env):
+        _, artifacts_dir = stage0_env
+        queries = [QuerySpec("ICD//X", 10.0)]
+        contexts = self._make_contexts(
+            [1, 3], ["0", "1"], [3, 3],
+        )
+        build_index(queries, contexts, artifacts_dir, "train", num_contexts_per_query=2)
+
+        idx0 = pl.read_parquet(index_path(artifacts_dir, "train", "0"))
+        idx1 = pl.read_parquet(index_path(artifacts_dir, "train", "1"))
+        assert idx0.height == 1
+        assert idx1.height == 1
+        assert idx0["subject_id"].to_list() == [1]
+        assert idx1["subject_id"].to_list() == [3]
+
+    def test_prediction_time_resolution_correctness(self, stage0_env):
+        _, artifacts_dir = stage0_env
+        pt_map = pl.read_parquet(prediction_times_path(artifacts_dir, "train", "0"))
+        s1_times = (
+            pt_map.filter(pl.col("subject_id") == 1)
+            .sort("prediction_time_index")["time"]
+            .to_list()
+        )
+
+        queries = [QuerySpec("ICD//A", 7.0)]
+        contexts = self._make_contexts([1, 1], ["0", "0"], [2, 4])
+        build_index(queries, contexts, artifacts_dir, "train", num_contexts_per_query=2)
+
+        idx = pl.read_parquet(index_path(artifacts_dir, "train", "0"))
+        resolved = idx.sort("prediction_time")["prediction_time"].to_list()
+        assert resolved == sorted([s1_times[2], s1_times[4]])
+
+    def test_query_zip_assignment(self, stage0_env):
+        _, artifacts_dir = stage0_env
+        queries = [QuerySpec("ICD//FIRST", 10.0), QuerySpec("ICD//SECOND", 20.0)]
+        contexts = self._make_contexts(
+            [1, 1, 2, 2], ["0", "0", "0", "0"], [3, 4, 3, 3],
+        )
+        build_index(queries, contexts, artifacts_dir, "train", num_contexts_per_query=2)
+
+        idx = pl.read_parquet(index_path(artifacts_dir, "train", "0"))
+        assert idx["query"].to_list() == ["ICD//FIRST", "ICD//FIRST", "ICD//SECOND", "ICD//SECOND"]
+        assert idx["duration_days"].to_list() == pytest.approx([10.0, 10.0, 20.0, 20.0])
+
+    def test_null_assertion_on_invalid_index(self, stage0_env):
+        _, artifacts_dir = stage0_env
+        queries = [QuerySpec("ICD//A", 5.0)]
+        contexts = self._make_contexts([1], ["0"], [999])
+        with pytest.raises(ValueError, match="null prediction_time"):
+            build_index(queries, contexts, artifacts_dir, "train", num_contexts_per_query=1)
+
+    def test_empty_queries(self, stage0_env):
+        _, artifacts_dir = stage0_env
+        contexts = pl.DataFrame(
+            schema={"subject_id": pl.Int64, "shard": pl.Utf8, "prediction_time_index": pl.Int64}
+        )
+        build_index([], contexts, artifacts_dir, "train", num_contexts_per_query=3)
+        assert not index_path(artifacts_dir, "train", "0").exists()
+
+    def test_height_mismatch_raises(self, stage0_env):
+        _, artifacts_dir = stage0_env
+        queries = [QuerySpec("ICD//A", 5.0), QuerySpec("ICD//B", 10.0)]
+        contexts = self._make_contexts([1, 1, 1], ["0", "0", "0"], [2, 3, 4])
+        with pytest.raises(ValueError, match="num_contexts_per_query"):
+            build_index(queries, contexts, artifacts_dir, "train", num_contexts_per_query=2)
+
+    def test_stale_index_dir_cleaned(self, stage0_env):
+        _, artifacts_dir = stage0_env
+        stale = index_path(artifacts_dir, "train", "stale_shard")
+        stale.parent.mkdir(parents=True, exist_ok=True)
+        stale.write_bytes(b"garbage")
+
+        queries = [QuerySpec("ICD//A", 5.0)]
+        contexts = self._make_contexts([1], ["0"], [3])
+        build_index(queries, contexts, artifacts_dir, "train", num_contexts_per_query=1)
+
+        assert not index_path(artifacts_dir, "train", "stale_shard").exists()
+        assert index_path(artifacts_dir, "train", "0").exists()
+
+    def test_duration_days_is_float32(self, stage0_env):
+        _, artifacts_dir = stage0_env
+        queries = [QuerySpec("ICD//A", 30.123456789)]
+        contexts = self._make_contexts([1], ["0"], [3])
+        build_index(queries, contexts, artifacts_dir, "train", num_contexts_per_query=1)
+
+        idx = pl.read_parquet(index_path(artifacts_dir, "train", "0"))
+        assert idx.schema["duration_days"] == pl.Float32


### PR DESCRIPTION
…ex (#208)

Add `build_index` which zips Stage 1 queries with Stage 2 contexts, resolves `prediction_time_index → prediction_time` per shard via the Stage 0 map, and writes `_index/{shard}.parquet` — the handoff artifact consumed by Stage 4.


Claude-Session: https://claude.ai/code/session_01Q41Gr8REtDonbybdpU6f9L