### PR TITLE
Fix four bugs in the 5-stage task sampler

### DIFF
--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -547,9 +547,14 @@ def _unique_tmp_path(fp: Path) -> Path:
     at the end to be the atomicity primitive.
     """
     fp.parent.mkdir(parents=True, exist_ok=True)
+    # The random token sits *after* ``.tmp.`` (prefix=".{name}.tmp.", empty suffix) so the produced
+    # name is ``.{name}.tmp.<random>`` — matching the ``.{shard}.parquet.tmp.*`` glob in
+    # ``_clean_stale_temps``.  Putting ``tmp`` in a ``suffix=".tmp"`` instead would emit
+    # ``.{name}.<random>.tmp``, which that glob never matches, so orphaned temps would never be
+    # cleaned (the random token lands between ``.parquet.`` and ``.tmp``).
     fd, tmp_name = tempfile.mkstemp(
-        prefix=f".{fp.name}.",
-        suffix=".tmp",
+        prefix=f".{fp.name}.tmp.",
+        suffix="",
         dir=str(fp.parent),
     )
     os.close(fd)
@@ -695,6 +700,7 @@ PREDICTION_TIME_COUNTS_NAME = "_prediction_time_counts.parquet"
 PREDICTION_TIMES_DIRNAME = "_prediction_times"
 PREDICTION_TIMES_META_NAME = "_prediction_times_meta.json"
 INDEX_DIRNAME = "_index"
+LABELED_DIRNAME = "_labeled"
 
 
 def final_output_path(training_tasks_dir: Path, split: str, shard: str) -> Path:
@@ -742,6 +748,22 @@ def index_path(training_task_artifacts_dir: Path, split: str, shard: str) -> Pat
     return training_task_artifacts_dir / split / INDEX_DIRNAME / f"{shard}.parquet"
 
 
+def labeled_fingerprint_path(training_task_artifacts_dir: Path, split: str, shard: str) -> Path:
+    """Stage 4 per-shard label-provenance sidecar: ``{artifacts}/{split}/_labeled/{shard}.json``.
+
+    Records the :func:`_index_fingerprint` of the Stage 3 index partition that produced the current
+    final ``{shard}.parquet`` output.  It lives in the **artifacts** root, never the final-output root,
+    so the final root keeps holding nothing but ``{shard}.parquet`` (invariant 7).  Stage 4 compares
+    the recorded fingerprint against the current index's fingerprint to decide whether an existing
+    output is still valid (skip) or was produced by a different index (stale ⇒ relabel).
+
+    Examples:
+        >>> labeled_fingerprint_path(Path("/x/tasks_artifacts"), "train", "0")
+        PosixPath('/x/tasks_artifacts/train/_labeled/0.json')
+    """
+    return training_task_artifacts_dir / split / LABELED_DIRNAME / f"{shard}.json"
+
+
 def prediction_times_meta_path(training_task_artifacts_dir: Path, split: str) -> Path:
     """Stage 0 cache sidecar: ``{artifacts}/{split}/_prediction_times_meta.json``.
 
@@ -768,6 +790,25 @@ def prediction_times_meta_path(training_task_artifacts_dir: Path, split: str) ->
 # ``evaluate_index_df``, aligns to ``TaskQuerySchema``, and writes the final dataset
 # shard atomically.  Workers are fully independent (own index partition, own event file,
 # own output file) so the orchestrator (#210) fans them out with ProcessPoolExecutor.
+
+
+def _index_fingerprint(index_df: pl.DataFrame) -> str:
+    """Serialization-independent fingerprint of a Stage 3 index partition's *logical* content.
+
+    Stage 3 unconditionally rebuilds (``rmtree`` + rewrite) the index every run, so an existence-only
+    Stage 4 skip would keep stale labels after a sampling-config change (different ``seed`` /
+    ``num_queries`` / ``query_codes`` / duration params) when ``overwrite=False``.  This fingerprint
+    lets the worker tell "same index as last time" (skip) from "different index" (relabel).
+
+    Built from polars' vectorized :meth:`~polars.DataFrame.hash_rows` summed over rows, combined with
+    the row count.  Summing is order-independent and counts duplicates, so the fingerprint depends only
+    on the *multiset* of index rows — exactly what determines the labels — and is stable across the
+    parquet re-serialization Stage 3 performs each run (a byte-hash of the parquet file would not be,
+    which would break ``overwrite=False`` idempotency).  Not collision-proof, but a collision only
+    causes an over-skip on content that already hashed and counted identically.
+    """
+    row_hash_sum = int(index_df.hash_rows(seed=0).sum()) if index_df.height else 0
+    return f"{index_df.height}:{row_hash_sum & 0xFFFFFFFFFFFFFFFF:016x}"
 
 
 def _clean_stale_temps(out_dir: Path, shard: str) -> int:
@@ -806,15 +847,30 @@ def label_one_shard(
 
     Returns:
         ``(shard, status)`` where status is ``"skipped"`` or ``"labeled"``.
+
+    The skip is keyed on the :func:`_index_fingerprint` of the current Stage 3 index partition, not
+    on mere output existence: an existing output is reused only when a recorded fingerprint matches
+    the current index (a genuine restart of the *same* run).  A changed sampling config rewrites the
+    index with a different fingerprint, so the stale output is relabeled even under ``overwrite=False``.
+    A missing/unreadable fingerprint (e.g. a pre-fingerprint output, or a crash between the parquet
+    and sidecar writes) is treated as stale ⇒ relabel.
     """
     final = out_dir / f"{shard}.parquet"
+    fingerprint_fp = index_dir.parent / LABELED_DIRNAME / f"{shard}.json"
+
+    index_df = pl.read_parquet(index_dir / f"{shard}.parquet")
+    current_fingerprint = _index_fingerprint(index_df)
 
     if not overwrite and final.exists():
-        return shard, "skipped"
+        try:
+            recorded = json.loads(fingerprint_fp.read_text()).get("index_fingerprint")
+        except (OSError, json.JSONDecodeError, AttributeError):
+            recorded = None
+        if recorded == current_fingerprint:
+            return shard, "skipped"
 
     _clean_stale_temps(out_dir, shard)
 
-    index_df = pl.read_parquet(index_dir / f"{shard}.parquet")
     events_df = _read_event_shard(data_dir / f"{shard}.parquet")
     max_time = compute_max_time_per_subject(events_df)
 
@@ -822,6 +878,9 @@ def label_one_shard(
     aligned = TaskQuerySchema.align(labeled.to_arrow())
 
     _atomic_write_parquet(pl.from_arrow(aligned), final)
+    # Record the index fingerprint *after* the output is committed so a present sidecar always
+    # describes a present, complete output (the parquet is the value, the sidecar is its provenance).
+    _atomic_write_json({"index_fingerprint": current_fingerprint}, fingerprint_fp)
     return shard, "labeled"
 
 
@@ -1139,9 +1198,11 @@ def build_index(
     # ``group_by`` (not ``partition_by``) for the same reason — it streams one group at a time
     # rather than materializing every shard's frame up front.
 
-    # Sort to make order that shards are processed deterministic
+    # Sort + ``maintain_order=True`` make the order shards are processed (and logged) deterministic;
+    # ``group_by`` alone is not order-preserving.  Output content is unaffected (shards are
+    # independent), but the deterministic order keeps reruns and logs stable.
     combined = combined.sort("shard")
-    for shard_key, shard_group in combined.group_by("shard"):
+    for shard_key, shard_group in combined.group_by("shard", maintain_order=True):
         (shard_name,) = shard_key
         pt_map = pl.read_parquet(prediction_times_path(training_task_artifacts_dir, split, str(shard_name)))
 
@@ -1324,6 +1385,13 @@ def run(cfg: DictConfig) -> None:
     for stale in out_dir.glob("*.parquet"):
         if stale.stem not in current_shards:
             stale.unlink()
+    # Mirror the prune onto the per-shard label-provenance sidecars so the _labeled/ dir never
+    # carries fingerprints for shards the final root no longer has.
+    labeled_dir = training_task_artifacts_dir / cfg.split / LABELED_DIRNAME
+    if labeled_dir.exists():
+        for stale_fp in labeled_dir.glob("*.json"):
+            if stale_fp.stem not in current_shards:
+                stale_fp.unlink()
 
     n_workers = resolve_workers(cfg.max_workers)
     logger.info("Stage 4: labeling %s shard(s) across %s worker(s).", f"{len(shards):,}", f"{n_workers:,}")
@@ -1339,8 +1407,12 @@ def run(cfg: DictConfig) -> None:
             fut.result()  # re-raise so a failed shard aborts the run loudly
 
     # The final dataset is the union of the shard parquets; its row count must equal the sampling
-    # budget N = num_queries * num_contexts_per_query (spec Stage 4).
-    written = int(pl.scan_parquet(out_dir / "*.parquet").select(pl.len()).collect().item())
+    # budget N = num_queries * num_contexts_per_query (spec Stage 4).  Resolve the file list
+    # explicitly (rather than a glob string) so the degenerate empty-budget case (num_queries=0 or
+    # num_contexts_per_query=0 -> no index, no output) reports 0 rows instead of tripping polars'
+    # "no files found" on an empty glob.
+    out_files = sorted(out_dir.glob("*.parquet"))
+    written = int(pl.scan_parquet(out_files).select(pl.len()).collect().item()) if out_files else 0
     if written != total_rows:
         raise ValueError(
             f"Stage 4 wrote {written} rows but expected {total_rows} "
@@ -1348,12 +1420,17 @@ def run(cfg: DictConfig) -> None:
         )
     logger.info("Pipeline complete: wrote %s labeled rows to %s.", f"{written:,}", out_dir)
 
+    if not out_files:
+        # Empty budget: nothing to summarize, and the summary scan below would hit the same empty-glob
+        # error the row-count scan just side-stepped.
+        return
+
     # Summary of the final dataset's coverage: how many distinct subjects and distinct queries the
     # written rows span (one scan over the {split}/*.parquet union).  A "query" is the full
     # QuerySpec identity -- the (query-code, duration_days) pair -- so it's counted as the number of
     # distinct (query, duration_days) combinations, not distinct codes alone.
     summary = (
-        pl.scan_parquet(out_dir / "*.parquet")
+        pl.scan_parquet(out_files)
         .select(
             pl.col(TaskQuerySchema.subject_id_name).n_unique().alias("n_subjects"),
             pl.struct(TaskQuerySchema.query_name, TaskQuerySchema.duration_days_name)

--- a/tests/sampler/test_orchestration.py
+++ b/tests/sampler/test_orchestration.py
@@ -223,6 +223,47 @@ class TestMainOrchestration:
         rebuilt = _union_final_output(tasks_dir)
         assert rebuilt.equals(clean)
 
+    def test_changed_seed_relabels_without_overwrite(
+        self, monkeypatch, tmp_path, synthetic_events, synthetic_query_codes
+    ):
+        """Bug #2: a sampling-config change must not leave stale labels under ``overwrite=False``.
+
+        Stage 3 always rebuilds the index, but Stage 4's skip used to be existence-only — so rerunning
+        with a new ``seed`` (same shard set) silently kept the previous run's labels. The per-shard
+        index fingerprint must detect the mismatch and relabel even without ``overwrite=True``.
+        """
+        tasks_dir = self._run_env(monkeypatch, tmp_path, synthetic_events, synthetic_query_codes)
+
+        st.run(self._cfg(synthetic_query_codes))  # seed=1
+        seed1 = _union_final_output(tasks_dir)
+
+        cfg2 = self._cfg(synthetic_query_codes)  # overwrite stays False
+        cfg2.seed = 2
+        st.run(cfg2)
+        relabeled = _union_final_output(tasks_dir)
+
+        # The stale seed-1 labels must be gone, and the output must match an overwrite=True rebuild at
+        # seed 2 (the ground truth for that config) — proving the relabel happened in place.
+        assert not relabeled.equals(seed1)
+        cfg2_force = self._cfg(synthetic_query_codes, overwrite=True)
+        cfg2_force.seed = 2
+        st.run(cfg2_force)
+        assert relabeled.equals(_union_final_output(tasks_dir))
+
+    def test_num_queries_zero_writes_empty_dataset(
+        self, monkeypatch, tmp_path, synthetic_events, synthetic_query_codes
+    ):
+        """Bug #3: ``num_queries=0`` (empty budget) must report 0 rows, not crash on an empty glob.
+
+        With no queries, Stage 3 writes no index and Stage 4 writes no output; the final/summary scans must
+        side-step polars' "no files found" error and the row-count guard must pass (0 == 0).
+        """
+        tasks_dir = self._run_env(monkeypatch, tmp_path, synthetic_events, synthetic_query_codes)
+
+        st.run(self._cfg(synthetic_query_codes, num_queries=0))  # must not raise
+
+        assert sorted((tasks_dir / "train").glob("*.parquet")) == []
+
 
 class TestCrossProcessDeterminism:
     """The parallel Stage 4 fan-out must produce the same labeled dataset as the serial path.

--- a/tests/sampler/test_pure_helpers.py
+++ b/tests/sampler/test_pure_helpers.py
@@ -259,6 +259,30 @@ class TestAtomicWrite:
         assert not fp.exists()
         assert list(tmp_path.glob(".out.parquet.tmp.*")) == []
 
+    def test_unique_tmp_path_matches_clean_glob(self, tmp_path):
+        """The temp name produced by ``_unique_tmp_path`` must match the ``_clean_stale_temps`` glob.
+
+        Regression for the bug where ``mkstemp(suffix=".tmp")`` emitted ``.{name}.<random>.tmp`` while
+        cleanup globbed ``.{name}.tmp.*`` — the two never agreed, so orphaned temps were never cleaned.
+        Pin the contract: a real ``_unique_tmp_path`` temp is found by the cleanup glob and removed.
+        """
+        fp = tmp_path / "0.parquet"
+        tmp = st._unique_tmp_path(fp)
+        try:
+            assert tmp.parent == fp.parent
+            assert tmp in set(tmp_path.glob(f".{fp.name}.tmp.*"))
+        finally:
+            tmp.unlink(missing_ok=True)
+
+        # And it does NOT collide with the final-root ``*.parquet`` safety glob (invariant 7).
+        recreated = st._unique_tmp_path(fp)
+        try:
+            assert recreated not in set(tmp_path.glob("*.parquet"))
+            assert st._clean_stale_temps(tmp_path, "0") == 1
+            assert not recreated.exists()
+        finally:
+            recreated.unlink(missing_ok=True)
+
 
 class TestResolveWorkers:
     """Stage 4 worker-pool sizing: SLURM env precedence, cpu_count fallback, downward-only cap."""

--- a/tests/sampler/test_stage4_labeling.py
+++ b/tests/sampler/test_stage4_labeling.py
@@ -474,17 +474,56 @@ class TestLabelOneShard:
         # prediction_time=day2, event at day5 is in (day2, day2+7=day9] → True for all
         assert result["boolean_value"].to_list() == [True, True, True]
 
-    def test_skip_on_success(self, tmp_path):
+    def test_skip_on_matching_fingerprint(self, tmp_path):
+        """A second run over the *same* index skips (fingerprint matches), leaving output untouched."""
         events = self._events()
         index_df = self._index()
         index_dir, data_dir, out_dir = _make_shard_fixture(tmp_path, events, index_df)
 
-        sentinel = b"sentinel"
-        (out_dir / "0.parquet").write_bytes(sentinel)
+        _shard, status = label_one_shard("0", index_dir, data_dir, out_dir, overwrite=False)
+        assert status == "labeled"
+        first_bytes = (out_dir / "0.parquet").read_bytes()
 
         _shard, status = label_one_shard("0", index_dir, data_dir, out_dir, overwrite=False)
         assert status == "skipped"
-        assert (out_dir / "0.parquet").read_bytes() == sentinel
+        assert (out_dir / "0.parquet").read_bytes() == first_bytes
+
+    def test_relabels_when_fingerprint_missing(self, tmp_path):
+        """An existing output with no provenance sidecar is treated as stale ⇒ relabel (safe default).
+
+        Guards against the old existence-only skip, which would silently keep a pre-fingerprint (or half-
+        written) output.
+        """
+        events = self._events()
+        index_df = self._index()
+        index_dir, data_dir, out_dir = _make_shard_fixture(tmp_path, events, index_df)
+
+        (out_dir / "0.parquet").write_bytes(b"stale-no-fingerprint")
+
+        _shard, status = label_one_shard("0", index_dir, data_dir, out_dir, overwrite=False)
+        assert status == "labeled"
+        assert pl.read_parquet(out_dir / "0.parquet").height == 3
+
+    def test_relabels_when_index_changed(self, tmp_path):
+        """When the Stage 3 index is rewritten with different content, overwrite=False still relabels.
+
+        This is bug #2: Stage 3 always rebuilds the index, so an existence-only skip would keep stale labels
+        after a sampling-config change. The fingerprint mismatch must force a relabel.
+        """
+        events = self._events()
+        index_dir, data_dir, out_dir = _make_shard_fixture(tmp_path, events, self._index(duration_days=7.0))
+
+        _shard, status = label_one_shard("0", index_dir, data_dir, out_dir, overwrite=False)
+        assert status == "labeled"
+
+        # Rewrite the index partition with a duration that flips the labels (window day2->day3 excludes
+        # the day5 event), mimicking Stage 3 rebuilding under a changed config.
+        self._index(duration_days=1.0).write_parquet(index_dir / "0.parquet")
+
+        _shard, status = label_one_shard("0", index_dir, data_dir, out_dir, overwrite=False)
+        assert status == "labeled"
+        # day2 + 1d = day3 window; the next "A01" event is day5 (outside) → False, not the prior True.
+        assert pl.read_parquet(out_dir / "0.parquet")["boolean_value"].to_list() == [False, False, False]
 
     def test_overwrite(self, tmp_path):
         events = self._events()
@@ -621,12 +660,16 @@ class TestCleanStaleTemps:
     def test_removes_matching_temps(self, tmp_path):
         (tmp_path / ".0.parquet.tmp.111").write_bytes(b"x")
         (tmp_path / ".0.parquet.tmp.222").write_bytes(b"x")
+        # A temp produced the *real* way (via _unique_tmp_path) must be cleaned too — guards against
+        # the cleanup glob drifting from the actual mkstemp naming.
+        real = st._unique_tmp_path(tmp_path / "0.parquet")
         (tmp_path / ".1.parquet.tmp.333").write_bytes(b"x")  # different shard
 
         removed = _clean_stale_temps(tmp_path, "0")
-        assert removed == 2
+        assert removed == 3
         assert not (tmp_path / ".0.parquet.tmp.111").exists()
         assert not (tmp_path / ".0.parquet.tmp.222").exists()
+        assert not real.exists()
         assert (tmp_path / ".1.parquet.tmp.333").exists()  # untouched
 
     def test_no_temps_returns_zero(self, tmp_path):


### PR DESCRIPTION
## Summary

Four bugs found while reviewing `sample_tasks.py` (the 5-stage sampling-first task generator), all fixed with tests.

### 1. Temp cleanup glob never matched real temp files
`_unique_tmp_path` built temps as `.{name}.<random>.tmp` (via `mkstemp(suffix=".tmp")`), but `_clean_stale_temps` globbed `.{name}.tmp.*` — the two never agreed, so orphaned atomic-write temps from crashed workers were **never cleaned**. The existing tests baked in the same wrong pattern, so they passed against the bug. Fix: move `tmp` into the prefix (`.{name}.tmp.<random>`), aligning real temp names with the cleanup glob, the docstrings, and the tests. Still hidden and not ending in `.parquet`, so the final-root `{split}/*.parquet` safety glob still skips it (invariant 7).

### 2. `overwrite=False` kept stale labels after a config change
Stage 3 always rebuilds the index, but Stage 4 skipped purely on output existence. Rerunning with a changed `seed`/`num_queries`/`query_codes`/duration params (same shard set) silently kept the **previous run's labels**, and the row-count guard could still pass. Fix: add a serialization-independent per-shard index fingerprint (`_index_fingerprint`, built from `hash_rows`) recorded in a `_labeled/{shard}.json` sidecar in the **artifacts** root (preserves invariant 7). Stage 4 skips only on a fingerprint match, else relabels; missing/corrupt fingerprint → relabel (safe default). Preserves rerun idempotency and `overwrite=True` semantics.

### 3. `num_queries=0` crashed the final/summary scans
The empty-budget path wrote no output, so `pl.scan_parquet(out_dir/"*.parquet")` raised "no files found" instead of reporting 0 rows. Fix: resolve an explicit file list; report 0 rows (passing the `0 == 0` guard) and return before the summary scan.

### 4. Misleading `group_by` ordering comment in `build_index`
A comment claimed `sort("shard")` made shard processing order deterministic, but `group_by` is not order-preserving without `maintain_order=True`. Output content was unaffected; added `maintain_order=True` so the comment is true.

## Tests
- `test_pure_helpers.py`: regression pinning `_unique_tmp_path` naming ↔ cleanup glob.
- `test_stage4_labeling.py`: real-temp cleanup; fingerprint skip / relabel-on-change / relabel-on-missing.
- `test_orchestration.py`: changed-seed-relabels end-to-end; `num_queries=0` no-crash.

All pass: 120 sampler unit tests, 10 module doctests, and the dataset-integration test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)