### PR TITLE
Rename env vars for clarity; merge PROCESSED/FINAL_DATA_DIR

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ The legacy four-stage evaluator (`every_query.evaluate.eval`, with `gen_index_ti
 ```mermaid
 flowchart TD
     meds[MEDS cohort] --> process[EQ_process_data]
-    process --> intermediate[("MEDS event shards<br/>($INTERMEDIATE)")]
-    process --> cohort[("tensorized cohort<br/>($FINAL_DATA_DIR)")]
+    process --> intermediate[("MEDS event shards<br/>($TOKENIZED_EVENTS_DIR)")]
+    process --> cohort[("tensorized cohort<br/>($TENSORIZED_COHORT_DIR)")]
 
     intermediate --> train_tasks[EQ_generate_training_tasks<br/><i>scattered, random tasks</i>]
     intermediate --> eval_tasks[EQ_generate_evaluation_tasks<br/><i>dense grid: codes × durations</i>]
@@ -105,13 +105,13 @@ Both task-generation endpoints emit `TaskQuerySchema`-conformant parquets. Train
 ```bash
 EQ_process_data \
 	input_dir="$DATA_DIR" \
-	intermediate_dir="$INTERMEDIATE" \
-	output_dir="$FINAL_DATA_DIR"
+	intermediate_dir="$TOKENIZED_EVENTS_DIR" \
+	output_dir="$TENSORIZED_COHORT_DIR"
 ```
 
-Produces a tensorized MEDS cohort under `$FINAL_DATA_DIR`. `$INTERMEDIATE` is a staging
-directory for the MEDS-transforms stages; `$PROCESSED` holds cross-shard metadata
-(`$PROCESSED/metadata/codes.parquet` is the query-code universe the sampler draws from).
+Produces a tensorized MEDS cohort under `$TENSORIZED_COHORT_DIR`. `$TOKENIZED_EVENTS_DIR` is a staging
+directory for the MEDS-transforms stages; `$TENSORIZED_COHORT_DIR` holds cross-shard metadata
+(`$TENSORIZED_COHORT_DIR/metadata/codes.parquet` is the query-code universe the sampler draws from).
 
 ### 2a. Generate pre-training task labels
 
@@ -121,9 +121,9 @@ EQ_generate_training_tasks \
 	num_queries=4000000 \
 	num_contexts_per_query=1 \
 	max_workers=1 \
-	data_dir="$INTERMEDIATE" \
+	data_dir="$TOKENIZED_EVENTS_DIR" \
 	out_dir="$TRAINING_TASKS_DIR" \
-	query_codes="$PROCESSED"
+	query_codes="$TENSORIZED_COHORT_DIR"
 ```
 
 `data_dir` is the MEDS dataset root (event shards read from `{data_dir}/data/{split}/*.parquet`) and `out_dir` is the final-dataset root. Both are required Hydra args (no `.env` fallback — see [#235](https://github.com/payalchandak/EveryQuery/issues/235)); pass them as shell-expanded vars after `source env.sh`.
@@ -134,7 +134,7 @@ One command runs the whole 5-stage sampler in a single process (Stages 0–3 inl
 
 > **Note:** The total number of training samples generated will be `num_queries * num_contexts_per_query`
 
-`query_codes=` is required for training. Set it to a metadata root (`query_codes=$PROCESSED`) to
+`query_codes=` is required for training. Set it to a metadata root (`query_codes=$TENSORIZED_COHORT_DIR`) to
 sample from `{dir}/metadata/codes.parquet`, or to an inline list / YAML path to restrict which codes
 can be sampled as queries. YAML files may be a flat list or a mapping with a `codes:` key. This does
 not remove codes from patient histories.
@@ -159,16 +159,16 @@ EQ_generate_evaluation_tasks \
 	prediction_times_per_subject=5 \
 	'query_codes=[HR, TEMP]' \
 	'durations=[1, 7, 30, 90, 365]' \
-	data_dir="$INTERMEDIATE" \
-	out_dir=$TASK_DIR
+	data_dir="$TOKENIZED_EVENTS_DIR" \
+	out_dir=$EVAL_TASKS_DIR
 ```
 
-Samples `1` prediction times per subject by default, cross-joins with the full `(codes × durations)` grid, labels via the same primitive as training. Output lands under `$TASK_DIR/eval/{split}/*.parquet` (separate `eval/` subdir so it doesn't collide with the training-task output).
+Samples `1` prediction times per subject by default, cross-joins with the full `(codes × durations)` grid, labels via the same primitive as training. Output lands under `$EVAL_TASKS_DIR/eval/{split}/*.parquet` (separate `eval/` subdir so it doesn't collide with the training-task output).
 
 The endpoint writes one parquet per `(split, input_shard)` worker, so to label a whole split use Hydra multirun (`-m`) to sweep `input_shard` — there's no auto-discovery, so enumerate the range explicitly. Count the shards for your split first (`N` = this number):
 
 ```bash
-ls "$INTERMEDIATE"/data/held_out/*.parquet | wc -l
+ls "$TOKENIZED_EVENTS_DIR"/data/held_out/*.parquet | wc -l
 ```
 
 Then sweep `input_shard=range(0,N)`:
@@ -193,7 +193,7 @@ A comma list (`input_shard=0,1,2`) works too; `range(0,16)` is just shorthand fo
 
 As with training, `data_dir` / `out_dir` are required Hydra args (pass them as shell-expanded vars). `query_codes` is also required — it is the evaluation query universe.
 
-`query_codes=` accepts an inline list (as above), a metadata root / `codes.parquet` path (`query_codes=$PROCESSED` reads `{dir}/metadata/codes.parquet`), or — for reproducible pre-sampled code universes kept out of git — a path to a YAML file. The YAML is either a bare list or a mapping with a `codes:` key:
+`query_codes=` accepts an inline list (as above), a metadata root / `codes.parquet` path (`query_codes=$TENSORIZED_COHORT_DIR` reads `{dir}/metadata/codes.parquet`), or — for reproducible pre-sampled code universes kept out of git — a path to a YAML file. The YAML is either a bare list or a mapping with a `codes:` key:
 
 ```yaml
 # sampled_codes.yaml
@@ -211,11 +211,11 @@ EQ_generate_evaluation_tasks codes=/path/to/sampled_codes.yaml …
 
 ```bash
 EQ_train \
-	datamodule.config.tensorized_cohort_dir="$FINAL_DATA_DIR" \
+	datamodule.config.tensorized_cohort_dir="$TENSORIZED_COHORT_DIR" \
 	datamodule.config.task_labels_dir="$TRAINING_TASKS_DIR"
 ```
 
-`tensorized_cohort_dir` and `task_labels_dir` are required Hydra args (no `.env` fallback — see [#235](https://github.com/payalchandak/EveryQuery/issues/235)); `task_labels_dir` is where `EQ_generate_training_tasks` writes. `output_dir` defaults to `${oc.env:OUTPUT_DIR}/${run_id:}/`, so export `OUTPUT_DIR` (via `env.sh`) or override `output_dir=` directly. `EQ_train` reads the long-format labels written by `EQ_generate_training_tasks` directly — the inline collation step that lived in `train.py` was removed in [#76](https://github.com/payalchandak/EveryQuery/pull/76).
+`tensorized_cohort_dir` and `task_labels_dir` are required Hydra args (no `.env` fallback — see [#235](https://github.com/payalchandak/EveryQuery/issues/235)); `task_labels_dir` is where `EQ_generate_training_tasks` writes. `output_dir` defaults to `${oc.env:TRAINING_OUTPUT_DIR}/${run_id:}/`, so export `TRAINING_OUTPUT_DIR` (via `env.sh`) or override `output_dir=` directly. `EQ_train` reads the long-format labels written by `EQ_generate_training_tasks` directly — the inline collation step that lived in `train.py` was removed in [#76](https://github.com/payalchandak/EveryQuery/pull/76).
 
 Seeding: `cfg.seed` (default `140799`) is passed through `lightning.seed_everything` *before* model + datamodule instantiation (fix landed in [#124](https://github.com/payalchandak/EveryQuery/pull/124)), so model weight initialization is byte-reproducible across Python versions and platforms for a given seed.
 
@@ -223,9 +223,9 @@ Seeding: `cfg.seed` (default `140799`) is passed through `lightning.seed_everyth
 
 ```bash
 EQ_predict \
-	model_run_dir="$OUTPUT_DIR/outputs/YYYY-MM-DD/HH-MM-SS" \
-	tasks_dir="$TASK_DIR/eval/held_out" \
-	output_parquet="$OUTPUT_DIR/predictions.parquet" \
+	model_run_dir="$TRAINING_OUTPUT_DIR/outputs/YYYY-MM-DD/HH-MM-SS" \
+	tasks_dir="$EVAL_TASKS_DIR/eval/held_out" \
+	output_parquet="$TRAINING_OUTPUT_DIR/predictions.parquet" \
 	split=held_out
 ```
 
@@ -235,8 +235,8 @@ Reads every `*.parquet` under `tasks_dir` (`TaskQuerySchema`-conformant), runs t
 
 ```bash
 EQ_evaluate \
-	predictions_parquet="$OUTPUT_DIR/predictions.parquet" \
-	metrics_parquet="$OUTPUT_DIR/metrics.parquet"
+	predictions_parquet="$TRAINING_OUTPUT_DIR/predictions.parquet" \
+	metrics_parquet="$TRAINING_OUTPUT_DIR/metrics.parquet"
 ```
 
 Per-`(query, duration_days)` metrics from the predictions parquet — `n_rows`, `n_occurs_labeled`, `n_positive`, `prevalence`, `occurs_auroc` (on non-censored rows), `censor_auroc`. See [`evaluate/README.md`](src/every_query/evaluate/README.md).
@@ -258,21 +258,20 @@ machines (SLURM scripts `source` the same file). `EQ_train` validates only the v
 resolves — `validate_training_config()` in `train.py` checks the resolved cohort/task dirs exist and
 that `WANDB_ENTITY` is set *only* when a wandb logger is enabled.
 
-The genuine env reads that remain in the **train** config: `OUTPUT_DIR` (backs
-`${oc.env:OUTPUT_DIR,null}` in `output_dir`) and `WANDB_ENTITY` (read natively by `wandb`, backs
+The genuine env reads that remain in the **train** config: `TRAINING_OUTPUT_DIR` (backs
+`${oc.env:TRAINING_OUTPUT_DIR,null}` in `output_dir`) and `WANDB_ENTITY` (read natively by `wandb`, backs
 `${oc.env:WANDB_ENTITY,null}`). The **preprocessing** subprocess bridge (`RAW_MEDS_DIR`,
 `MTD_INPUT_DIR`, `MIN_SUBJECTS_PER_CODE`, `MIN_EVENTS_PER_SUBJECT`) and the optional `aces_to_eq`
 pipeline (`ACES_SHARDS_DIR`) also use `${oc.env:...}` — see those submodules.
 
-| Var                  | Used as                                                                            |
-| -------------------- | ---------------------------------------------------------------------------------- |
-| `INTERMEDIATE`       | `data_dir=` for the samplers (MEDS event shards)                                   |
-| `PROCESSED`          | `query_codes=` for the samplers (query-universe metadata)                          |
-| `FINAL_DATA_DIR`     | `datamodule.config.tensorized_cohort_dir=` for `EQ_train`                          |
-| `TRAINING_TASKS_DIR` | `out_dir=` for training tasks; `datamodule.config.task_labels_dir=` for `EQ_train` |
-| `TASK_DIR`           | `out_dir=` for evaluation tasks (`$TASK_DIR/eval/...`)                             |
-| `OUTPUT_DIR`         | `${oc.env:OUTPUT_DIR}` in the train config's `output_dir`                          |
-| `WANDB_ENTITY`       | W&B entity (read natively by `wandb`; only when the logger is enabled)             |
+| Var                     | Used as                                                                                                                                                                   |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `TOKENIZED_EVENTS_DIR`  | `data_dir=` for the samplers (MEDS event shards)                                                                                                                          |
+| `TENSORIZED_COHORT_DIR` | `output_dir=` (preprocess); `datamodule.config.tensorized_cohort_dir=` (`EQ_train`); `query_codes=` for the samplers (its `metadata/codes.parquet` is the query universe) |
+| `TRAINING_TASKS_DIR`    | `out_dir=` for training tasks; `datamodule.config.task_labels_dir=` for `EQ_train`                                                                                        |
+| `EVAL_TASKS_DIR`        | `out_dir=` for evaluation tasks (`$EVAL_TASKS_DIR/eval/...`)                                                                                                              |
+| `TRAINING_OUTPUT_DIR`   | `${oc.env:TRAINING_OUTPUT_DIR}` in the train config's `output_dir`                                                                                                        |
+| `WANDB_ENTITY`          | W&B entity (read natively by `wandb`; only when the logger is enabled)                                                                                                    |
 
 `env.example.sh` is the reference — copy to `env.sh`, edit, and `source` it.
 

--- a/conftest.py
+++ b/conftest.py
@@ -170,7 +170,7 @@ def eq_preprocessed_dataset(simple_static_MEDS: Path, tmp_path_factory: pytest.T
     """Runs ``EQ_process_data do_demo=True`` against ``simple_static_MEDS``.
 
     Returns the tensorized-cohort output dir (``final/``), ready to feed into
-    ``EQ_generate_training_tasks`` and ``EQ_train`` as ``$PROCESSED`` and
+    ``EQ_generate_training_tasks`` and ``EQ_train`` as ``$TENSORIZED_COHORT_DIR`` and
     ``tensorized_cohort_dir`` respectively.
 
     Sibling ``intermediate/`` dir is also produced (needed as ``data_dir`` for

--- a/env.example.sh
+++ b/env.example.sh
@@ -5,7 +5,7 @@
 # (and from your SLURM scripts) so the vars below expand into the Hydra args the CLIs take:
 #     cp env.example.sh env.sh   # edit env.sh for your machine
 #     source env.sh
-#     EQ_generate_training_tasks data_dir=$INTERMEDIATE out_dir=$TRAINING_TASKS_DIR ...
+#     EQ_generate_training_tasks data_dir=$TOKENIZED_EVENTS_DIR out_dir=$TRAINING_TASKS_DIR ...
 #
 # Nothing in the Python package reads these directly (no dotenv) — they are plain shell
 # vars expanded into `key=value` Hydra overrides. `source`-ing one file is all that's
@@ -13,17 +13,18 @@
 
 # --- Paths -------------------------------------------------------------------
 
-# Root of the MEDS cohort. The INTERMEDIATE / PROCESSED dirs below are written here by
-# preprocessing. (Preprocessing reads the *raw* MEDS via `input_dir=` and sets RAW_MEDS_DIR
-# internally for its subprocess — there is no RAW env var.)
+# Root of the raw MEDS cohort, read by preprocessing via `input_dir=`. (Preprocessing also sets
+# RAW_MEDS_DIR internally for its subprocess — there is no user-facing RAW env var.)
 export DATA_DIR="/path/to/MIMIC_MEDS/MEDS_cohort"
 
-export INTERMEDIATE="${DATA_DIR}/intermediate"          # data_dir= for the samplers
-export PROCESSED="${DATA_DIR}/processed"                 # codes_dir= (query universe metadata)
-export FINAL_DATA_DIR="${PROCESSED}"                     # datamodule.config.tensorized_cohort_dir=
-export TASK_DIR="/path/to/eq_stuff/tasks"               # out_dir= for evaluation tasks
-export TRAINING_TASKS_DIR="/path/to/eq_stuff/training_tasks"  # out_dir= for training tasks
-export OUTPUT_DIR="/path/to/EveryQuery/results"         # OUTPUT_DIR for ${oc.env:OUTPUT_DIR} in train config
+# Preprocessing writes both dirs below: TOKENIZED_EVENTS_DIR (intermediate event shards the
+# samplers read) and TENSORIZED_COHORT_DIR (the final tensorized cohort, which also holds the
+# query-code universe at metadata/codes.parquet).
+export TOKENIZED_EVENTS_DIR="${DATA_DIR}/intermediate"        # data_dir= for the samplers
+export TENSORIZED_COHORT_DIR="${DATA_DIR}/processed"          # output_dir= (preprocess); tensorized_cohort_dir= (train); query_codes= (samplers)
+export EVAL_TASKS_DIR="/path/to/eq_stuff/tasks"              # out_dir= for evaluation tasks
+export TRAINING_TASKS_DIR="/path/to/eq_stuff/training_tasks" # out_dir= for training tasks
+export TRAINING_OUTPUT_DIR="/path/to/EveryQuery/results"     # ${oc.env:TRAINING_OUTPUT_DIR} in the train config's output_dir
 
 # Only for the `aces_to_eq` conversion pipeline (predict/external_tasks), read via
 # ${oc.env:ACES_SHARDS_DIR}. Leave unset/commented otherwise.

--- a/src/every_query/evaluate/README.md
+++ b/src/every_query/evaluate/README.md
@@ -22,8 +22,8 @@ predict/ predictions.parquet  ──►  EQ_evaluate  ──►  metrics.parquet
 
 ```bash
 EQ_evaluate \
-	predictions_parquet="$OUTPUT_DIR/predictions.parquet" \
-	metrics_parquet="$OUTPUT_DIR/metrics.parquet"
+	predictions_parquet="$TRAINING_OUTPUT_DIR/predictions.parquet" \
+	metrics_parquet="$TRAINING_OUTPUT_DIR/metrics.parquet"
 ```
 
 One Hydra main. No model instantiation, no trainer loop, no multi-model orchestration.

--- a/src/every_query/generate_tasks/README.md
+++ b/src/every_query/generate_tasks/README.md
@@ -41,7 +41,7 @@ different row distributions:
     — shipped Hydra configs. Path roots (`data_dir`, `out_dir`, and `query_codes` — pass the
     metadata root dir to load the full universe) are **required Hydra args** — no `.env`/env-var
     fallback (see [#235](https://github.com/payalchandak/EveryQuery/issues/235)). Pass them as
-    shell-expanded vars (`data_dir=$INTERMEDIATE out_dir=$TRAINING_TASKS_DIR query_codes=$PROCESSED`);
+    shell-expanded vars (`data_dir=$TOKENIZED_EVENTS_DIR out_dir=$TRAINING_TASKS_DIR query_codes=$TENSORIZED_COHORT_DIR`);
     everything else is a Hydra override.
 
 ## Pipeline position
@@ -54,10 +54,10 @@ EQ_process_data       EQ_generate_training_tasks           EQ_train       EQ_pre
 
 Both endpoints consume:
 
-1. Event shards at `$INTERMEDIATE/data/{split}/*.parquet` (from
+1. Event shards at `$TOKENIZED_EVENTS_DIR/data/{split}/*.parquet` (from
     [`preprocessing/`](../preprocessing/)).
-2. The query-code universe — pass `query_codes=$PROCESSED` (a metadata root dir resolves to
-    `$PROCESSED/metadata/codes.parquet`), or override with an explicit list / file path. Same
+2. The query-code universe — pass `query_codes=$TENSORIZED_COHORT_DIR` (a metadata root dir resolves to
+    `$TENSORIZED_COHORT_DIR/metadata/codes.parquet`), or override with an explicit list / file path. Same
     `query_codes` knob for both training and evaluation.
 
 **Training-task outputs** land at `$TRAINING_TASKS_DIR/{split}/{shard}.parquet` — the final
@@ -66,7 +66,7 @@ All intermediates (the Stage 0 prediction-time map, Stage 3 index) live in the *
 `*_artifacts` root (`{parent}/{name}_artifacts` of `$TRAINING_TASKS_DIR`, no env var of its
 own), so the two trees never nest and cleanup is a single `rm -rf` of the artifacts dir.
 
-**Evaluation-task outputs** land at `$TASK_DIR/eval/{split}/*.parquet`. The separate `eval/`
+**Evaluation-task outputs** land at `$EVAL_TASKS_DIR/eval/{split}/*.parquet`. The separate `eval/`
 subdirectory keeps the two row distributions from colliding in one directory.
 
 ## Running it
@@ -96,8 +96,8 @@ process samples globally and fans Stage-4 labeling out itself. Key knobs (full l
     (distinct `(subject_id, time)` rows, not events) before a prediction time is eligible.
 - `min_duration`, `max_duration`, `duration_distribution` (`uniform | log-uniform`) — the
     Stage 1 duration draw; `duration_days` is a float (no day-rounding).
-- `query_codes` — **required**: `query_codes=$PROCESSED` (a metadata root dir) loads the full
-    vocabulary from `$PROCESSED/metadata/codes.parquet`; or pass an inline Hydra list
+- `query_codes` — **required**: `query_codes=$TENSORIZED_COHORT_DIR` (a metadata root dir) loads the full
+    vocabulary from `$TENSORIZED_COHORT_DIR/metadata/codes.parquet`; or pass an inline Hydra list
     (`query_codes=[HR,TEMP]`) or a YAML/parquet path.
 - `max_workers` — optional cap on the Stage 4 pool; `null` uses cores-on-node, an int caps that
     downward only. Set it when a run OOMs.

--- a/src/every_query/generate_tasks/configs/sample_evaluation_tasks_config.yaml
+++ b/src/every_query/generate_tasks/configs/sample_evaluation_tasks_config.yaml
@@ -10,7 +10,7 @@
 #   python -m every_query.generate_tasks.sample_evaluation_tasks -m input_shard=0,1,2,...
 #
 # Path roots are required Hydra args (no `.env`/env-var fallback — see #235).  Pass them on the
-# CLI, typically as shell-expanded vars (`data_dir=$INTERMEDIATE out_dir=$TASK_DIR`):
+# CLI, typically as shell-expanded vars (`data_dir=$TOKENIZED_EVENTS_DIR out_dir=$EVAL_TASKS_DIR`):
 #   data_dir  (event shards live under `{data_dir}/data/{split}/*.parquet`)
 #   out_dir   (labeled shards land at {out_dir}/eval/{split}/*.parquet — separate `eval/` subdir
 #             so they don't collide with `sample_tasks`'s pretraining outputs at {out_dir}/{split}/*)
@@ -33,7 +33,7 @@ min_context_per_subject: 50
 
 # Codes to evaluate (required).  Either an explicit list (`query_codes=[HR, TEMP]`), a YAML/parquet
 # path, or a metadata root directory to load the full vocabulary from `{dir}/metadata/codes.parquet`
-# (typically `query_codes=$PROCESSED`).
+# (typically `query_codes=$TENSORIZED_COHORT_DIR`).
 query_codes: ???
 
 # Duration-day horizons to evaluate at every prediction time.  Must be a list of

--- a/src/every_query/generate_tasks/configs/sample_training_tasks_config.yaml
+++ b/src/every_query/generate_tasks/configs/sample_training_tasks_config.yaml
@@ -3,7 +3,7 @@
 # later stage issues (#205-#210).
 #
 # Path roots are machine-specific, required Hydra args (no `.env`/env-var fallback — see #235).
-# Pass them on the CLI, typically as shell-expanded vars (`data_dir=$INTERMEDIATE out_dir=$TRAINING_TASKS_DIR`):
+# Pass them on the CLI, typically as shell-expanded vars (`data_dir=$TOKENIZED_EVENTS_DIR out_dir=$TRAINING_TASKS_DIR`):
 #   path_to_data (data_dir)       (event shards under `{path_to_data}/data/{split}/*.parquet`)
 #   training_tasks_dir (out_dir)  (final dataset only: `{split}/{shard}.parquet`)
 # Both are `???` (mandatory); leaving one unset raises OmegaConf's MissingMandatoryValue.  The
@@ -25,7 +25,7 @@ max_workers: null
 
 # Query-code sampling universe (required).  Pass an explicit Hydra list (`query_codes=[HR,TEMP]`),
 # a YAML/parquet path, or a metadata root directory to load the full vocabulary from
-# `{dir}/metadata/codes.parquet` (typically `query_codes=$PROCESSED`).  Resolved by
+# `{dir}/metadata/codes.parquet` (typically `query_codes=$TENSORIZED_COHORT_DIR`).  Resolved by
 # `read_query_codes` outside `QueryDistribution`.
 query_codes: ???
 
@@ -34,7 +34,7 @@ min_duration: 1
 max_duration: 731
 duration_distribution: log-uniform # uniform | log-uniform
 
-# Path roots (see header): required Hydra args, no env fallback.  Pass `data_dir=$INTERMEDIATE out_dir=$TRAINING_TASKS_DIR`.
+# Path roots (see header): required Hydra args, no env fallback.  Pass `data_dir=$TOKENIZED_EVENTS_DIR out_dir=$TRAINING_TASKS_DIR`.
 data_dir: ???
 out_dir: ???
 

--- a/src/every_query/generate_tasks/redesign-spec.md
+++ b/src/every_query/generate_tasks/redesign-spec.md
@@ -86,7 +86,7 @@ These hold throughout the design; later sections reference them rather than rest
 | `seed`                             | top-level seed; all draws derive from it                                                                                                                                                               |
 
 Path roots are **required Hydra args** (machine-specific, no `.env`/env-var fallback — see #235);
-pass them as shell-expanded vars (`data_dir=$INTERMEDIATE out_dir=$TRAINING_TASKS_DIR`). See
+pass them as shell-expanded vars (`data_dir=$TOKENIZED_EVENTS_DIR out_dir=$TRAINING_TASKS_DIR`). See
 `resolve_training_task_paths`:
 
 | key / derived                    | meaning                                                                                 |
@@ -100,7 +100,7 @@ code draw and the duration draw, so Stage 1 is just `query_dist.sample(num_queri
 
 - `query_codes`: already-resolved `list[str]` code universe (one code per query). **Resolution stays
     outside the dataclass** — the caller runs `read_query_codes()` (a metadata root dir →
-    `{dir}/metadata/codes.parquet`, e.g. `query_codes=$PROCESSED`; an explicit Hydra list; or a
+    `{dir}/metadata/codes.parquet`, e.g. `query_codes=$TENSORIZED_COHORT_DIR`; an explicit Hydra list; or a
     YAML/parquet path; see `read_query_codes` in `sample_tasks.py`) and passes the result in, e.g.
     `QueryDistribution.from_config(cfg, query_codes=read_query_codes(...))`. The dataclass does no file I/O.
 - `min_duration`, `max_duration`: duration bounds in days.

--- a/src/every_query/generate_tasks/sample_evaluation_tasks.py
+++ b/src/every_query/generate_tasks/sample_evaluation_tasks.py
@@ -427,7 +427,7 @@ def main(cfg: DictConfig) -> None:
     data_dir = _require_path_arg(cfg.get("data_dir"), "data_dir")
     out_dir = _require_path_arg(cfg.get("out_dir"), "out_dir")
 
-    # Either an explicit list or a directory/path (query_codes=$PROCESSED loads the full universe).
+    # Either an explicit list or a dir/path (query_codes=$TENSORIZED_COHORT_DIR loads the full universe).
     codes = read_query_codes(cfg.get("query_codes"))
 
     # Durations must be whole-day ints — silent truncation (e.g. ``0.5 → 0``) would

--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -487,7 +487,7 @@ def read_query_codes(
     Accepts:
     - an explicit list (from Hydra ``query_codes: [A, B, C]`` or a code-group YAML default),
     - a metadata root directory (``codes.parquet`` is expected at ``{dir}/metadata/codes.parquet``;
-      e.g. ``query_codes=$PROCESSED`` to load the full vocabulary), or
+      e.g. ``query_codes=$TENSORIZED_COHORT_DIR`` to load the full vocabulary), or
     - a direct path to a ``codes.parquet``/YAML file.
 
     The ``.unique().sort()`` makes the returned list deterministic across workers reading
@@ -505,8 +505,8 @@ def read_query_codes(
     if not codes_or_path:
         raise ValueError(
             "query_codes is unset; pass an explicit list (query_codes=[A,B]), a codes.parquet/YAML "
-            "path, or a metadata root directory (query_codes=$PROCESSED) to load the full vocabulary "
-            "from {dir}/metadata/codes.parquet."
+            "path, or a metadata root dir (query_codes=$TENSORIZED_COHORT_DIR) to load the full "
+            "vocabulary from {dir}/metadata/codes.parquet."
         )
     p = Path(str(codes_or_path))
     if p.suffix in {".yaml", ".yml"}:
@@ -634,7 +634,7 @@ def resolve_training_task_paths(cfg: DictConfig) -> tuple[Path, Path, Path]:
     """Resolve the redesigned sampler's three path roots from required Hydra keys.
 
     The two input roots are machine-specific Hydra args (supplied on the CLI, typically as
-    shell-expanded ``data_dir=$INTERMEDIATE out_dir=$TRAINING_TASKS_DIR``).  Both are mandatory; an
+    shell-expanded ``data_dir=$TOKENIZED_EVENTS_DIR out_dir=$TRAINING_TASKS_DIR``).  Both are mandatory; an
     unset or empty value (including ``data_dir=$VAR`` with an unexported ``$VAR``) raises a clear
     ``ValueError`` via :func:`_require_path_arg` — there is no env-var fallback (see issue #235).
 

--- a/src/every_query/predict/external_tasks/configs/aces_to_eq.yaml
+++ b/src/every_query/predict/external_tasks/configs/aces_to_eq.yaml
@@ -11,7 +11,7 @@ queries: ${query_codes}
 # ACES task you're converting (``readmiss_30d`` → 30, ``mortality_1y`` → 365, etc.).
 duration_days: 30.0
 
-eq_tasks_all_dir: ${oc.env:TASK_DIR}/all/held_out
-# ACES_SHARDS_DIR lives outside TASK_DIR/OUTPUT_DIR — export it (e.g. via env.sh) if you use this pipeline.
+eq_tasks_all_dir: ${oc.env:EVAL_TASKS_DIR}/all/held_out
+# ACES_SHARDS_DIR lives outside EVAL_TASKS_DIR/TRAINING_OUTPUT_DIR — export it (e.g. via env.sh) if you use this pipeline.
 aces_shards_dir: ${oc.env:ACES_SHARDS_DIR}/${task_name}/held_out
-output_dir: ${oc.env:TASK_DIR}/eval/aces/${task_name}/held_out
+output_dir: ${oc.env:EVAL_TASKS_DIR}/eval/aces/${task_name}/held_out

--- a/src/every_query/predict/external_tasks/configs/get_per_code_from_composite_config.yaml
+++ b/src/every_query/predict/external_tasks/configs/get_per_code_from_composite_config.yaml
@@ -2,8 +2,8 @@ defaults:
   - _self_
 
 # inputs
-model_run_dir: ${oc.env:OUTPUT_DIR}/outputs/2026-01-03/15-43-49/
-task_df_fp: ${oc.env:TASK_DIR}/eval/aces/readmiss_30d/held_out
+model_run_dir: ${oc.env:TRAINING_OUTPUT_DIR}/outputs/2026-01-03/15-43-49/
+task_df_fp: ${oc.env:EVAL_TASKS_DIR}/eval/aces/readmiss_30d/held_out
 preds_df_fp: ${model_run_dir}/eval/readmiss_30d/readmiss_30d.csv
 
 # where to save eval outputs (outside hydra run dir if you want)

--- a/src/every_query/train/README.md
+++ b/src/every_query/train/README.md
@@ -29,7 +29,7 @@ EQ_process_data       EQ_generate_training_tasks         EQ_train       EQ_predi
 
 `train/` consumes two artifacts from upstream:
 
-1. The tensorized MEDS cohort at `$FINAL_DATA_DIR`, produced by
+1. The tensorized MEDS cohort at `$TENSORIZED_COHORT_DIR`, produced by
     [`preprocessing/`](../preprocessing/).
 2. Long-format task-label parquets, produced by
     [`generate_tasks/`](../generate_tasks/) (no intermediate "collation" step — the
@@ -38,7 +38,7 @@ EQ_process_data       EQ_generate_training_tasks         EQ_train       EQ_predi
     `datamodule.config.task_labels_dir` Hydra arg (typically `=$TRAINING_TASKS_DIR`).
 
 `train/` produces a run directory at
-`$OUTPUT_DIR/outputs/<YYYY-MM-DD>/<HH-MM-SS>/` containing `best_model.ckpt`,
+`$TRAINING_OUTPUT_DIR/outputs/<YYYY-MM-DD>/<HH-MM-SS>/` containing `best_model.ckpt`,
 `config.yaml` (used config), `resolved_config.yaml` (used config with all
 interpolations resolved — consumed by downstream loaders), and a
 `checkpoints/` dir with epoch-indexed checkpoints.

--- a/src/every_query/train/configs/config.yaml
+++ b/src/every_query/train/configs/config.yaml
@@ -1,7 +1,7 @@
 defaults:
   - _self_
 
-output_dir: ${oc.env:OUTPUT_DIR,null}/${run_id:}/
+output_dir: ${oc.env:TRAINING_OUTPUT_DIR,null}/${run_id:}/
 do_overwrite: true
 do_resume: false
 seed: 140799

--- a/src/every_query/train/train.py
+++ b/src/every_query/train/train.py
@@ -229,7 +229,7 @@ def validate_training_config(cfg: DictConfig) -> None:
     """
     ds_cfg = cfg.datamodule.config
     for node, env_var in (
-        ("tensorized_cohort_dir", "FINAL_DATA_DIR"),
+        ("tensorized_cohort_dir", "TENSORIZED_COHORT_DIR"),
         ("task_labels_dir", "TRAINING_TASKS_DIR"),
     ):
         value = ds_cfg.get(node)
@@ -243,14 +243,15 @@ def validate_training_config(cfg: DictConfig) -> None:
                 f"datamodule.config.{node} ({value!r}, from ${env_var}) is not an existing directory."
             )
 
-    # An unset $OUTPUT_DIR resolves the shipped ``${oc.env:OUTPUT_DIR,null}/${run_id:}/``
+    # An unset $TRAINING_OUTPUT_DIR resolves the shipped ``${oc.env:TRAINING_OUTPUT_DIR,null}/${run_id:}/``
     # interpolation to the *truthy* string ``'None/<run_id>/'`` (the null default is
     # stringified into the surrounding path), so a bare falsy check is not enough — reject a
     # leading ``None/`` / ``null/`` segment too, lest the run write to a literal ``None/...`` dir.
     output_dir = cfg.get("output_dir")
     if not output_dir or str(output_dir).startswith(("None/", "null/")):
         raise ValueError(
-            "output_dir is unset (is $OUTPUT_DIR exported?). Pass output_dir=/path or export $OUTPUT_DIR."
+            "output_dir is unset (is $TRAINING_OUTPUT_DIR exported?). "
+            "Pass output_dir=/path or export $TRAINING_OUTPUT_DIR."
         )
 
     if _is_wandb_logger(cfg.trainer.get("logger")) and not cfg.trainer.logger.get("entity"):

--- a/tests/sampler/test_orchestration.py
+++ b/tests/sampler/test_orchestration.py
@@ -63,7 +63,7 @@ def _union_final_output(tasks_dir: Path, split: str = "train") -> pl.DataFrame:
 def _two_shard_cohort(tmp_path: Path, query_codes: list[str], *, split: str = "train") -> Path:
     """Write a two-shard MEDS cohort (subjects do NOT span shards — invariant 4) and return its root.
 
-    Mirrors ``_write_fake_cohort``'s ``$INTERMEDIATE`` layout but splits subjects across two shard
+    Mirrors ``_write_fake_cohort``'s ``$TOKENIZED_EVENTS_DIR`` layout but splits subjects across two shard
     parquets so Stage 4's ProcessPoolExecutor actually fans out (a single shard collapses N workers
     to 1).  Shard "0" holds subjects 1 & 2, shard "1" holds subject 3; each subject gets enough
     distinct prediction times to clear ``min_prediction_times_per_subject`` and cycles through

--- a/tests/test_env_validation.py
+++ b/tests/test_env_validation.py
@@ -103,7 +103,7 @@ def test_missing_output_dir_raises(existing_dirs):
 
 
 def test_unset_output_dir_env_resolves_to_none_string_raises(existing_dirs, tmp_path):
-    """An unset $OUTPUT_DIR resolves the config interpolation to a truthy 'None/<run_id>/'.
+    """An unset $TRAINING_OUTPUT_DIR resolves the config interpolation to a truthy 'None/<run_id>/'.
 
     Regression guard for the #234 review gap: the gate must reject this, not let a run write
     to a directory literally named ``None/...``.


### PR DESCRIPTION
## Why

The shell vars in `env.example.sh` are just expanded into Hydra `key=$VAR` overrides on the CLI — nothing in the Python package reads them directly after the `.env`/`load_dotenv` removal in #235. After that change several names no longer matched their role, and **`PROCESSED` and `FINAL_DATA_DIR` were literally the same directory**: preprocessing writes the tensorized cohort to `output_dir`, and that cohort's `metadata/codes.parquet` *is* the query-code universe the samplers read. Two names for one dir.

## What

| Old | New |
|---|---|
| `INTERMEDIATE` | `TOKENIZED_EVENTS_DIR` |
| `PROCESSED` + `FINAL_DATA_DIR` | `TENSORIZED_COHORT_DIR` (merged) |
| `TASK_DIR` | `EVAL_TASKS_DIR` |
| `OUTPUT_DIR` | `TRAINING_OUTPUT_DIR` |
| `DATA_DIR`, `TRAINING_TASKS_DIR` | unchanged |

All names normalized to a `_DIR` suffix.

Most occurrences are docs/comments/docstrings, but a few are genuine `${oc.env:...}` reads that were updated in lockstep:
- `train/configs/config.yaml` — `output_dir: ${oc.env:TRAINING_OUTPUT_DIR,null}/...`
- `predict/external_tasks/configs/aces_to_eq.yaml` + `get_per_code_from_composite_config.yaml` — `${oc.env:EVAL_TASKS_DIR}` / `${oc.env:TRAINING_OUTPUT_DIR}`
- `train.py` — the validation error-message hint map + messages

The `env.example.sh` duplicate line and the README var-table duplicate row were hand-collapsed into a single `TENSORIZED_COHORT_DIR` entry.

Internal subprocess-bridge vars (`RAW_MEDS_DIR`, `MTD_INPUT_DIR`, `MIN_*`) are set by `preprocessing/__main__.py`, never by the user, so they're left untouched.

## Tests

`uv run pytest tests/test_env_validation.py` — 9 passed. No tests set these as env vars (they pass Hydra overrides directly per #235), so nothing else is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)