### PR TITLE
Fix build_index skipping index rebuild on num_queries=0 rerun

### DIFF
--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -1141,6 +1141,13 @@ def build_index(
             f"len(queries) * num_contexts_per_query ({n_queries} * {num_contexts_per_query} = {expected})"
         )
 
+    # Wipe ``_index/`` before the empty-input early return (not after) so a ``num_queries=0``
+    # rerun following a real run leaves no stale partitions behind (see #255 finding #1); the
+    # early return below must not short-circuit past this cleanup.
+    index_dir = training_task_artifacts_dir / split / INDEX_DIRNAME
+    if index_dir.exists():
+        shutil.rmtree(index_dir)
+
     if n_queries == 0 or contexts.height == 0:
         return 0
 
@@ -1156,10 +1163,6 @@ def build_index(
     )
 
     combined = contexts.with_columns(query_col, duration_col)
-
-    index_dir = training_task_artifacts_dir / split / INDEX_DIRNAME
-    if index_dir.exists():
-        shutil.rmtree(index_dir)
 
     output_cols = [
         TaskQuerySchema.subject_id_name,

--- a/tests/sampler/test_stage3_build_index.py
+++ b/tests/sampler/test_stage3_build_index.py
@@ -154,6 +154,22 @@ class TestStage3:
         build_index([], contexts, artifacts_dir, "train", num_contexts_per_query=3)
         assert not index_path(artifacts_dir, "train", "0").exists()
 
+    def test_num_queries_zero_rerun_wipes_stale_index(self, stage0_env):
+        """A ``num_queries=0`` rerun after a real run must not leave stale ``_index/`` partitions (#255 #1)"""
+        _, artifacts_dir = stage0_env
+        queries = [QuerySpec("ICD//A", 5.0)]
+        contexts = self._make_contexts([1], ["0"], [3])
+        build_index(queries, contexts, artifacts_dir, "train", num_contexts_per_query=1)
+        assert index_path(artifacts_dir, "train", "0").exists()
+
+        empty_contexts = pl.DataFrame(
+            schema={"subject_id": pl.Int64, "shard": pl.Utf8, "prediction_time_index": pl.Int64}
+        )
+        build_index([], empty_contexts, artifacts_dir, "train", num_contexts_per_query=1)
+
+        assert not (artifacts_dir / "train" / "_index").exists()
+        assert not index_path(artifacts_dir, "train", "0").exists()
+
     def test_height_mismatch_raises(self, stage0_env):
         _, artifacts_dir = stage0_env
         queries = [QuerySpec("ICD//A", 5.0), QuerySpec("ICD//B", 10.0)]


### PR DESCRIPTION
## Summary
- `build_index` ran the `_index/` `rmtree` *after* the `n_queries == 0` early return, so a `num_queries=0` rerun following a real run left stale index partitions on disk instead of wiping them.
- Moves the `rmtree` to run before that early return (but still after the `contexts.height != expected` validation, so a bad-shape call raises before touching the filesystem).
- Adds a regression test that builds a real index, then reruns with `num_queries=0` and asserts `_index/` is fully wiped.

Fixes finding #1 from #255.

## Test plan
- [x] `uv run pytest tests/sampler/test_stage3_build_index.py` — 14 passed (incl. new regression test)
- [x] `uv run pytest tests/sampler tests/test_sampler_dataset_integration.py` — 115 passed
- [x] `uv run ruff check` / `uv run ruff format --check` — clean
- [ ] Manual: run the pipeline once with queries, then rerun with `num_queries=0`; confirm the run completes with no `_validate_row_count` mismatch and `_index/` ends up empty

🤖 Generated with [Claude Code](https://claude.com/claude-code)