### PR TITLE
Fix #223: make Stage-4 label window upper bound inclusive (<=)

### DIFF
--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -436,7 +436,9 @@ def evaluate_index_df(
     window_end = pl.col(TaskQuerySchema.prediction_time_name) + duration_expr
     # `(window_end > max_time).fill_null(True)` resolves the missing-subject case to censored.
     censored = (window_end > pl.col("max_time")).fill_null(True)
-    event_in_window = pl.col(DataSchema.time_name).is_not_null() & (pl.col(DataSchema.time_name) <= window_end)
+    event_in_window = pl.col(DataSchema.time_name).is_not_null() & (
+        pl.col(DataSchema.time_name) <= window_end
+    )
 
     # Occurrence takes priority: True even if the window extends past max_time (spec §Stage 4).
     boolean_value = (

--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -436,7 +436,7 @@ def evaluate_index_df(
     window_end = pl.col(TaskQuerySchema.prediction_time_name) + duration_expr
     # `(window_end > max_time).fill_null(True)` resolves the missing-subject case to censored.
     censored = (window_end > pl.col("max_time")).fill_null(True)
-    event_in_window = pl.col(DataSchema.time_name).is_not_null() & (pl.col(DataSchema.time_name) < window_end)
+    event_in_window = pl.col(DataSchema.time_name).is_not_null() & (pl.col(DataSchema.time_name) <= window_end)
 
     # Occurrence takes priority: True even if the window extends past max_time (spec §Stage 4).
     boolean_value = (

--- a/tests/test_generate_tasks.py
+++ b/tests/test_generate_tasks.py
@@ -75,7 +75,7 @@ def test_labels_match_ground_truth(
 
         window_end    = prediction_time + duration_days
         censored      = window_end > max_time[subject]
-        event_fires   = exists event(subject, code=query, time in (prediction_time, window_end))
+        event_fires   = exists event(subject, code=query, time in (prediction_time, window_end])
         boolean_value = True  if event_fires        # occurrence takes priority (spec §Stage 4)
                         else None if censored        # unobserved tail → censored
                         else False                   # full window observed, no event
@@ -124,7 +124,7 @@ def test_labels_match_ground_truth(
         #
         # Collapsed nullable boolean_value per TaskQuerySchema (occurrence takes priority over
         # censoring — spec §Stage 4 / evaluate_index_df line "Occurrence takes priority"):
-        #   True  → event occurred in (prediction_time, window_end), even if the window's tail
+        #   True  → event occurred in (prediction_time, window_end], even if the window's tail
         #           extends past max_time (an observed event is a definitive positive)
         #   null  → no event in window AND censored (window_end > max_time OR subject absent)
         #   False → no event in window and the full window is observed
@@ -136,13 +136,14 @@ def test_labels_match_ground_truth(
             expected_censored = max_time is None or window_end > max_time
 
             # Ground-truth event_fires: any event of the matching code in
-            # (prediction_time, prediction_time + duration_days).  Sampler uses strict-> via a
-            # 1µs-shifted join_asof key, so we mirror with a strict > comparison here.
+            # (prediction_time, prediction_time + duration_days].  Sampler uses strict-> via a
+            # 1µs-shifted join_asof key, so we mirror with a strict > lower bound and an
+            # inclusive <= upper bound here.
             subj_events = events.filter(pl.col("subject_id") == subj)
             event_fires = not subj_events.filter(
                 (pl.col("code") == row["query"])
                 & (pl.col("time") > row["prediction_time"])
-                & (pl.col("time") < window_end)
+                & (pl.col("time") <= window_end)
             ).is_empty()
 
             # Occurrence takes priority: an event observed in-window is True even when the

--- a/tests/test_sample_tasks.py
+++ b/tests/test_sample_tasks.py
@@ -415,18 +415,22 @@ class TestEvaluateIndexDfEdgeCases:
         """
         # window_end for prediction_time 2020-01-01 + 10 days == 2020-01-11 00:00:00 exactly.
         window_end = datetime(2020, 1, 11)
-        events = pl.DataFrame(
-            {
-                "subject_id": [1, 1, 2, 2],
-                "time": [
-                    window_end,  # subj 1: exactly on the boundary → included
-                    datetime(2021, 1, 1),  # pushes max_time well past window_end (uncensored)
-                    window_end + timedelta(microseconds=1),  # subj 2: just past boundary → excluded
-                    datetime(2021, 1, 1),  # uncensored
-                ],
-                "code": ["A", "A", "A", "A"],
-            }
-        ).with_columns(pl.col("time").cast(pl.Datetime("us"))).sort(["subject_id", "time"])
+        events = (
+            pl.DataFrame(
+                {
+                    "subject_id": [1, 1, 2, 2],
+                    "time": [
+                        window_end,  # subj 1: exactly on the boundary → included
+                        datetime(2021, 1, 1),  # pushes max_time well past window_end (uncensored)
+                        window_end + timedelta(microseconds=1),  # subj 2: just past boundary → excluded
+                        datetime(2021, 1, 1),  # uncensored
+                    ],
+                    "code": ["A", "A", "A", "A"],
+                }
+            )
+            .with_columns(pl.col("time").cast(pl.Datetime("us")))
+            .sort(["subject_id", "time"])
+        )
 
         index_df = pl.DataFrame(
             {
@@ -438,10 +442,7 @@ class TestEvaluateIndexDfEdgeCases:
         ).with_columns(pl.col("prediction_time").cast(pl.Datetime("us")))
 
         result = evaluate_index_df(index_df, events, compute_max_time_per_subject(events))
-        labels = {
-            row["subject_id"]: row["boolean_value"]
-            for row in result.iter_rows(named=True)
-        }
+        labels = {row["subject_id"]: row["boolean_value"] for row in result.iter_rows(named=True)}
         assert labels == {1: True, 2: False}
 
     def test_unknown_subject_is_treated_as_censored(self, caplog):

--- a/tests/test_sample_tasks.py
+++ b/tests/test_sample_tasks.py
@@ -401,6 +401,49 @@ class TestEvaluateIndexDfEdgeCases:
         result_zero = evaluate_index_df(index_df_zero, events, max_time_df)
         assert result_zero["boolean_value"].to_list() == [False]
 
+    def test_event_exactly_at_window_end_is_included(self):
+        """An event at exactly ``prediction_time + duration_days`` counts as an occurrence.
+
+        The upper window bound is **inclusive** (``<=``), matching upstream
+        ``MEDS_trajectory_evaluation`` (``tte <= evaluation_window_end``).  This test hardcodes
+        the expected label rather than re-deriving it, so it pins the inclusive boundary
+        independent of the implementation's own comparison (issue #223).
+
+        - subject 1: only matching event lands exactly on ``window_end`` → ``True``.
+        - subject 2: only matching event lands 1µs **past** ``window_end`` → ``False``
+          (uncensored, so the bound — not censoring — is what excludes it).
+        """
+        # window_end for prediction_time 2020-01-01 + 10 days == 2020-01-11 00:00:00 exactly.
+        window_end = datetime(2020, 1, 11)
+        events = pl.DataFrame(
+            {
+                "subject_id": [1, 1, 2, 2],
+                "time": [
+                    window_end,  # subj 1: exactly on the boundary → included
+                    datetime(2021, 1, 1),  # pushes max_time well past window_end (uncensored)
+                    window_end + timedelta(microseconds=1),  # subj 2: just past boundary → excluded
+                    datetime(2021, 1, 1),  # uncensored
+                ],
+                "code": ["A", "A", "A", "A"],
+            }
+        ).with_columns(pl.col("time").cast(pl.Datetime("us"))).sort(["subject_id", "time"])
+
+        index_df = pl.DataFrame(
+            {
+                "subject_id": [1, 2],
+                "prediction_time": [datetime(2020, 1, 1), datetime(2020, 1, 1)],
+                "query": ["A", "A"],
+                "duration_days": [10, 10],
+            }
+        ).with_columns(pl.col("prediction_time").cast(pl.Datetime("us")))
+
+        result = evaluate_index_df(index_df, events, compute_max_time_per_subject(events))
+        labels = {
+            row["subject_id"]: row["boolean_value"]
+            for row in result.iter_rows(named=True)
+        }
+        assert labels == {1: True, 2: False}
+
     def test_unknown_subject_is_treated_as_censored(self, caplog):
         """An index_df row referencing a subject absent from events_df resolves to censored (``boolean_value =
         null``) under the collapsed schema, and emits a warning."""

--- a/tests/training_validity/test_training_validity.py
+++ b/tests/training_validity/test_training_validity.py
@@ -162,7 +162,7 @@ def _compute_labels(events: pl.DataFrame, subject_ids: list[int]) -> pl.DataFram
             event_fires = not subj_events.filter(
                 (pl.col("code") == _TARGET_CODE)
                 & (pl.col("time") > window_start)
-                & (pl.col("time") < window_end)
+                & (pl.col("time") <= window_end)
             ).is_empty()
             # Collapsed nullable boolean_value per TaskQuerySchema:
             #   null  → censored


### PR DESCRIPTION
## Summary

`evaluate_index_df` (Stage-4 labeler) used an **exclusive** upper bound on the prediction window (`time < window_end`), while the upstream reference [`MEDS_trajectory_evaluation/temporal_AUCS.py`](https://github.com/mmcdermott/MEDS_trajectory_evaluation/blob/main/src/MEDS_trajectory_evaluation/temporal_AUC_evaluation/temporal_AUCS.py) (`add_labels_from_true_tte`) uses an **inclusive** one (`tte <= evaluation_window_end`). An event landing exactly at `prediction_time + duration` was labeled `True` upstream but treated as not-in-window in EveryQuery. This was the only remaining window-semantics divergence (lower bound, occurrence-priority, and censored boundary already match).

Fixes #223.

## Changes
- **`sample_tasks.py`** — `event_in_window` now uses `<= window_end` (the fix). Docstring already documented the window as `(prediction_time, ... duration_days]`, so the implementation had simply drifted from intent.
- **`tests/test_generate_tasks.py`** & **`tests/training_validity/test_training_validity.py`** — the two ground-truth recomputes that mirror the labeler flipped to `<=` so they stay faithful; interval-notation comments updated half-open → half-closed.
- **`tests/test_sample_tasks.py`** — new `test_event_exactly_at_window_end_is_included` with **hardcoded** expectations (event at exactly `window_end` → `True`; 1µs past → `False`, uncensored), pinning the inclusive boundary independent of the implementation's own comparison.

## Do NOT change (per issue)
- Lower bound stays strict `>` (the +1µs asof key).
- Censored boundary stays `>=`.

## Verification
`uv run pytest tests/test_sample_tasks.py tests/test_generate_tasks.py tests/training_validity/test_training_validity.py` → **112 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)