### PR TITLE
Document eligibility/ranking/RNG invariants in sample_tasks.py (#255 #2-#4)

### DIFF
--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -300,11 +300,11 @@ def sample_patient_contexts(
         )
 
     # Step A — subject indices (consumed first), with replacement.  One row-gather over the table
-    # (same indices for every column) instead of three per-column gathers.
-    # Do NOT replace `rng.integers` with `prediction_time_counts.sample(..., with_replacement=True)`:
-    # `pl.DataFrame.sample` takes only an int seed, not the caller-owned numpy Generator, so it would
-    # fork RNG state away from Step B and break the single-generator fixed-order determinism contract
-    # (spec invariant 5).
+    # (same indices for every column) instead of three per-column gathers.  Drawn via `rng.integers`
+    # rather than `prediction_time_counts.sample(..., with_replacement=True)` — both do the same
+    # index-then-gather, but `pl.DataFrame.sample` takes only an int seed, not the caller-owned numpy
+    # Generator.  Using it would fork RNG state away from Step B, breaking the single-generator
+    # fixed-order determinism contract (spec invariant 5).
     subject_idx = rng.integers(0, patient_universe_size, size=n)
     sampled = prediction_time_counts[subject_idx]
     subject_id = sampled["subject_id"]

--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -300,11 +300,11 @@ def sample_patient_contexts(
         )
 
     # Step A — subject indices (consumed first), with replacement.  One row-gather over the table
-    # (same indices for every column) instead of three per-column gathers.  Drawn via `rng.integers`
-    # rather than `prediction_time_counts.sample(..., with_replacement=True)` — both do the same
-    # index-then-gather, but `pl.DataFrame.sample` takes only an int seed, not the caller-owned numpy
-    # Generator.  Using it would fork RNG state away from Step B, breaking the single-generator
-    # fixed-order determinism contract (spec invariant 5).
+    # (same indices for every column) instead of three per-column gathers.
+    # Do NOT replace `rng.integers` with `prediction_time_counts.sample(..., with_replacement=True)`:
+    # `pl.DataFrame.sample` takes only an int seed, not the caller-owned numpy Generator, so it would
+    # fork RNG state away from Step B and break the single-generator fixed-order determinism contract
+    # (spec invariant 5).
     subject_idx = rng.integers(0, patient_universe_size, size=n)
     sampled = prediction_time_counts[subject_idx]
     subject_id = sampled["subject_id"]
@@ -1025,6 +1025,10 @@ def build_prediction_times(
     # Gapless zero-based index over each subject's ascending distinct times.  No within-subject ties
     # (step above deduped), so int_range is identical to a dense rank and cheaper (invariant 2).
     # prediction_times columns: (subject_id, time, shard, prediction_time_index).
+    # This depends on `_read_prediction_time_shard` having already dropped null-`time` rows before
+    # `distinct` reaches this sort/rank — nulls sort first, so an unfiltered null would claim
+    # `prediction_time_index = 0` and inflate `n_prediction_times`. Do not reorder dedup/rank ahead of
+    # that filter.
     prediction_times = distinct.sort(["subject_id", "time"]).with_columns(
         pl.int_range(pl.len()).over("subject_id").alias("prediction_time_index")
     )
@@ -1034,6 +1038,10 @@ def build_prediction_times(
         pl.col("shard").first(),
         pl.len().alias("n_prediction_times"),
     )
+    # Strict `>` (not `>=`) is load-bearing: Stage 2 draws `rng.integers(low=min, high=n)`, which is a
+    # valid (non-empty) range only when `n > min`. `>=` would let a subject with
+    # `n_prediction_times == min_prediction_times_per_subject` reach Stage 2 and raise on an illegal
+    # empty draw range.
     eligible = counts.filter(pl.col("n_prediction_times") > min_prediction_times_per_subject).sort(
         "subject_id"
     )


### PR DESCRIPTION
## Summary
Comment-only follow-up to #255, addressing findings #2, #3, #4. No logic changes.

- **#2** — comment explaining why the `n_prediction_times > min` filter must be strict `>`, not `>=` (Stage 2's `rng.integers(low=min, high=n)` draw would be an illegal empty range at `n == min`).
- **#3** — comment at the ranking step (`build_prediction_times`) noting it depends on `_read_prediction_time_shard` already having dropped null-`time` rows, since nulls sort first and would otherwise claim `prediction_time_index = 0`.
- **#4** — reworked the existing Step A comment in `sample_patient_contexts` to lead with an explicit "do NOT replace with `pl.sample`" warning instead of burying it mid-paragraph.

Plan: `docs/plans/2026-07-02-sample-tasks-255-p2-comments.md`

## Test plan
- [x] `uv run pytest tests/sampler/` — 113 passed
- [x] `uv run ruff check src/every_query/generate_tasks/sample_tasks.py` — pass
- [x] `uv run ruff format --check src/every_query/generate_tasks/sample_tasks.py` — pass
- [x] `git diff` confirmed comment-only (no code lines changed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)