### PR TITLE
Fix #228: rewrite generate_tasks docs to match the 5-stage sampler

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,11 +127,16 @@ directory for the MEDS-transforms stages; `$PROCESSED` holds cross-shard metadat
 ```bash
 EQ_generate_training_tasks \
 	split=train \
-	num_queries=1024 \
-	num_contexts_per_query=1
+	num_queries=4000000 \
+	num_contexts_per_query=1 \
+	max_workers=1
 ```
 
-A single command runs the whole 5-stage sampler in one process — Stages 0–3 inline in the driver, then Stage 4 fans labeling out across shards via a `ProcessPoolExecutor` (optionally capped with `max_workers`). There is no `task_shard`/`input_shard` sweep. The final dataset lands at `$TRAINING_TASKS_DIR/{split}/{shard}.parquet` (intermediates go to the sibling `*_artifacts` dir; see [`generate_tasks/README.md`](src/every_query/generate_tasks/README.md)). Output columns conform to [`TaskQuerySchema`](src/every_query/data/schema.py) — `subject_id, prediction_time, query, duration_days, boolean_value` — where `boolean_value` is a nullable three-valued label (`null` = censored, `True` = the query code occurred in the observed window `(prediction_time, prediction_time + duration_days]` — strict-after lower bound, inclusive upper — `False` = the full window is observed with no occurrence). Censoring (`null`) applies when the window extends past the subject's last recorded time.
+One command runs the whole 5-stage sampler in a single process (Stages 0–3 inline, then Stage 4 labels shards in parallel). The dataset lands at `$TRAINING_TASKS_DIR/{split}/{shard}.parquet`, with intermediates in the sibling `*_artifacts` dir (see [`generate_tasks/README.md`](src/every_query/generate_tasks/README.md)). Columns conform to [`TaskQuerySchema`](src/every_query/data/schema.py) — `subject_id, prediction_time, query, duration_days, boolean_value` — where `boolean_value` is three-valued: `True` (query code occurs in `(prediction_time, prediction_time + duration_days]`), `False` (window fully observed, no occurrence), or `null` (censored — window extends past the subject's last recorded time).
+
+> `max_workers` sets how many shards are labeled in parallel, so raising it raises peak RAM. If Stage 4 OOMs, set `max_workers=1`.
+
+> **Note:** The total number of training samples generated will be `num_queries * num_contexts_per_query`
 
 `query_codes=` is optional for training. Leave it unset/null to sample query codes from
 `$PROCESSED/metadata/codes.parquet`, or set it to an inline list / YAML path to restrict which

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ EQ_generate_training_tasks \
 	num_queries=4000000 \
 	num_contexts_per_query=1 \
 	max_workers=1 \
-	data_dir=/path/to/intermediate \
-	out_dir=/path/to/training_tasks
+	data_dir="$INTERMEDIATE" \
+	out_dir="$TRAINING_TASKS_DIR"
 ```
 
 `data_dir` is the MEDS dataset root (event shards read from `{data_dir}/data/{split}/*.parquet`) and `out_dir` is the final-dataset root. Both are optional CLI overrides — omit them to fall back to `$INTERMEDIATE` and `$TRAINING_TASKS_DIR` from your `.env`.
@@ -167,9 +167,9 @@ EQ_generate_evaluation_tasks \
 	prediction_times_per_subject=5 \
 	'codes=[HR, TEMP]' \
 	'durations=[1, 7, 30, 90, 365]' \
-	data_dir=/path/to/intermediate \
+	data_dir="$INTERMEDIATE" \
 	codes_dir=/path/to/processed \
-	out_dir=/path/to/tasks
+	out_dir=$TASK_DIR
 ```
 
 Samples `K` prediction times per subject, cross-joins with the full `(codes × durations)` grid, labels via the same primitive as training. Output lands under `$TASK_DIR/eval/{split}/*.parquet` (separate `eval/` subdir so it doesn't collide with the training-task output).

--- a/README.md
+++ b/README.md
@@ -129,8 +129,12 @@ EQ_generate_training_tasks \
 	split=train \
 	num_queries=4000000 \
 	num_contexts_per_query=1 \
-	max_workers=1
+	max_workers=1 \
+	data_dir=/path/to/intermediate \
+	out_dir=/path/to/training_tasks
 ```
+
+`data_dir` is the MEDS dataset root (event shards read from `{data_dir}/data/{split}/*.parquet`) and `out_dir` is the final-dataset root. Both are optional CLI overrides — omit them to fall back to `$INTERMEDIATE` and `$TRAINING_TASKS_DIR` from your `.env`.
 
 One command runs the whole 5-stage sampler in a single process (Stages 0–3 inline, then Stage 4 labels shards in parallel). The dataset lands at `$TRAINING_TASKS_DIR/{split}/{shard}.parquet`, with intermediates in the sibling `*_artifacts` dir (see [`generate_tasks/README.md`](src/every_query/generate_tasks/README.md)). Columns conform to [`TaskQuerySchema`](src/every_query/data/schema.py) — `subject_id, prediction_time, query, duration_days, boolean_value` — where `boolean_value` is three-valued: `True` (query code occurs in `(prediction_time, prediction_time + duration_days]`), `False` (window fully observed, no occurrence), or `null` (censored — window extends past the subject's last recorded time).
 

--- a/README.md
+++ b/README.md
@@ -166,10 +166,15 @@ EQ_generate_evaluation_tasks \
 	input_shard=0 \
 	prediction_times_per_subject=5 \
 	'codes=[HR, TEMP]' \
-	'durations=[1, 7, 30, 90, 365]'
+	'durations=[1, 7, 30, 90, 365]' \
+	data_dir=/path/to/intermediate \
+	codes_dir=/path/to/processed \
+	out_dir=/path/to/tasks
 ```
 
 Samples `K` prediction times per subject, cross-joins with the full `(codes × durations)` grid, labels via the same primitive as training. Output lands under `$TASK_DIR/eval/{split}/*.parquet` (separate `eval/` subdir so it doesn't collide with the training-task output).
+
+As with training, `data_dir` / `codes_dir` / `out_dir` are optional CLI overrides — omit them to fall back to `$INTERMEDIATE`, `$PROCESSED`, and `$TASK_DIR` from your `.env`. `codes_dir` (the `{codes_dir}/metadata/codes.parquet` query universe) is ignored when `codes=` is passed explicitly.
 
 `codes=` accepts an inline list (as above), a metadata root / `codes.parquet` path, or — for reproducible pre-sampled code universes kept out of git — a path to a YAML file. The YAML is either a bare list or a mapping with a `codes:` key:
 

--- a/README.md
+++ b/README.md
@@ -84,27 +84,24 @@ The legacy four-stage evaluator (`every_query.evaluate.eval`, with `gen_index_ti
 
 ### Current (on `dev`)
 
-```
-    MEDS cohort  ──►  EQ_process_data  ──►  tensorized cohort ($FINAL_DATA_DIR)
-                                                          │
-                                                          ├─────────────────────────────┐
-                                                          ▼                             ▼
-                                            EQ_generate_training_tasks       EQ_generate_evaluation_tasks
-                                            (scattered, random tasks)        (dense grid: codes × durations)
-                                                          │                             │
-                                                          │ TaskQuerySchema parquets    │
-                                                          ▼                             │
-                                                     EQ_train ──► best_model.ckpt       │
-                                                                           │            │
-                                                                           ▼            │
-                                                                      EQ_predict ◄──────┘
-                                                                           │
-                                                                           │ PredictionSchema parquet
-                                                                           ▼
-                                                                     EQ_evaluate
-                                                                           │
-                                                                           ▼
-                                                               per-(query, duration_days) metrics parquet
+```mermaid
+flowchart TD
+    meds[MEDS cohort] --> process[EQ_process_data]
+    process --> intermediate[("MEDS event shards<br/>($INTERMEDIATE)")]
+    process --> cohort[("tensorized cohort<br/>($FINAL_DATA_DIR)")]
+
+    intermediate --> train_tasks[EQ_generate_training_tasks<br/><i>scattered, random tasks</i>]
+    intermediate --> eval_tasks[EQ_generate_evaluation_tasks<br/><i>dense grid: codes × durations</i>]
+
+    train_tasks -- TaskQuerySchema parquets --> train[EQ_train]
+    cohort -- tensorized cohort --> train
+    train --> ckpt[/best_model.ckpt/]
+
+    ckpt --> predict[EQ_predict]
+    eval_tasks -- TaskQuerySchema parquets --> predict
+
+    predict -- PredictionSchema parquet --> evaluate[EQ_evaluate]
+    evaluate --> metrics[("per-(query, duration_days)<br/>metrics parquet")]
 ```
 
 Both task-generation endpoints emit `TaskQuerySchema`-conformant parquets. Training uses the scattered shape (one random `(query, duration_days)` per row); evaluation uses the dense shape (every held-out `(subject, time)` × every `(query × duration)` the user wants metrics for) so `EQ_predict` + `EQ_evaluate` cover a full grid without having to run inference twice.
@@ -172,7 +169,33 @@ EQ_generate_evaluation_tasks \
 	out_dir=$TASK_DIR
 ```
 
-Samples `K` prediction times per subject, cross-joins with the full `(codes × durations)` grid, labels via the same primitive as training. Output lands under `$TASK_DIR/eval/{split}/*.parquet` (separate `eval/` subdir so it doesn't collide with the training-task output).
+Samples `1` prediction times per subject by default, cross-joins with the full `(codes × durations)` grid, labels via the same primitive as training. Output lands under `$TASK_DIR/eval/{split}/*.parquet` (separate `eval/` subdir so it doesn't collide with the training-task output).
+
+The endpoint writes one parquet per `(split, input_shard)` worker, so to label a whole split use Hydra multirun (`-m`) to sweep `input_shard` — there's no auto-discovery, so enumerate the range explicitly. Count the shards for your split first (`N` = this number):
+
+```bash
+ls "$INTERMEDIATE"/data/held_out/*.parquet | wc -l
+```
+
+Then sweep `input_shard=range(0,N)`:
+
+```bash
+# Sequential (basic launcher) — one shard after another in a single process:
+EQ_generate_evaluation_tasks -m \
+	input_shard=range(0,16) \
+	split=held_out \
+	prediction_times_per_subject=5 \
+	'codes=[HR, TEMP]' \
+	'durations=[1, 7, 30, 90, 365]'
+
+# Parallel on SLURM (submitit launcher — already a dependency):
+EQ_generate_evaluation_tasks -m \
+	hydra/launcher=submitit_slurm \
+	input_shard=range(0,16) \
+	split=held_out …
+```
+
+A comma list (`input_shard=0,1,2`) works too; `range(0,16)` is just shorthand for `0..15`. The prediction-time sampler is deterministic in `(seed, input_shard, split)`, so a swept run and the equivalent per-shard runs produce identical output.
 
 As with training, `data_dir` / `codes_dir` / `out_dir` are optional CLI overrides — omit them to fall back to `$INTERMEDIATE`, `$PROCESSED`, and `$TASK_DIR` from your `.env`. `codes_dir` (the `{codes_dir}/metadata/codes.parquet` query universe) is ignored when `codes=` is passed explicitly.
 

--- a/README.md
+++ b/README.md
@@ -127,15 +127,11 @@ directory for the MEDS-transforms stages; `$PROCESSED` holds cross-shard metadat
 ```bash
 EQ_generate_training_tasks \
 	split=train \
-	input_shard=0 \
-	task_shard=0 \
-	n_tasks=1024 \
-	contexts_per_task=1
+	num_queries=1024 \
+	num_contexts_per_query=1
 ```
 
-Sweep across shards with
-`python -m every_query.generate_tasks.sample_tasks -m input_shard=0,1,2,… task_shard=range(0,K)`.
-Each worker writes labeled task parquets under `$TASK_DIR/{split}/*.parquet` idempotently. Output columns conform to [`TaskQuerySchema`](src/every_query/data/schema.py) — `subject_id, prediction_time, query, duration_days, boolean_value` — where `boolean_value` is a nullable three-valued label (`null` = censored, `True` = event occurred in `[prediction_time, prediction_time + duration_days)`, `False` = observed-but-no-event).
+A single command runs the whole 5-stage sampler in one process — Stages 0–3 inline in the driver, then Stage 4 fans labeling out across shards via a `ProcessPoolExecutor` (optionally capped with `max_workers`). There is no `task_shard`/`input_shard` sweep. The final dataset lands at `$TRAINING_TASKS_DIR/{split}/{shard}.parquet` (intermediates go to the sibling `*_artifacts` dir; see [`generate_tasks/README.md`](src/every_query/generate_tasks/README.md)). Output columns conform to [`TaskQuerySchema`](src/every_query/data/schema.py) — `subject_id, prediction_time, query, duration_days, boolean_value` — where `boolean_value` is a nullable three-valued label (`null` = censored, `True` = the query code occurred in the observed window `(prediction_time, prediction_time + duration_days]` — strict-after lower bound, inclusive upper — `False` = the full window is observed with no occurrence). Censoring (`null`) applies when the window extends past the subject's last recorded time.
 
 `query_codes=` is optional for training. Leave it unset/null to sample query codes from
 `$PROCESSED/metadata/codes.parquet`, or set it to an inline list / YAML path to restrict which
@@ -185,11 +181,11 @@ EQ_generate_evaluation_tasks codes=/path/to/sampled_codes.yaml …
 ```bash
 EQ_train \
 	output_dir="$OUTPUT_DIR/outputs/\${run_id:}" \
-	datamodule.config.task_labels_dir="$TASK_DIR" \
+	datamodule.config.task_labels_dir="$TRAINING_TASKS_DIR" \
 	datamodule.config.tensorized_cohort_dir="$FINAL_DATA_DIR"
 ```
 
-`EQ_train` reads the long-format labels written by `EQ_generate_training_tasks` directly — the inline collation step that lived in `train.py` was removed in [#76](https://github.com/payalchandak/EveryQuery/pull/76).
+`datamodule.config.task_labels_dir` defaults to `${oc.env:TASK_DIR}`, so point it at `$TRAINING_TASKS_DIR` (where `EQ_generate_training_tasks` now writes) — or export `$TASK_DIR` to that location. `EQ_train` reads the long-format labels written by `EQ_generate_training_tasks` directly — the inline collation step that lived in `train.py` was removed in [#76](https://github.com/payalchandak/EveryQuery/pull/76).
 
 Seeding: `cfg.seed` (default `140799`) is passed through `lightning.seed_everything` *before* model + datamodule instantiation (fix landed in [#124](https://github.com/payalchandak/EveryQuery/pull/124)), so model weight initialization is byte-reproducible across Python versions and platforms for a given seed.
 
@@ -230,13 +226,14 @@ CLIs. Scope of this gate was tightened in [#127](https://github.com/payalchandak
 (they were only read by a dotenv fallback in the sampler, which already tolerates missing
 env vars when CLI config values are supplied).
 
-| Var              | Purpose                                                |
-| ---------------- | ------------------------------------------------------ |
-| `PROJECT_DIR`    | Repo root (for relative output paths in a few configs) |
-| `OUTPUT_DIR`     | Where training run dirs land                           |
-| `TASK_DIR`       | Where task parquets read / write                       |
-| `FINAL_DATA_DIR` | Tensorized cohort (output of `EQ_process_data`)        |
-| `WANDB_ENTITY`   | W&B entity for training telemetry                      |
+| Var                  | Purpose                                                                                                                                  |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `PROJECT_DIR`        | Repo root (for relative output paths in a few configs)                                                                                   |
+| `OUTPUT_DIR`         | Where training run dirs land                                                                                                             |
+| `TRAINING_TASKS_DIR` | Final training-task dataset (output of `EQ_generate_training_tasks`); intermediates go to the sibling `*_artifacts` dir                  |
+| `TASK_DIR`           | Evaluation-task parquets (`EQ_generate_evaluation_tasks` writes `$TASK_DIR/eval/...`); also the default `task_labels_dir` for `EQ_train` |
+| `FINAL_DATA_DIR`     | Tensorized cohort (output of `EQ_process_data`)                                                                                          |
+| `WANDB_ENTITY`       | W&B entity for training telemetry                                                                                                        |
 
 `.env.example` is the reference — copy to `.env` and edit. Python loads it via
 `python-dotenv`. Further phases of

--- a/src/every_query/generate_tasks/README.md
+++ b/src/every_query/generate_tasks/README.md
@@ -4,29 +4,44 @@ Task-label generation stage of the EveryQuery pipeline. Two console scripts
 live here, each producing a `TaskQuerySchema`-conformant parquet but with
 different row distributions:
 
-- **`EQ_generate_training_tasks`** — scattered shape: `N` independent
-    `(query, duration_days)` tasks × `M` contexts, for pretraining.
+- **`EQ_generate_training_tasks`** — scattered shape: `num_queries` independent
+    `(code, duration_days)` queries × `num_contexts_per_query` patient contexts,
+    for pretraining. Runs a single-process 5-stage pipeline (see below).
 - **`EQ_generate_evaluation_tasks`** — dense-grid shape: sampled prediction
     times × `(codes × durations)`, for feeding `EQ_predict` → `EQ_evaluate`.
 
 ## What lives here
 
-- **`sample_tasks.py`** — sampling-first pretraining-task generator. Draws `N`
-    `(code, duration_days)` tasks from a uniform × log-uniform distribution, `N × M`
-    `(subject_id, prediction_time)` contexts iid with replacement, zips them, and
-    writes a long-format labels parquet per worker via a single-pass `join_asof`.
-    Registered as `EQ_generate_training_tasks` and runnable as
-    `python -m every_query.generate_tasks.sample_tasks`.
+- **`sample_tasks.py`** — the 5-stage training-task sampler. Registered as
+    `EQ_generate_training_tasks` and runnable as
+    `python -m every_query.generate_tasks.sample_tasks`. One console invocation runs
+    the **whole** pipeline in one process on one node — Stages 0–3 sequentially in the
+    driver, then Stage 4 fans out one labeling worker per shard via a
+    `ProcessPoolExecutor`:
+
+    | Stage | Where             | What                                                                                                                          |
+    | ----- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------- |
+    | 0     | driver            | Scan shards once, dedup to distinct `(subject_id, time)`, dense-rank → prediction-time map; filter eligible subjects. Cached. |
+    | 1     | driver            | Sample `num_queries` `(code, duration_days)` queries (uniform code × uniform/log-uniform duration).                           |
+    | 2     | driver            | Sample `N = num_queries × num_contexts_per_query` `(subject_idx, prediction_time_index)` contexts, iid with replacement.      |
+    | 3     | driver            | Resolve each context's `prediction_time` against the Stage 0 map, zip with queries, write the partitioned index.              |
+    | 4     | per-shard workers | Label each index shard independently via `join_asof`; write the final per-shard parquet atomically.                           |
+
+    See [`redesign-spec.md`](redesign-spec.md) for the full stage contract, invariants,
+    and determinism model — this README does not restate them.
+
 - **`sample_evaluation_tasks.py`** — dense-grid evaluation-task generator.
     Samples `K` prediction times per subject, cross-joins with the full
     `(codes × durations)` grid the caller specifies, labels via the same
     `evaluate_index_df` primitive from `sample_tasks.py`. Registered as
     `EQ_generate_evaluation_tasks` and runnable as
     `python -m every_query.generate_tasks.sample_evaluation_tasks`.
-- **`configs/sample_tasks_config.yaml`** / **`configs/sample_evaluation_tasks_config.yaml`**
-    — shipped Hydra configs. Path fallbacks resolve via the repo's `.env`-based
-    env-var convention (`$INTERMEDIATE`, `$PROCESSED`, `$TASK_DIR`); everything
-    else is a Hydra override.
+
+- **`configs/sample_training_tasks_config.yaml`** / **`configs/sample_evaluation_tasks_config.yaml`**
+    — shipped Hydra configs. Path roots resolve with precedence `CLI override > env var > raise`
+    via the repo's `.env`-based convention (`$INTERMEDIATE`, `$PROCESSED`,
+    `$TRAINING_TASKS_DIR` for training; `$TASK_DIR` for evaluation); everything else is a
+    Hydra override.
 
 ## Pipeline position
 
@@ -43,38 +58,68 @@ Both endpoints consume:
 2. The query-code universe at `$PROCESSED/metadata/codes.parquet` — or a CLI override:
     `query_codes=...` for training, `codes=...` for evaluation.
 
-Training-task outputs land at `$TASK_DIR/{split}/*.parquet`; evaluation-task
-outputs land at `$TASK_DIR/eval/{split}/*.parquet`. The separate `eval/`
+**Training-task outputs** land at `$TRAINING_TASKS_DIR/{split}/{shard}.parquet` — the final
+dataset is the union of the per-shard files, and that directory holds *nothing else* at rest.
+All intermediates (the Stage 0 prediction-time map, Stage 3 index) live in the **sibling**
+`*_artifacts` root (`{parent}/{name}_artifacts` of `$TRAINING_TASKS_DIR`, no env var of its
+own), so the two trees never nest and cleanup is a single `rm -rf` of the artifacts dir.
+
+**Evaluation-task outputs** land at `$TASK_DIR/eval/{split}/*.parquet`. The separate `eval/`
 subdirectory keeps the two row distributions from colliding in one directory.
 
-## Sweeping across shards
+## Running it
 
-```
-# Pretraining tasks (random tasks × random contexts):
-python -m every_query.generate_tasks.sample_tasks -m \
-    input_shard=0,1,2,... task_shard=range(0,K)
+### Pretraining tasks — whole pipeline, one command
 
-# Restrict sampled training queries to a YAML code list:
-python -m every_query.generate_tasks.sample_tasks -m \
-    input_shard=0,1,2,... task_shard=range(0,K) \
-    query_codes=/path/to/train_query_codes.yaml
+```bash
+# Stages 0–3 run inline in the driver; Stage 4 fans out across shards in-process.
+EQ_generate_training_tasks \
+	split=train \
+	num_queries=1024 \
+	num_contexts_per_query=1
 
-# `train_query_codes.yaml` may be either a flat list or `{codes: [...]}`.
-
-# Evaluation tasks (dense grid over the held-out cohort):
-python -m every_query.generate_tasks.sample_evaluation_tasks -m \
-    input_shard=0,1,2,... split=held_out
+# Restrict sampled training queries to a YAML code list (flat list or `{codes: [...]}`):
+EQ_generate_training_tasks \
+	split=train \
+	query_codes=/path/to/train_query_codes.yaml
 ```
 
-The pretraining generator's seed derivation (`utils.seeds.derive_seed`)
-separates task-axis and context-axis randomness so fixing `task_shard` across
-`input_shard` values evaluates the *same* tasks on *different* patients; the
-evaluation generator only has a prediction-time axis (codes and durations are
-caller-specified), so its seed derives on `(seed, split, input_shard)`. Each
-worker writes idempotently; re-running is a no-op.
+There is **no** `task_shard`/`input_shard` axis and no Hydra `-m` sweep — the single driver
+process samples globally and fans Stage-4 labeling out itself. Key knobs (full list in
+`configs/sample_training_tasks_config.yaml`):
+
+- `num_queries`, `num_contexts_per_query` — sampling budget; output is
+    `num_queries × num_contexts_per_query` rows.
+- `min_prediction_times_per_subject` (default 50) — minimum prior **prediction times**
+    (distinct `(subject_id, time)` rows, not events) before a prediction time is eligible.
+- `min_duration`, `max_duration`, `duration_distribution` (`uniform | log-uniform`) — the
+    Stage 1 duration draw; `duration_days` is a float (no day-rounding).
+- `query_codes` — `null` loads the full vocabulary from `$PROCESSED/metadata/codes.parquet`;
+    or pass an inline Hydra list (`query_codes=[HR,TEMP]`) or a YAML/parquet path.
+- `max_workers` — optional cap on the Stage 4 pool; `null` uses cores-on-node, an int caps that
+    downward only. Set it when a run OOMs.
+- `seed`, `overwrite`, and optional path overrides `data_dir` / `out_dir`.
+
+### Evaluation tasks — dense grid, swept per shard
+
+```bash
+EQ_generate_evaluation_tasks -m \
+	input_shard=0,1,2,... split=held_out
+```
+
+## Determinism & restartability
+
+All training draws derive from `seed` via `utils.seeds.derive_seed`, splitting the **query
+axis** (`derive_seed(seed, "queries")`) and **context axis** (`derive_seed(seed, "contexts")`)
+so they reproduce independently for a fixed seed. Stage 4 writes each shard via a temp file +
+`os.replace`, so a present `{shard}.parquet` is always complete; reruns skip finished shards
+(idempotent), and `overwrite=true` forces relabeling. The evaluation generator has only a
+prediction-time axis (codes and durations are caller-specified), so its seed derives on
+`(seed, split, input_shard)` and each worker writes idempotently.
 
 ## Related
 
+- Architecture reference for the training sampler: [`redesign-spec.md`](redesign-spec.md).
 - Parent refactor umbrella: [#54](https://github.com/payalchandak/EveryQuery/issues/54).
 - Phase 2.1 — cross-stage `TaskQuerySchema`: [#80](https://github.com/payalchandak/EveryQuery/issues/80) (closed, merged in #96).
 - Phase 2.2 — `EQ_predict` (consumes `sample_evaluation_tasks` output):

--- a/src/every_query/train/README.md
+++ b/src/every_query/train/README.md
@@ -11,7 +11,8 @@ Training stage of the EveryQuery pipeline. Home of the `EQ_train` console script
     - `config.yaml` — default production config (ModernBERT encoder, AdamW, wandb
         logger, early-stopping on tuning/loss). Training has no query-codes knob:
         the set of queried codes is determined by whatever `EQ_generate_training_tasks`
-        wrote into the task-labels parquet at `$TASK_DIR`. Code filtering happens
+        wrote into the task-labels parquet (`datamodule.config.task_labels_dir`,
+        default `${oc.env:TASK_DIR}`). Code filtering happens
         upstream in preprocessing.
     - `fast_config.yaml` — speed-tuned override bundle that inherits `config.yaml` and
         shrinks `max_seq_len`, bumps batch size, etc. Targeted at tokenization-sweep
@@ -30,9 +31,11 @@ EQ_process_data       EQ_generate_training_tasks         EQ_train       EQ_predi
 
 1. The tensorized MEDS cohort at `$FINAL_DATA_DIR`, produced by
     [`preprocessing/`](../preprocessing/).
-2. Long-format task-label parquets at `$TASK_DIR`, produced by
+2. Long-format task-label parquets, produced by
     [`generate_tasks/`](../generate_tasks/) (no intermediate "collation" step — the
-    sampler writes the dataloader's input format directly).
+    sampler writes the dataloader's input format directly). `EQ_generate_training_tasks`
+    writes these to `$TRAINING_TASKS_DIR`; point `datamodule.config.task_labels_dir`
+    there (it defaults to `$TASK_DIR`).
 
 `train/` produces a run directory at
 `$OUTPUT_DIR/outputs/<YYYY-MM-DD>/<HH-MM-SS>/` containing `best_model.ckpt`,


### PR DESCRIPTION
Closes #228 (sub-issue of #225, finding 3).

The task-generation docs still described the **pre-refactor per-worker** training model. This is a from-scratch rewrite of the training docs against the current 5-stage `sample_tasks.py` + `sample_training_tasks_config.yaml`, plus a repo-wide audit for the same drift. **Docs-only** — the code-side stale references (error message at `sample_tasks.py:606`, legacy comment/docstring back-refs) stay with #225.

## Changes
- **`generate_tasks/README.md`** — full rewrite of the training half. Drops the deleted `sample_tasks_config.yaml`; describes the 5-stage sampler (S0 prediction-time map → S1 queries → S2 contexts → S3 index → S4 per-shard labeling) as a single-command, single-process driver + in-process Stage-4 fan-out. Correct output roots (`$TRAINING_TASKS_DIR/{split}/{shard}.parquet` + sibling `*_artifacts`), real knobs, real determinism model. Removes the dead `task_shard`/`input_shard` `-m` sweep and **links `redesign-spec.md`** as the architecture reference rather than restating it.
- **Top-level `README.md`** — §2a swapped to current knobs (`num_queries`/`num_contexts_per_query`/`max_workers`); fixed training output path; **corrected the label window** to `(prediction_time, prediction_time + duration_days]` (strict-after lower, inclusive upper — the old `[…)` was wrong); added `$TRAINING_TASKS_DIR` to the env table.
- **`train/README.md`** — clarifies `task_labels_dir` defaults to `$TASK_DIR` while the sampler now writes `$TRAINING_TASKS_DIR`.

## Note (not fixed here)
Surfaced an integration gap: the sampler writes `$TRAINING_TASKS_DIR`, but `train/configs/config.yaml` still defaults `task_labels_dir: ${oc.env:TASK_DIR}`. Docs now tell users to point `task_labels_dir` at the sampler output; a real rewiring is code-side and out of scope for #228.

## Verification
- `grep -rE 'task_shard|input_shard|sample_tasks_config|n_tasks|contexts_per_task'` over READMEs shows no stale training-sampler hits (only the eval generator's legitimate `input_shard`).
- Every documented knob confirmed present in `sample_training_tasks_config.yaml`; path/env claims checked against `resolve_training_task_paths`/`read_query_codes`; final column name verified `query` (not `code`) via `TaskQuerySchema.query_name`; label window matches redesign invariant 6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)