### PR TITLE
Make QueryDistribution.sample's uniform branch explicit

### DIFF
--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -168,8 +168,15 @@ class QueryDistribution:
         ``np.random.default_rng(derive_seed(seed, "queries"))``.  Draws happen in a fixed order (codes
         then durations) so output is deterministic for a fixed ``rng``.
 
+        The distribution branch below is exhaustive over ``_VALID_DISTRIBUTIONS``; ``__post_init__``
+        is what actually enforces that invariant on construction, so the trailing ``else`` here should
+        be unreachable and only guards against that invariant drifting out of sync with this method.
+
         Raises:
             ValueError: If ``num_queries < 0``.
+            AssertionError: If ``duration_distribution`` is outside ``_VALID_DISTRIBUTIONS`` — this
+                indicates ``_VALID_DISTRIBUTIONS`` and this method have drifted out of sync, since
+                ``__post_init__`` should already have rejected any other value.
         """
         if num_queries < 0:
             raise ValueError(f"num_queries must be >= 0 (got {num_queries})")
@@ -181,8 +188,14 @@ class QueryDistribution:
             durations = np.exp(
                 rng.uniform(np.log(self.min_duration), np.log(self.max_duration), size=num_queries)
             )
-        else:  # "uniform"
+        elif self.duration_distribution == "uniform":
             durations = rng.uniform(self.min_duration, self.max_duration, size=num_queries)
+        else:
+            raise AssertionError(
+                f"duration_distribution={self.duration_distribution!r} is outside "
+                f"_VALID_DISTRIBUTIONS={self._VALID_DISTRIBUTIONS}; __post_init__ should have "
+                "rejected this already"
+            )
 
         codes = np.array(self.query_codes, dtype=object)
         selected_codes = codes[code_indices]

--- a/tests/sampler/test_stage1_query_distribution.py
+++ b/tests/sampler/test_stage1_query_distribution.py
@@ -92,6 +92,17 @@ class TestQueryDistribution:
         with pytest.raises(ValueError, match="duration_distribution"):
             QueryDistribution(synthetic_query_codes, 1.0, 365.0, "normal")
 
+    def test_sample_raises_if_distribution_drifts_from_valid_set(self, synthetic_query_codes):
+        """``sample`` must not silently default to ``uniform`` if its branch drifts out of sync
+
+        with ``_VALID_DISTRIBUTIONS``. Simulates that drift via the frozen-dataclass escape hatch,
+        since ``__post_init__`` already blocks constructing an invalid value normally.
+        """
+        dist = QueryDistribution(synthetic_query_codes, 1.0, 365.0, "uniform")
+        object.__setattr__(dist, "duration_distribution", "bogus")
+        with pytest.raises(AssertionError, match="duration_distribution"):
+            dist.sample(1, self._rng(0))
+
     # -- Distribution-shape gap tests (plain pytest, fixed seed, generous bounds) --------------
 
     def test_log_uniform_skews_shorter_than_uniform(self, synthetic_query_codes):


### PR DESCRIPTION
## Summary
- Fixes finding #7 from #255: `QueryDistribution.sample`'s duration draw fell through a bare `else` to treat any non-`log-uniform` value as `uniform`, relying entirely on `__post_init__` having already validated `duration_distribution`.
- Makes the branch exhaustive against `_VALID_DISTRIBUTIONS`, raising `AssertionError` if it ever drifts out of sync with `__post_init__`'s validation, instead of silently defaulting.
- Note: `__post_init__` already rejects any missing/blank/invalid `duration_distribution` at construction time (confirmed present at the pinned review commit and covered by an existing test), so this closes a defense-in-depth gap rather than a live silent-default bug.

## Test plan
- [x] `uv run pytest tests/sampler/test_stage1_query_distribution.py -v` — 17/17 pass, including new `test_sample_raises_if_distribution_drifts_from_valid_set`
- [x] `uv run pytest --doctest-modules src/every_query/generate_tasks/sample_tasks.py` — 10/10 pass
- [x] `uv run ruff check` — clean
- [x] `uv run pytest tests/sampler/` — full suite passes, no regressions