### PR TITLE
Fix #242: inline max_time computation into evaluate_index_df

### DIFF
--- a/src/every_query/generate_tasks/sample_evaluation_tasks.py
+++ b/src/every_query/generate_tasks/sample_evaluation_tasks.py
@@ -38,7 +38,6 @@ from every_query.generate_tasks.sample_tasks import (
     _atomic_write_parquet,
     _read_event_shard,
     _resolve_path,
-    compute_max_time_per_subject,
     evaluate_index_df,
     read_query_codes,
 )
@@ -374,8 +373,7 @@ def run_worker(
         ]
         labeled = empty_task_query_df().select(out_cols)
     else:
-        max_time_df = compute_max_time_per_subject(events_df)
-        labeled = evaluate_index_df(index_df, events_df, max_time_df)
+        labeled = evaluate_index_df(index_df, events_df)
 
     # Censored rows (null boolean_value) are not actionable downstream — drop them
     # so EQ_predict / EQ_evaluate consume a ready-to-score parquet.

--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -342,8 +342,8 @@ def sample_patient_contexts(
 def compute_max_time_per_subject(events_df: pl.DataFrame) -> pl.DataFrame:
     """Return a ``(subject_id, max_time)`` DataFrame.
 
-    Used once per shard to turn the per-row censoring check into an O(1) lookup inside
-    ``evaluate_index_df``.
+    Implementation detail of ``evaluate_index_df``'s censoring check (kept module-level for
+    direct unit testing).
     """
     return events_df.group_by(DataSchema.subject_id_name).agg(
         pl.col(DataSchema.time_name).max().alias("max_time")
@@ -353,7 +353,6 @@ def compute_max_time_per_subject(events_df: pl.DataFrame) -> pl.DataFrame:
 def evaluate_index_df(
     index_df: pl.DataFrame,
     events_df: pl.DataFrame,
-    max_time_per_subject: pl.DataFrame,
 ) -> pl.DataFrame:
     """Label an index DataFrame with the single nullable ``boolean_value`` column via a single ``join_asof``.
 
@@ -375,7 +374,6 @@ def evaluate_index_df(
             ``query``, ``duration_days``. If ``task_id`` is present it is ignored and dropped from
             the output.
         events_df: Shard events with columns ``subject_id``, ``time``, ``code``.
-        max_time_per_subject: Output of ``compute_max_time_per_subject``.
 
     Returns:
         DataFrame with columns ``(subject_id, prediction_time, boolean_value, query,
@@ -398,6 +396,8 @@ def evaluate_index_df(
     # dtypes, guaranteed to pass ``TaskQuerySchema.align()`` downstream.
     if index_df.height == 0:
         return empty_task_query_df().select(out_cols)
+
+    max_time_per_subject = compute_max_time_per_subject(events_df)
 
     # Left side: index rows with a +1µs-shifted prediction_time for the strict-> asof key.
     left = index_df.with_columns(
@@ -872,9 +872,8 @@ def label_one_shard(
     _clean_stale_temps(out_dir, shard)
 
     events_df = _read_event_shard(data_dir / f"{shard}.parquet")
-    max_time = compute_max_time_per_subject(events_df)
 
-    labeled = evaluate_index_df(index_df, events_df, max_time)
+    labeled = evaluate_index_df(index_df, events_df)
     aligned = TaskQuerySchema.align(labeled.to_arrow())
 
     _atomic_write_parquet(pl.from_arrow(aligned), final)

--- a/tests/sampler/test_stage4_labeling.py
+++ b/tests/sampler/test_stage4_labeling.py
@@ -14,7 +14,6 @@ import polars as pl
 from every_query.generate_tasks import sample_tasks as st
 from every_query.generate_tasks.sample_tasks import (
     _clean_stale_temps,
-    compute_max_time_per_subject,
     evaluate_index_df,
     label_one_shard,
 )
@@ -68,14 +67,13 @@ class TestEvaluateIndexDfEdgeCases:
                 "duration_days": [10],
             }
         ).with_columns(pl.col("prediction_time").cast(pl.Datetime("us")))
-        max_time_df = compute_max_time_per_subject(events)
-        result = evaluate_index_df(index_df, events, max_time_df)
+        result = evaluate_index_df(index_df, events)
         assert result["boolean_value"].to_list() == [True]
 
         # Now with duration=0: no window → False (and not censored because 2020-01-03
         # + 0 days = 2020-01-03 which is <= 2021-01-01).
         index_df_zero = index_df.with_columns(pl.lit(0, dtype=pl.Int64).alias("duration_days"))
-        result_zero = evaluate_index_df(index_df_zero, events, max_time_df)
+        result_zero = evaluate_index_df(index_df_zero, events)
         assert result_zero["boolean_value"].to_list() == [False]
 
     def test_event_exactly_at_window_end_is_included(self):
@@ -118,7 +116,7 @@ class TestEvaluateIndexDfEdgeCases:
             }
         ).with_columns(pl.col("prediction_time").cast(pl.Datetime("us")))
 
-        result = evaluate_index_df(index_df, events, compute_max_time_per_subject(events))
+        result = evaluate_index_df(index_df, events)
         labels = {row["subject_id"]: row["boolean_value"] for row in result.iter_rows(named=True)}
         assert labels == {1: True, 2: False}
 
@@ -143,9 +141,8 @@ class TestEvaluateIndexDfEdgeCases:
             }
         ).with_columns(pl.col("prediction_time").cast(pl.Datetime("us")))
 
-        max_time_df = compute_max_time_per_subject(events)
         with caplog.at_level("WARNING", logger="every_query.generate_tasks.sample_tasks"):
-            result = evaluate_index_df(index_df, events, max_time_df)
+            result = evaluate_index_df(index_df, events)
 
         # Subject 2 (unknown) → censored → null boolean_value.
         unknown = result.filter(pl.col("subject_id") == 2)
@@ -182,7 +179,7 @@ class TestEvaluateIndexDfEdgeCases:
             }
         ).with_columns(pl.col("prediction_time").cast(pl.Datetime("us")))
 
-        result = evaluate_index_df(index_df, events, compute_max_time_per_subject(events))
+        result = evaluate_index_df(index_df, events)
         assert result["boolean_value"].to_list() == [False]
 
     def test_nonmatching_code_in_window_is_ignored(self):
@@ -211,7 +208,7 @@ class TestEvaluateIndexDfEdgeCases:
             }
         ).with_columns(pl.col("prediction_time").cast(pl.Datetime("us")))
 
-        result = evaluate_index_df(index_df, events, compute_max_time_per_subject(events))
+        result = evaluate_index_df(index_df, events)
         labels = {row["query"]: row["boolean_value"] for row in result.iter_rows(named=True)}
         assert labels == {"A": False, "B": True}
 
@@ -235,7 +232,7 @@ class TestEvaluateIndexDfEdgeCases:
             }
         ).with_columns(pl.col("prediction_time").cast(pl.Datetime("us")))
 
-        result = evaluate_index_df(index_df, events, compute_max_time_per_subject(events))
+        result = evaluate_index_df(index_df, events)
         assert result.height == 1
         assert result["boolean_value"].to_list() == [True]
 
@@ -271,7 +268,7 @@ class TestBooleanValueTruthTable:
                 "duration_days": [duration_days],
             }
         ).with_columns(pl.col("prediction_time").cast(pl.Datetime("us")))
-        result = evaluate_index_df(index_df, events, compute_max_time_per_subject(events))
+        result = evaluate_index_df(index_df, events)
         assert result.height == 1
         return result["boolean_value"].to_list()[0]
 
@@ -401,7 +398,7 @@ class TestReadEventShardDtypeNormalization:
             }
         ).with_columns(pl.col("prediction_time").cast(pl.Datetime("us")))
 
-        result = evaluate_index_df(index_df, events, compute_max_time_per_subject(events))
+        result = evaluate_index_df(index_df, events)
         # Uncensored (max_time = 2021-01-01 is way past prediction + 10d) and the next "A"
         # event is 2020-01-02, which is strictly within the window → boolean_value=True.
         assert result["boolean_value"].to_list() == [True]

--- a/tests/test_sampler_dataset_integration.py
+++ b/tests/test_sampler_dataset_integration.py
@@ -16,7 +16,7 @@ from meds_torchdata.config import MEDSTorchDataConfig
 
 from every_query.data.dataset import EveryQueryPytorchDataset
 from every_query.data.schema import TaskQuerySchema
-from every_query.generate_tasks.sample_tasks import compute_max_time_per_subject, evaluate_index_df
+from every_query.generate_tasks.sample_tasks import evaluate_index_df
 
 # Subject IDs and prediction times from conftest / simple_static_MEDS.  Duplicated here rather
 # than imported to keep the test module self-contained.
@@ -87,8 +87,7 @@ class TestEndToEndWithDataset:
             }
         )
 
-        max_time_df = compute_max_time_per_subject(events_df)
-        labeled = evaluate_index_df(index_df, events_df, max_time_df)
+        labeled = evaluate_index_df(index_df, events_df)
 
         # Sanity: labeled output conforms to TaskQuerySchema — same check the Stage 4 write path
         # (``label_one_shard``) does, exercised here at the per-function boundary.


### PR DESCRIPTION
## Summary

Inlines the per-subject `max_time` computation into `evaluate_index_df`, dropping it from the signature (closes #242).

The `compute_max_time_per_subject(events_df)` → pass-into-`evaluate_index_df` split never realized its claimed "compute once per shard for O(1) lookup" reuse benefit — every call site was a 1:1 compute-then-pass. `max_time` is always a pure function of `events_df` with no production path where the two diverge, so the split only added boilerplate and a two-step contract that was easy to misuse.

## Changes

- `evaluate_index_df(index_df, events_df)` now computes `max_time` internally (after the empty-input fast-path guard).
- Production call sites simplified to the two-arg form: `label_one_shard` (`sample_tasks.py`) and `run_eval` (`sample_evaluation_tasks.py`); dropped the now-unused `compute_max_time_per_subject` import in the latter.
- `compute_max_time_per_subject` kept as a module-level helper (still directly unit-tested in `test_pure_helpers.py`); stale "O(1) lookup once per shard" docstring framing updated.
- Tests drop the redundant `max_time_df` argument (`test_stage4_labeling.py`, `test_sampler_dataset_integration.py`).

**No change to label semantics, censoring logic, or schemas.**

## Test plan

`uv run pytest tests/sampler/ tests/test_generate_tasks.py tests/test_sampler_dataset_integration.py` — **124 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)