### PR TITLE
Fail loudly on empty queries/contexts in build_index

### DIFF
--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -1126,11 +1126,13 @@ def build_index(
         num_contexts_per_query: Number of patient contexts per query (the ``M`` multiplier).
 
     Returns:
-        ``n_shards`` — the number of index partitions written (0 when there are no queries/contexts).
+        ``n_shards`` — the number of index partitions written.
 
     Raises:
         ValueError: If ``contexts.height != len(queries) * num_contexts_per_query``, or if
             any context fails to resolve a prediction time (null after join).
+        AssertionError: If ``queries`` or ``contexts`` is empty — there is no supported empty-budget
+            path through this pipeline.
     """
     n_queries = len(queries)
     expected = n_queries * num_contexts_per_query
@@ -1141,8 +1143,8 @@ def build_index(
             f"len(queries) * num_contexts_per_query ({n_queries} * {num_contexts_per_query} = {expected})"
         )
 
-    if n_queries == 0 or contexts.height == 0:
-        return 0
+    assert n_queries > 0, "queries must be non-empty"
+    assert contexts.height > 0, "contexts must be non-empty"
 
     query_col = pl.Series(
         TaskQuerySchema.query_name,

--- a/tests/sampler/test_orchestration.py
+++ b/tests/sampler/test_orchestration.py
@@ -252,20 +252,6 @@ class TestMainOrchestration:
         st.run(cfg2_force)
         assert relabeled.equals(_union_final_output(tasks_dir))
 
-    def test_num_queries_zero_writes_empty_dataset(
-        self, monkeypatch, tmp_path, synthetic_events, synthetic_query_codes
-    ):
-        """Bug #3: ``num_queries=0`` (empty budget) must report 0 rows, not crash on an empty glob.
-
-        With no queries, Stage 3 writes no index and Stage 4 writes no output; the final/summary scans must
-        side-step polars' "no files found" error and the row-count guard must pass (0 == 0).
-        """
-        tasks_dir = self._run_env(monkeypatch, tmp_path, synthetic_events, synthetic_query_codes)
-
-        st.run(self._cfg(synthetic_query_codes, num_queries=0))  # must not raise
-
-        assert sorted((tasks_dir / "train").glob("*.parquet")) == []
-
 
 class TestCrossProcessDeterminism:
     """The parallel Stage 4 fan-out must produce the same labeled dataset as the serial path.

--- a/tests/sampler/test_stage3_build_index.py
+++ b/tests/sampler/test_stage3_build_index.py
@@ -146,13 +146,14 @@ class TestStage3:
         with pytest.raises(ValueError, match="dtype mismatch"):
             build_index(queries, contexts, artifacts_dir, "train", num_contexts_per_query=1)
 
-    def test_empty_queries(self, stage0_env):
+    def test_empty_queries_raises(self, stage0_env):
+        """There is no supported empty-budget path: an empty ``queries``/``contexts`` must fail loudly."""
         _, artifacts_dir = stage0_env
         contexts = pl.DataFrame(
             schema={"subject_id": pl.Int64, "shard": pl.Utf8, "prediction_time_index": pl.Int64}
         )
-        build_index([], contexts, artifacts_dir, "train", num_contexts_per_query=3)
-        assert not index_path(artifacts_dir, "train", "0").exists()
+        with pytest.raises(AssertionError):
+            build_index([], contexts, artifacts_dir, "train", num_contexts_per_query=3)
 
     def test_height_mismatch_raises(self, stage0_env):
         _, artifacts_dir = stage0_env


### PR DESCRIPTION
## Summary

Fixes item #1 from #255.

- `build_index`'s `if n_queries == 0 or contexts.height == 0: return 0` fired *before* the `_index/` `rmtree`, so a `num_queries=0` rerun after a prior real run left the previous run's stale index partitions in place.
- Since there's no supported empty-budget path through the pipeline (Stage 3's "0 rows written" case was never actually exercised outside this edge case), the early return is replaced with two asserts: `assert n_queries > 0` and `assert contexts.height > 0`. The function now fails fast instead of silently no-op'ing.
- Removed `tests/sampler/test_orchestration.py::test_num_queries_zero_writes_empty_dataset`, the regression test asserting `run()` with `num_queries=0` must succeed against an empty dataset — there's no precedent for using the pipeline this way.
- Updated `tests/sampler/test_stage3_build_index.py::test_empty_queries` (renamed to `test_empty_queries_raises`) to assert `build_index([], ...)` now raises `AssertionError` instead of silently succeeding.

## Test plan

- [x] `uv run pytest tests/sampler -q` — 112 passed
- [x] `uv run ruff check` on changed files — all checks passed


---
_Generated by [Claude Code](https://claude.ai/code/session_01VJjSwcqJsjgy2KLMdZiiQu)_