### PR TITLE
Truncate observation at MEDS_DEATH in evaluate_index_df (fixes #257)

### DIFF
--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -41,7 +41,7 @@ from pathlib import Path
 import hydra
 import numpy as np
 import polars as pl
-from meds import DataSchema
+from meds import DataSchema, death_code
 from omegaconf import DictConfig, ListConfig
 
 from every_query.data.schema import TaskQuerySchema, empty_task_query_df
@@ -372,6 +372,12 @@ def evaluate_index_df(
     excludes exact-key matches from ``strategy="forward"``'s default ``>=`` search, leaving a
     strict ``>``.
 
+    Death is terminal (#257): events timestamped strictly after a subject's ``MEDS_DEATH`` row
+    (the earliest one, if duplicated) are dropped before labeling, so they neither extend
+    ``max_time`` nor satisfy an occurrence match.  The death row itself is kept, so
+    ``MEDS_DEATH`` remains answerable as a query code; subjects with no death row are
+    unaffected.  This is a no-op when ``MEDS_DEATH`` is already the last recorded event.
+
     Args:
         index_df: Output of ``build_index_df``. Must have columns ``subject_id``, ``prediction_time``,
             ``query``, ``duration_days``. If ``task_id`` is present it is ignored and dropped from
@@ -407,6 +413,17 @@ def evaluate_index_df(
     # dtypes, guaranteed to pass ``TaskQuerySchema.align()`` downstream.
     if index_df.height == 0:
         return empty_task_query_df().select(out_cols)
+
+    # Truncate each subject's record at death (see docstring, #257).  Must happen before *both*
+    # consumers of events_df below — max_time_per_subject and the join_asof right side — or a
+    # post-death event could still asof-match into an occurrence.  ``<=`` keeps the death row.
+    death_time = (
+        pl.col(DataSchema.time_name)
+        .filter(pl.col(DataSchema.code_name) == death_code)
+        .min()
+        .over(DataSchema.subject_id_name)
+    )
+    events_df = events_df.filter(death_time.is_null() | (pl.col(DataSchema.time_name) <= death_time))
 
     max_time_per_subject = events_df.group_by(DataSchema.subject_id_name).agg(
         pl.col(DataSchema.time_name).max().alias("max_time")

--- a/tests/sampler/test_stage4_labeling.py
+++ b/tests/sampler/test_stage4_labeling.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 import polars as pl
 import pytest
+from meds import death_code
 
 from every_query.generate_tasks import sample_tasks as st
 from every_query.generate_tasks.sample_tasks import (
@@ -227,6 +228,108 @@ class TestEvaluateIndexDfEdgeCases:
         result = evaluate_index_df(index_df, events)
         assert result.height == 1
         assert result["boolean_value"].to_list() == [True]
+
+
+class TestDeathTruncation:
+    """Death is terminal (#257): events after a subject's ``MEDS_DEATH`` row are unobservable.
+
+    Truncation happens inside ``evaluate_index_df`` on ``events_df`` itself, so it affects both
+    ``max_time`` (censoring boundary) and occurrence matching, while the death row itself stays
+    queryable.
+    """
+
+    BASE = datetime(2020, 1, 1)
+
+    def _label(self, events: pl.DataFrame, query: str, duration_days: float) -> bool | None:
+        events = events.with_columns(pl.col("time").cast(pl.Datetime("us"))).sort(["subject_id", "time"])
+        index_df = pl.DataFrame(
+            {
+                "subject_id": [1],
+                "prediction_time": [self.BASE],
+                "query": [query],
+                "duration_days": [duration_days],
+            }
+        ).with_columns(pl.col("prediction_time").cast(pl.Datetime("us")))
+        result = evaluate_index_df(index_df, events)
+        assert result.height == 1
+        return result["boolean_value"].to_list()[0]
+
+    def test_death_as_last_event_is_a_noop(self):
+        """Regression guard: ``MEDS_DEATH`` already last → identical to pre-#257 behavior.
+
+        ``max_time = death (day 10)``; the 30d window runs past it with no matching event → null.
+        """
+        events = pl.DataFrame(
+            {
+                "subject_id": [1, 1],
+                "time": [self.BASE + timedelta(days=3), self.BASE + timedelta(days=10)],
+                "code": ["B", death_code],
+            }
+        )
+        assert self._label(events, query="A", duration_days=30.0) is None
+
+    def test_event_after_death_neither_matches_nor_extends_max_time(self):
+        """The drift case: a post-death event (day 20) must be invisible.
+
+        - query "A" (the post-death code, in the 30d window): must not match → and because
+          ``max_time`` is now the death time (day 10) < window end (day 30), the label is
+          null (censored), not True and not False.
+        - query "B" with a 5d window fully observed before death: still False (truncation
+          doesn't disturb pre-death labeling).
+        """
+        events = pl.DataFrame(
+            {
+                "subject_id": [1, 1, 1],
+                "time": [
+                    self.BASE + timedelta(days=3),
+                    self.BASE + timedelta(days=10),
+                    self.BASE + timedelta(days=20),  # post-death drift row
+                ],
+                "code": ["C", death_code, "A"],
+            }
+        )
+        assert self._label(events, query="A", duration_days=30.0) is None
+        assert self._label(events, query="B", duration_days=5.0) is False
+
+    def test_death_code_itself_is_still_queryable(self):
+        """A query on ``MEDS_DEATH`` occurring in-window resolves True: the death row is kept (``<=``, not
+        ``<``) and occurrence takes priority over censoring."""
+        events = pl.DataFrame(
+            {
+                "subject_id": [1, 1],
+                "time": [self.BASE + timedelta(days=3), self.BASE + timedelta(days=10)],
+                "code": ["B", death_code],
+            }
+        )
+        assert self._label(events, query=death_code, duration_days=30.0) is True
+
+    def test_no_death_row_is_unaffected(self):
+        """No ``MEDS_DEATH`` for the subject → truncation is a no-op; day-100 event keeps the 7d window fully
+        observed → False."""
+        events = pl.DataFrame(
+            {
+                "subject_id": [1],
+                "time": [self.BASE + timedelta(days=100)],
+                "code": ["B"],
+            }
+        )
+        assert self._label(events, query="A", duration_days=7.0) is False
+
+    def test_duplicate_death_rows_use_earliest(self):
+        """Two ``MEDS_DEATH`` rows (data-quality edge) truncate at the *earlier* one: the "A" event between
+        the two death times must not match → censored null."""
+        events = pl.DataFrame(
+            {
+                "subject_id": [1, 1, 1],
+                "time": [
+                    self.BASE + timedelta(days=10),
+                    self.BASE + timedelta(days=15),  # between the two death rows → dropped
+                    self.BASE + timedelta(days=20),
+                ],
+                "code": [death_code, "A", death_code],
+            }
+        )
+        assert self._label(events, query="A", duration_days=30.0) is None
 
 
 class TestBooleanValueTruthTable:


### PR DESCRIPTION
Implements the fix proposed on #257: death is a terminal event, so nothing timestamped after a subject's `MEDS_DEATH` row is observable — for any code, not just for the `max_time` censoring boundary.

## What changed

- `evaluate_index_df` now drops events strictly after each subject's (earliest) `MEDS_DEATH` row **before** both consumers of `events_df` — the `max_time_per_subject` aggregation and the `join_asof` right side. Capping only `max_time` would have left a gap: a post-death event could still asof-match into an occurrence and yield a spurious `True`.
- Implemented as a single window-expression filter (`min().over(subject_id)`) rather than the join+drop in the issue — same semantics, no temp column.
- The death row itself is kept (`<=`, not `<`), so `MEDS_DEATH` stays valid as a query code (occurrence takes priority over censoring, unchanged), and every subject keeps ≥1 event so the unknown-subject `ValueError` guard can't misfire.
- Duplicate `MEDS_DEATH` rows resolve to the earliest (conservative).
- Docstring updated to state the truncation rule alongside the three-valued semantics.

## Behavior change

No-op when `MEDS_DEATH` is absent or already the subject's last event (the common case). Only the drift case changes: a subject with events after their death row now gets `max_time = death_time`, and those later events can't satisfy any query.

## Tests

New `TestDeathTruncation` in `tests/sampler/test_stage4_labeling.py` covering the four cases from the issue plus duplicate death rows. All 29 stage-4 tests pass; full suite passes except the pre-existing `test_train_hydra_dirs.py::test_sweep_creates_one_subdir_per_param_with_paths_excluded` failure introduced on main by df90e55 (sweep subdir renamed to `hydra.job.num`), unrelated to this change.

## Known follow-up (separate issue)

Stage 0 prediction times are **not** truncated: `_read_prediction_time_shard` still counts post-death timestamps as valid prediction times, so a drift subject's sampled contexts at/after death now label `null` for every query. Filed as #265 because fixing it changes `n_prediction_times` eligibility and the `_prediction_times_meta.json` cache doesn't encode this rule (stale-cache hazard).

Fixes #257

🤖 Generated with [Claude Code](https://claude.com/claude-code)