### PR TITLE
Fix #233: simplify eligibility filter to `> min`

### DIFF
--- a/src/every_query/generate_tasks/redesign-spec.md
+++ b/src/every_query/generate_tasks/redesign-spec.md
@@ -199,8 +199,9 @@ re-sampling or re-resolving.
 > so any disagreement between `_prediction_time_counts.parquet` and `_prediction_times/` means `_prediction_time_counts.parquet`
 > is **stale or corrupt** and must be rebuilt from `_prediction_times/`.
 
-- **Eligibility:** `n_prediction_times >= min_prediction_times_per_subject + 1`. The `+1` guarantees at
-    least one prediction time beyond the prefix, so Stage 2's draw range is non-empty.
+- **Eligibility:** `n_prediction_times > min_prediction_times_per_subject` (strictly more than the
+    minimum). This guarantees at least one prediction time beyond the prefix, so Stage 2's draw range
+    is non-empty.
 - **Algorithm:**
     1. Loop over shards `path_to_data/data/{split}/{i}.parquet`, reading only `subject_id`, `time`. Per
         shard, dedup to distinct `(subject_id, time)`; record each `subject_id`'s `shard`.

--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -317,7 +317,7 @@ def sample_patient_contexts(
         raise ValueError(
             "prediction_time_counts contains a subject with "
             f"n_prediction_times <= min_prediction_times_per_subject ({min_prediction_times_per_subject}); "
-            "Stage 0 eligibility requires n_prediction_times >= min_prediction_times_per_subject + 1 — "
+            "Stage 0 eligibility requires n_prediction_times > min_prediction_times_per_subject — "
             "the counts table is stale or corrupt and must be rebuilt from _prediction_times/"
         )
 
@@ -946,8 +946,8 @@ def build_prediction_times(
     Scans ``path_to_data/data/{split}/*.parquet`` once, deduping to distinct ``(subject_id, time)``
     rows, assigns each subject a gapless zero-based ``prediction_time_index`` over its
     ascending-sorted distinct times, filters to eligible subjects
-    (``n_prediction_times >= min_prediction_times_per_subject + 1`` — the ``+1`` keeps Stage 2's
-    ``[min, n)`` draw range non-empty), and writes:
+    (``n_prediction_times > min_prediction_times_per_subject`` — strictly more than the minimum,
+    which keeps Stage 2's ``[min, n)`` draw range non-empty), and writes:
 
     - ``_prediction_times/{shard}.parquet`` -- canonical map ``(subject_id, prediction_time_index, time)``.
     - ``_prediction_time_counts.parquet``   -- summary ``(subject_id, shard, n_prediction_times)``,
@@ -996,7 +996,7 @@ def build_prediction_times(
         pl.col("shard").first(),
         pl.len().alias("n_prediction_times"),
     )
-    eligible = counts.filter(pl.col("n_prediction_times") >= min_prediction_times_per_subject + 1).sort(
+    eligible = counts.filter(pl.col("n_prediction_times") > min_prediction_times_per_subject).sort(
         "subject_id"
     )
 


### PR DESCRIPTION
## Summary

Closes #233. In `build_prediction_times`, the subject-eligibility filter was written as `n_prediction_times >= min_prediction_times_per_subject + 1`. Since `n_prediction_times` (`pl.len()`) and `min_prediction_times_per_subject` are both integers, this is exactly equivalent to `> min_prediction_times_per_subject`, which expresses "strictly more than the minimum" directly and drops the `+1` that needed a comment.

## Changes

- `sample_tasks.py`: filter uses `> min_prediction_times_per_subject`.
- `sample_tasks.py`: docstring updated to the `> min` form.
- `sample_tasks.py`: stale-counts error message updated to match (the runtime guard already used `>`).
- `redesign-spec.md`: eligibility description updated; pre-commit mdformat also normalized two adjacent code blocks.

Purely a readability cleanup — no behavioral change. Existing prediction-time tests (19) pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)