### PR TITLE
Fix #184: post-compose config validation, retire ensure_env() presence gate

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,20 +9,18 @@
 
 # --- Paths -------------------------------------------------------------------
 
-# Absolute path to this repo on the current machine.
-PROJECT_DIR="/path/to/EveryQuery"
-
 # Root of the MEDS cohort. The INTERMEDIATE / PROCESSED dirs below are written
-# here by the preprocessing pipeline.
+# here by the preprocessing pipeline.  (Preprocessing reads the *raw* MEDS via the
+# `input_dir=` CLI arg and sets `RAW_MEDS_DIR` internally — there is no `RAW` env var.)
 DATA_DIR="/path/to/MIMIC_MEDS/MEDS_cohort"
 
-RAW="${DATA_DIR}"
 INTERMEDIATE="${DATA_DIR}/intermediate"
-INTERMEDIATE_DIR="${INTERMEDIATE}"   # duplicate; kept for backward compatibility
 PROCESSED="${DATA_DIR}/processed"
 FINAL_DATA_DIR="${PROCESSED}"
 
-# Where task parquet files live / are written.
+# Where *evaluation* task parquet files are written.  Only the evaluation generator
+# (`EQ_generate_evaluation_tasks`, output under `$TASK_DIR/eval/...`) reads this.
+# Training reads `TRAINING_TASKS_DIR` below, not this.
 TASK_DIR="/path/to/eq_stuff/tasks"
 
 # Final-output root for the redesigned training-task sampler (EQ_generate_training_tasks).
@@ -35,9 +33,8 @@ TRAINING_TASKS_DIR="/path/to/eq_stuff/training_tasks"
 # ACES_SHARDS_DIR="/path/to/eic_stuff/make_index_dfs/task_configs"
 
 # Where training outputs and checkpoints land. Hydra creates
-# ${OUTPUT_DIR}/outputs/<date>/<time>/ run dirs underneath.
-SAVE_DIR="${PROJECT_DIR}/results/"
-OUTPUT_DIR="${PROJECT_DIR}/results"
+# ${OUTPUT_DIR}/<date>/<time>/ run dirs underneath.
+OUTPUT_DIR="/path/to/EveryQuery/results"
 
 # --- Weights & Biases --------------------------------------------------------
 # `wandb` itself also picks these up automatically.

--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ Both task-generation endpoints emit `TaskQuerySchema`-conformant parquets. Train
 
 ```bash
 EQ_process_data \
-	input_dir="$RAW" \
+	input_dir="$DATA_DIR" \
 	intermediate_dir="$INTERMEDIATE" \
 	output_dir="$FINAL_DATA_DIR"
 ```
@@ -212,11 +212,10 @@ EQ_generate_evaluation_tasks codes=/path/to/sampled_codes.yaml …
 ```bash
 EQ_train \
 	output_dir="$OUTPUT_DIR/outputs/\${run_id:}" \
-	datamodule.config.task_labels_dir="$TRAINING_TASKS_DIR" \
 	datamodule.config.tensorized_cohort_dir="$FINAL_DATA_DIR"
 ```
 
-`datamodule.config.task_labels_dir` defaults to `${oc.env:TASK_DIR}`, so point it at `$TRAINING_TASKS_DIR` (where `EQ_generate_training_tasks` now writes) — or export `$TASK_DIR` to that location. `EQ_train` reads the long-format labels written by `EQ_generate_training_tasks` directly — the inline collation step that lived in `train.py` was removed in [#76](https://github.com/payalchandak/EveryQuery/pull/76).
+`datamodule.config.task_labels_dir` defaults to `${oc.env:TRAINING_TASKS_DIR}` (where `EQ_generate_training_tasks` writes), so with `.env` set you don't need to pass it — override it only to read labels from a different location. `EQ_train` reads the long-format labels written by `EQ_generate_training_tasks` directly — the inline collation step that lived in `train.py` was removed in [#76](https://github.com/payalchandak/EveryQuery/pull/76).
 
 Seeding: `cfg.seed` (default `140799`) is passed through `lightning.seed_everything` *before* model + datamodule instantiation (fix landed in [#124](https://github.com/payalchandak/EveryQuery/pull/124)), so model weight initialization is byte-reproducible across Python versions and platforms for a given seed.
 
@@ -251,26 +250,23 @@ whether you run from a source checkout or a `pip install`ed wheel.
 
 ### Environment variables
 
-`ensure_env()` (in `utils/_env.py`) requires these be set before `EQ_train` and the eval
-CLIs. Scope of this gate was tightened in [#127](https://github.com/payalchandak/EveryQuery/pull/127)
-— `PROCESSED` and `INTERMEDIATE` were dropped because no Hydra config interpolates them
-(they were only read by a dotenv fallback in the sampler, which already tolerates missing
-env vars when CLI config values are supplied).
+These back the `${oc.env:VAR,null}` interpolations in the shipped configs. None are hard-required:
+a CLI override of the corresponding node (e.g. `datamodule.config.task_labels_dir=/path`) makes the
+backing interpolation never evaluate, so you can run fully CLI-driven with no env vars at all. `EQ_train`
+validates only the values it actually resolves — `validate_training_config()` in `train.py` checks that the
+resolved cohort/task dirs exist and that `WANDB_ENTITY` is set *only* when a wandb logger is enabled. The
+old blind presence gate in `ensure_env()` was removed in [#184](https://github.com/payalchandak/EveryQuery/issues/184);
+`ensure_env()` now just loads `.env`.
 
-| Var                  | Purpose                                                                                                                                  |
-| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
-| `PROJECT_DIR`        | Repo root (for relative output paths in a few configs)                                                                                   |
-| `OUTPUT_DIR`         | Where training run dirs land                                                                                                             |
-| `TRAINING_TASKS_DIR` | Final training-task dataset (output of `EQ_generate_training_tasks`); intermediates go to the sibling `*_artifacts` dir                  |
-| `TASK_DIR`           | Evaluation-task parquets (`EQ_generate_evaluation_tasks` writes `$TASK_DIR/eval/...`); also the default `task_labels_dir` for `EQ_train` |
-| `FINAL_DATA_DIR`     | Tensorized cohort (output of `EQ_process_data`)                                                                                          |
-| `WANDB_ENTITY`       | W&B entity for training telemetry                                                                                                        |
+| Var                  | Purpose                                                                                                            |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------ |
+| `OUTPUT_DIR`         | Where training run dirs land (`output_dir`)                                                                        |
+| `TRAINING_TASKS_DIR` | Final training-task dataset (output of `EQ_generate_training_tasks`); the default `task_labels_dir` for `EQ_train` |
+| `TASK_DIR`           | Evaluation-task parquets (`EQ_generate_evaluation_tasks` writes `$TASK_DIR/eval/...`)                              |
+| `FINAL_DATA_DIR`     | Tensorized cohort (output of `EQ_process_data`); the default `tensorized_cohort_dir` for `EQ_train`                |
+| `WANDB_ENTITY`       | W&B entity for training telemetry (only needed when the wandb logger is enabled)                                   |
 
-`.env.example` is the reference — copy to `.env` and edit. Python loads it via
-`python-dotenv`. Further phases of
-[#117](https://github.com/payalchandak/EveryQuery/issues/117) will migrate the remaining
-gated vars to `${oc.env:VAR,???}` / `${oc.env:VAR,default}` form (Hydra-native required
-or optional-with-fallback) and eventually retire `ensure_env()` entirely.
+`.env.example` is the reference — copy to `.env` and edit. Python loads it via `python-dotenv`.
 
 ## Development
 

--- a/conftest.py
+++ b/conftest.py
@@ -165,18 +165,6 @@ def run_and_check(cmd: list[str], *, env: dict[str, str] | None = None, timeout:
     return result
 
 
-# Placeholder values for the ``ensure_env()`` gate in ``utils/_env.py``.  The demo Hydra configs
-# do not interpolate any of these env vars, so the actual values are inert — they exist purely
-# to let the gate pass on a clean CI machine with no ``.env`` file.
-ENSURE_ENV_PLACEHOLDERS: dict[str, str] = {
-    "PROJECT_DIR": "/tmp",
-    "OUTPUT_DIR": "/tmp",
-    "TASK_DIR": "/tmp",
-    "FINAL_DATA_DIR": "/tmp",
-    "WANDB_ENTITY": "test",
-}
-
-
 @pytest.fixture(scope="session")
 def eq_preprocessed_dataset(simple_static_MEDS: Path, tmp_path_factory: pytest.TempPathFactory) -> Path:
     """Runs ``EQ_process_data do_demo=True`` against ``simple_static_MEDS``.
@@ -273,7 +261,6 @@ def eq_trained_model_dir(
             f"datamodule.config.tensorized_cohort_dir={eq_preprocessed_dataset!s}",
             f"datamodule.config.task_labels_dir={eq_sampled_tasks_dir!s}",
         ],
-        env=ENSURE_ENV_PLACEHOLDERS,
         timeout=300.0,
     )
     return output_dir

--- a/src/every_query/train/README.md
+++ b/src/every_query/train/README.md
@@ -12,7 +12,7 @@ Training stage of the EveryQuery pipeline. Home of the `EQ_train` console script
         logger, early-stopping on tuning/loss). Training has no query-codes knob:
         the set of queried codes is determined by whatever `EQ_generate_training_tasks`
         wrote into the task-labels parquet (`datamodule.config.task_labels_dir`,
-        default `${oc.env:TASK_DIR}`). Code filtering happens
+        default `${oc.env:TRAINING_TASKS_DIR}`). Code filtering happens
         upstream in preprocessing.
     - `fast_config.yaml` — speed-tuned override bundle that inherits `config.yaml` and
         shrinks `max_seq_len`, bumps batch size, etc. Targeted at tokenization-sweep
@@ -34,8 +34,8 @@ EQ_process_data       EQ_generate_training_tasks         EQ_train       EQ_predi
 2. Long-format task-label parquets, produced by
     [`generate_tasks/`](../generate_tasks/) (no intermediate "collation" step — the
     sampler writes the dataloader's input format directly). `EQ_generate_training_tasks`
-    writes these to `$TRAINING_TASKS_DIR`; point `datamodule.config.task_labels_dir`
-    there (it defaults to `$TASK_DIR`).
+    writes these to `$TRAINING_TASKS_DIR`, which is also the default for
+    `datamodule.config.task_labels_dir` — no override needed when `.env` is set.
 
 `train/` produces a run directory at
 `$OUTPUT_DIR/outputs/<YYYY-MM-DD>/<HH-MM-SS>/` containing `best_model.ckpt`,

--- a/src/every_query/train/configs/config.yaml
+++ b/src/every_query/train/configs/config.yaml
@@ -1,7 +1,7 @@
 defaults:
   - _self_
 
-output_dir: ${oc.env:OUTPUT_DIR}/${run_id:}/
+output_dir: ${oc.env:OUTPUT_DIR,null}/${run_id:}/
 do_overwrite: true
 do_resume: false
 seed: 140799
@@ -11,8 +11,8 @@ datamodule:
   data_class: every_query.data.dataset.EveryQueryPytorchDataset
   config:
     _target_: meds_torchdata.MEDSTorchDataConfig
-    tensorized_cohort_dir: ${oc.env:FINAL_DATA_DIR}
-    task_labels_dir: ${oc.env:TASK_DIR}
+    tensorized_cohort_dir: ${oc.env:FINAL_DATA_DIR,null}
+    task_labels_dir: ${oc.env:TRAINING_TASKS_DIR,null}
     static_inclusion_mode: omit
     seq_sampling_strategy: to_end
     max_seq_len: 256
@@ -58,7 +58,7 @@ trainer:
     project: EveryQuery
     log_model: False # upload lightning ckpts
     prefix: "" # a string to put at the beginning of metric keys
-    entity: ${oc.env:WANDB_ENTITY}
+    entity: ${oc.env:WANDB_ENTITY,null}
   callbacks:
     _target_: every_query.train.train.values_as_list
     learning_rate_monitor:

--- a/src/every_query/train/train.py
+++ b/src/every_query/train/train.py
@@ -185,8 +185,77 @@ def find_checkpoint_path(output_dir: Path) -> Path | None:
     return sorted_checkpoints[-1] if sorted_checkpoints else None
 
 
+def _is_wandb_logger(logger_cfg: Any) -> bool:
+    """Return ``True`` if *logger_cfg* is a wandb-shaped logger node.
+
+    A disabled (``false`` / ``null``) or non-wandb logger returns ``False`` so that
+    ``WANDB_ENTITY`` is only required when a wandb logger is actually instantiated.
+
+    Examples:
+        >>> _is_wandb_logger(False)
+        False
+        >>> _is_wandb_logger(None)
+        False
+        >>> _is_wandb_logger(OmegaConf.create({"_target_": "lightning.pytorch.loggers.CSVLogger"}))
+        False
+        >>> _is_wandb_logger(
+        ...     OmegaConf.create({"_target_": "pytorch_lightning.loggers.wandb.WandbLogger"})
+        ... )
+        True
+    """
+    if not logger_cfg or not isinstance(logger_cfg, DictConfig):
+        return False
+    return "WandbLogger" in str(logger_cfg.get("_target_", ""))
+
+
+def validate_training_config(cfg: DictConfig) -> None:
+    """Validate the *resolved* training config, raising a clear error on a missing/bad value.
+
+    Replaces the old blind env-var presence gate (#184).  Because this runs after Hydra has
+    composed the config, a CLI override of a node (e.g. ``datamodule.config.task_labels_dir=/p``)
+    means the backing ``${oc.env:...}`` interpolation never evaluates and the env var is not
+    required.  Each error message names both the config node and the env var that backs it.
+
+    Checks:
+      * ``datamodule.config.tensorized_cohort_dir`` / ``datamodule.config.task_labels_dir`` —
+        must resolve to an existing directory (these are read inputs).
+      * ``output_dir`` — must resolve to a non-empty path (write target; created later, so it
+        need not pre-exist).
+      * wandb ``entity`` — required only when ``trainer.logger`` is wandb-shaped.
+
+    Raises:
+        ValueError: If a required path/value is missing or empty.
+        NotADirectoryError: If a required input path does not exist or is not a directory.
+    """
+    ds_cfg = cfg.datamodule.config
+    for node, env_var in (
+        ("tensorized_cohort_dir", "FINAL_DATA_DIR"),
+        ("task_labels_dir", "TRAINING_TASKS_DIR"),
+    ):
+        value = ds_cfg.get(node)
+        if not value:
+            raise ValueError(
+                f"datamodule.config.{node} is unset. Pass it as a CLI override "
+                f"(datamodule.config.{node}=/path) or set ${env_var} in your .env."
+            )
+        if not Path(value).is_dir():
+            raise NotADirectoryError(
+                f"datamodule.config.{node} ({value!r}, from ${env_var}) is not an existing directory."
+            )
+
+    if not cfg.get("output_dir"):
+        raise ValueError("output_dir is unset. Pass output_dir=/path or set $OUTPUT_DIR in your .env.")
+
+    if _is_wandb_logger(cfg.trainer.get("logger")) and not cfg.trainer.logger.get("entity"):
+        raise ValueError(
+            "trainer.logger.entity is unset for a wandb logger. Pass "
+            "trainer.logger.entity=<entity> or set $WANDB_ENTITY in your .env "
+            "(or disable the logger with trainer.logger=false)."
+        )
+
+
 def _init_env() -> None:
-    """Validate required env vars and configure thread counts for polars/OMP."""
+    """Load ``.env`` and configure thread counts for polars/OMP."""
     from every_query.utils._env import ensure_env
 
     ensure_env()
@@ -202,6 +271,7 @@ CONFIGS = str(files("every_query") / "train" / "configs")
 @hydra.main(version_base="1.3", config_path=CONFIGS, config_name="config.yaml")
 def main(cfg: DictConfig) -> float | None:
     _init_env()
+    validate_training_config(cfg)
 
     if cfg.do_overwrite and cfg.do_resume:
         logger.warning(

--- a/src/every_query/train/train.py
+++ b/src/every_query/train/train.py
@@ -243,8 +243,16 @@ def validate_training_config(cfg: DictConfig) -> None:
                 f"datamodule.config.{node} ({value!r}, from ${env_var}) is not an existing directory."
             )
 
-    if not cfg.get("output_dir"):
-        raise ValueError("output_dir is unset. Pass output_dir=/path or set $OUTPUT_DIR in your .env.")
+    # An unset $OUTPUT_DIR resolves the shipped ``${oc.env:OUTPUT_DIR,null}/${run_id:}/``
+    # interpolation to the *truthy* string ``'None/<run_id>/'`` (the null default is
+    # stringified into the surrounding path), so a bare falsy check is not enough — reject a
+    # leading ``None/`` / ``null/`` segment too, lest the run write to a literal ``None/...`` dir.
+    output_dir = cfg.get("output_dir")
+    if not output_dir or str(output_dir).startswith(("None/", "null/")):
+        raise ValueError(
+            "output_dir is unset (is $OUTPUT_DIR set?). Pass output_dir=/path "
+            "or set $OUTPUT_DIR in your .env."
+        )
 
     if _is_wandb_logger(cfg.trainer.get("logger")) and not cfg.trainer.logger.get("entity"):
         raise ValueError(

--- a/src/every_query/utils/_env.py
+++ b/src/every_query/utils/_env.py
@@ -1,42 +1,20 @@
-"""Load .env and validate that required environment variables are set.
+"""Load ``.env`` so that ``${oc.env:...}`` interpolations in the Hydra configs can resolve.
 
-Imported early by both train.py and tasks.py so that a missing .env on a fresh machine surfaces a single clear
-error rather than a mid-run KeyError or Hydra InterpolationResolutionError.
+This module used to additionally gate a fixed list of "required" environment variables for
+*presence* before the Hydra config was composed.  That check was too blunt: it could not see
+CLI overrides (``datamodule.config.task_labels_dir=/path`` makes the backing ``${oc.env:TASK_DIR}``
+interpolation never evaluate, yet the gate still demanded the env var), and it required
+``WANDB_ENTITY`` even when the logger was disabled.  Path/entity validation now happens
+*post-compose* against the resolved config in ``every_query.train.train.validate_training_config``,
+which can tell whether a node was overridden.  See #184.
+
+``train.py::_init_env`` is the only caller; it loads ``.env`` here so the values are visible to the
+lazy ``${oc.env:...}`` interpolations Hydra resolves later.
 """
-
-import os
-import sys
 
 from dotenv import load_dotenv
 
-REQUIRED_ENV_VARS = (
-    "PROJECT_DIR",
-    "OUTPUT_DIR",
-    "TASK_DIR",
-    "FINAL_DATA_DIR",
-    "WANDB_ENTITY",
-)
-# `PROCESSED` and `INTERMEDIATE` are used by the preprocessing pipeline (the dirs it
-# writes to) and by the generate_tasks stage as dotenv fallbacks inside
-# `sample_tasks.py::_resolve_path` / `sample_evaluation_tasks.py::_resolve_path`.
-# They're not gated by this `REQUIRED_ENV_VARS` check because:
-#   1. `_resolve_path` already tolerates a missing env var when the caller supplies the
-#      path directly (the normal CLI / test path).
-#   2. No Hydra config interpolates `${oc.env:PROCESSED}` or `${oc.env:INTERMEDIATE}`,
-#      so demo fixtures / `--help` invocations don't need throwaway placeholders.
-# If you're running a full fresh-machine setup that includes preprocessing, set both
-# in `.env` (see `.env.example`).  See #117 for the history.
-
 
 def ensure_env() -> None:
+    """Load ``.env`` (if present) so ``${oc.env:...}`` interpolations can resolve."""
     load_dotenv()
-    missing = [v for v in REQUIRED_ENV_VARS if not os.environ.get(v)]
-    if missing:
-        joined = ", ".join(missing)
-        print(
-            f"ERROR: required environment variables not set: {joined}\n"
-            "Copy .env.example to .env and fill in machine-specific paths, "
-            "or export these variables before running.",
-            file=sys.stderr,
-        )
-        sys.exit(1)

--- a/tests/test_env_validation.py
+++ b/tests/test_env_validation.py
@@ -1,0 +1,142 @@
+"""Unit tests for ``every_query.train.train.validate_training_config`` (the #184 post-compose gate).
+
+These replace the old blind ``ensure_env()`` env-var presence check: validation now runs against the
+*resolved* Hydra config, so an overridden node needs no backing env var, and a disabled logger needs
+no ``WANDB_ENTITY``.
+"""
+
+from pathlib import Path
+
+import pytest
+from omegaconf import OmegaConf
+
+from every_query.train.train import validate_training_config
+
+
+def _make_cfg(
+    *,
+    tensorized_cohort_dir,
+    task_labels_dir,
+    output_dir,
+    logger,
+) -> "OmegaConf":
+    return OmegaConf.create(
+        {
+            "output_dir": output_dir,
+            "datamodule": {
+                "config": {
+                    "tensorized_cohort_dir": tensorized_cohort_dir,
+                    "task_labels_dir": task_labels_dir,
+                }
+            },
+            "trainer": {"logger": logger},
+        }
+    )
+
+
+@pytest.fixture
+def existing_dirs(tmp_path: Path) -> tuple[Path, Path]:
+    cohort = tmp_path / "cohort"
+    tasks = tmp_path / "tasks"
+    cohort.mkdir()
+    tasks.mkdir()
+    return cohort, tasks
+
+
+def test_valid_config_no_logger_passes(existing_dirs, tmp_path):
+    cohort, tasks = existing_dirs
+    cfg = _make_cfg(
+        tensorized_cohort_dir=str(cohort),
+        task_labels_dir=str(tasks),
+        output_dir=str(tmp_path / "does_not_exist_yet"),  # write target, need not pre-exist
+        logger=False,
+    )
+    validate_training_config(cfg)  # should not raise
+
+
+def test_missing_task_labels_dir_raises(existing_dirs, tmp_path):
+    cohort, _ = existing_dirs
+    cfg = _make_cfg(
+        tensorized_cohort_dir=str(cohort),
+        task_labels_dir=None,
+        output_dir=str(tmp_path / "out"),
+        logger=False,
+    )
+    with pytest.raises(ValueError, match="task_labels_dir"):
+        validate_training_config(cfg)
+
+
+def test_nonexistent_task_labels_dir_raises(existing_dirs, tmp_path):
+    cohort, _ = existing_dirs
+    cfg = _make_cfg(
+        tensorized_cohort_dir=str(cohort),
+        task_labels_dir=str(tmp_path / "nope"),
+        output_dir=str(tmp_path / "out"),
+        logger=False,
+    )
+    with pytest.raises(NotADirectoryError, match="task_labels_dir"):
+        validate_training_config(cfg)
+
+
+def test_missing_tensorized_cohort_dir_raises(existing_dirs, tmp_path):
+    _, tasks = existing_dirs
+    cfg = _make_cfg(
+        tensorized_cohort_dir=None,
+        task_labels_dir=str(tasks),
+        output_dir=str(tmp_path / "out"),
+        logger=False,
+    )
+    with pytest.raises(ValueError, match="tensorized_cohort_dir"):
+        validate_training_config(cfg)
+
+
+def test_missing_output_dir_raises(existing_dirs):
+    cohort, tasks = existing_dirs
+    cfg = _make_cfg(
+        tensorized_cohort_dir=str(cohort),
+        task_labels_dir=str(tasks),
+        output_dir=None,
+        logger=False,
+    )
+    with pytest.raises(ValueError, match="output_dir"):
+        validate_training_config(cfg)
+
+
+def test_wandb_logger_without_entity_raises(existing_dirs, tmp_path):
+    cohort, tasks = existing_dirs
+    cfg = _make_cfg(
+        tensorized_cohort_dir=str(cohort),
+        task_labels_dir=str(tasks),
+        output_dir=str(tmp_path / "out"),
+        logger={
+            "_target_": "pytorch_lightning.loggers.wandb.WandbLogger",
+            "entity": None,
+        },
+    )
+    with pytest.raises(ValueError, match="entity"):
+        validate_training_config(cfg)
+
+
+def test_wandb_logger_with_entity_passes(existing_dirs, tmp_path):
+    cohort, tasks = existing_dirs
+    cfg = _make_cfg(
+        tensorized_cohort_dir=str(cohort),
+        task_labels_dir=str(tasks),
+        output_dir=str(tmp_path / "out"),
+        logger={
+            "_target_": "pytorch_lightning.loggers.wandb.WandbLogger",
+            "entity": "my-entity",
+        },
+    )
+    validate_training_config(cfg)  # should not raise
+
+
+def test_non_wandb_logger_without_entity_passes(existing_dirs, tmp_path):
+    cohort, tasks = existing_dirs
+    cfg = _make_cfg(
+        tensorized_cohort_dir=str(cohort),
+        task_labels_dir=str(tasks),
+        output_dir=str(tmp_path / "out"),
+        logger={"_target_": "lightning.pytorch.loggers.CSVLogger"},
+    )
+    validate_training_config(cfg)  # should not raise

--- a/tests/test_env_validation.py
+++ b/tests/test_env_validation.py
@@ -102,6 +102,23 @@ def test_missing_output_dir_raises(existing_dirs):
         validate_training_config(cfg)
 
 
+def test_unset_output_dir_env_resolves_to_none_string_raises(existing_dirs, tmp_path):
+    """An unset $OUTPUT_DIR resolves the config interpolation to a truthy 'None/<run_id>/'.
+
+    Regression guard for the #234 review gap: the gate must reject this, not let a run write
+    to a directory literally named ``None/...``.
+    """
+    cohort, tasks = existing_dirs
+    cfg = _make_cfg(
+        tensorized_cohort_dir=str(cohort),
+        task_labels_dir=str(tasks),
+        output_dir="None/2026-06-22/12-00-00/",
+        logger=False,
+    )
+    with pytest.raises(ValueError, match="output_dir"):
+        validate_training_config(cfg)
+
+
 def test_wandb_logger_without_entity_raises(existing_dirs, tmp_path):
     cohort, tasks = existing_dirs
     cfg = _make_cfg(

--- a/tests/test_generate_evaluation_tasks_cli.py
+++ b/tests/test_generate_evaluation_tasks_cli.py
@@ -22,7 +22,7 @@ import pyarrow.parquet as pq
 import pytest
 from meds import DataSchema
 
-from conftest import ENSURE_ENV_PLACEHOLDERS, run_and_check
+from conftest import run_and_check
 from every_query.data.schema import TaskQuerySchema
 from every_query.generate_tasks.sample_evaluation_tasks import subsample_subject_ids
 
@@ -54,7 +54,6 @@ def test_eq_generate_evaluation_tasks_end_to_end(
             "durations=[1,7,30]",
             "seed=42",
         ],
-        env=ENSURE_ENV_PLACEHOLDERS,
         timeout=120.0,
     )
 
@@ -117,7 +116,6 @@ def test_eq_generate_evaluation_tasks_deterministic(
     for out in (out_a, out_b):
         run_and_check(
             ["EQ_generate_evaluation_tasks", f"out_dir={out!s}", *common_args],
-            env=ENSURE_ENV_PLACEHOLDERS,
             timeout=120.0,
         )
 
@@ -172,7 +170,6 @@ def test_eq_generate_evaluation_tasks_subject_subsample_deterministic(
     for out in (out_a, out_b):
         run_and_check(
             ["EQ_generate_evaluation_tasks", f"out_dir={out!s}", *common_args],
-            env=ENSURE_ENV_PLACEHOLDERS,
             timeout=120.0,
         )
 

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -13,7 +13,7 @@ from typing import TYPE_CHECKING
 import torch
 from omegaconf import OmegaConf
 
-from conftest import ENSURE_ENV_PLACEHOLDERS, run_and_check
+from conftest import run_and_check
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -151,7 +151,6 @@ def test_resume_actually_loads_checkpoint_state(
             "do_resume=True",
             f"trainer.max_steps={starting_step}",
         ],
-        env=ENSURE_ENV_PLACEHOLDERS,
         timeout=300.0,
     )
     _, noop_ckpt = _highest_step_checkpoint(resume_dir)
@@ -183,7 +182,6 @@ def test_resume_actually_loads_checkpoint_state(
             "do_resume=True",
             "trainer.max_steps=4",
         ],
-        env=ENSURE_ENV_PLACEHOLDERS,
         timeout=300.0,
     )
     _, resumed_ckpt = _highest_step_checkpoint(resume_dir)

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -23,14 +23,13 @@ def _run_train_subprocess(
     do_overwrite: bool = True,
     extra_overrides: list[str] | None = None,
 ) -> subprocess.CompletedProcess:
-    """Run ``python -m every_query.train.train`` as a subprocess with the demo config."""
+    """Run ``python -m every_query.train.train`` as a subprocess with the demo config.
+
+    No EveryQuery env vars are set: ``_demo_train.yaml`` overrides every path via Hydra CLI and
+    disables the logger, so a fully CLI-driven run needs zero env vars (regression guard for #184).
+    """
     env = os.environ.copy()
     env["PATH"] = _VENV_BIN + os.pathsep + env.get("PATH", "")
-    # Provide dummy env vars so ensure_env() passes in the subprocess.
-    # Hydra CLI overrides control the actual paths used by the test.
-    for var in ("PROJECT_DIR", "OUTPUT_DIR", "TASK_DIR", "FINAL_DATA_DIR"):
-        env.setdefault(var, str(output_dir))
-    env.setdefault("WANDB_ENTITY", "test")
 
     overrides = [
         f"output_dir={output_dir}",

--- a/tests/training_validity/test_training_validity.py
+++ b/tests/training_validity/test_training_validity.py
@@ -17,7 +17,7 @@ import pytest
 from meds import DatasetMetadataSchema, train_split, tuning_split
 from meds_testing_helpers.dataset import MEDSDataset
 
-from conftest import ENSURE_ENV_PLACEHOLDERS, run_and_check
+from conftest import run_and_check
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -247,7 +247,6 @@ def oracle_trained_model_dir(
             "trainer.val_check_interval=1000",
             "lightning_module.optimizer.lr=1e-3",
         ],
-        env=ENSURE_ENV_PLACEHOLDERS,
         timeout=1800.0,
     )
     return output_dir
@@ -292,7 +291,6 @@ def test_trained_model_learns_occurs_and_censor(
             f"output_parquet={predictions_parquet!s}",
             f"split={tuning_split}",
         ],
-        env=ENSURE_ENV_PLACEHOLDERS,
         timeout=600.0,
     )
 
@@ -304,7 +302,6 @@ def test_trained_model_learns_occurs_and_censor(
             f"predictions_parquet={predictions_parquet!s}",
             f"metrics_parquet={metrics_parquet!s}",
         ],
-        env=ENSURE_ENV_PLACEHOLDERS,
         timeout=60.0,
     )
     metrics = pl.read_parquet(metrics_parquet).sort(["query", "duration_days"])


### PR DESCRIPTION
Closes #184.

## Problem
`ensure_env()` was a blind env-var **presence** gate run *before* the Hydra config was composed. It couldn't see CLI overrides (a `datamodule.config.task_labels_dir=/path` override makes the backing `${oc.env:TASK_DIR}` interpolation never evaluate, yet the gate still demanded the env var), required `WANDB_ENTITY` even when the logger was disabled, and hard-required the dead `PROJECT_DIR`. Separately, the redesigned sampler writes to `$TRAINING_TASKS_DIR` but train still defaulted `task_labels_dir` to `$TASK_DIR`, so `EQ_train` did not auto-read sampler output.

## Changes
- **`utils/_env.py`** — `ensure_env()` now only `load_dotenv()`; `REQUIRED_ENV_VARS` + presence loop removed; stale docstring rewritten.
- **`train/train.py`** — new `validate_training_config(cfg)` (+ `_is_wandb_logger` helper), called from `main()` after `_init_env()`. Validates the **resolved** config: cohort/task dirs must exist, `output_dir` non-empty, wandb `entity` required only for a wandb-shaped logger.
- **`train/configs/config.yaml`** — null-default the `${oc.env:...}` interpolations; **rewire** `task_labels_dir` from `TASK_DIR` → `TRAINING_TASKS_DIR` so `EQ_train` auto-reads sampler output.
- **`.env.example`** — drop dead `PROJECT_DIR`/`SAVE_DIR`/`INTERMEDIATE_DIR`/`RAW`; clarify `TASK_DIR` is eval-only. (`INTERMEDIATE` stays — it's the live `data_dir` fallback for both samplers.)
- **READMEs** (top + `train/`) — update env-var docs and the `task_labels_dir` default.
- **tests** — drop `ENSURE_ENV_PLACEHOLDERS` scaffolding from conftest + 4 files; `test_train_cli.py` now runs with **zero** EveryQuery env vars (regression guard); add `tests/test_env_validation.py` (8 cases).

## Net effect
A fully CLI-driven `EQ_train` needs **zero** env vars; an `.env`-driven run gets a clear early error if a path is missing/wrong (not a cryptic `InterpolationResolutionError`); `trainer.logger=false` needs no phantom `WANDB_ENTITY`; a default `.env` run reads the sampler output automatically.

## Verification
- `test_env_validation.py` + `train.py` doctests → 12 passed
- `test_cli_smoke.py` + `test_train_cli.py` → 17 passed (zero-env subprocess train)
- `ruff` clean; manual negative check raises a clear `ValueError` naming the node + env var

> Base is `dev-task-sampler` (the sampler-redesign integration branch), not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)