### PR TITLE
Truncate Stage 0 prediction times at MEDS_DEATH (fixes #265)

### DIFF
--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -352,6 +352,23 @@ def sample_patient_contexts(
 # ---------------------------------------------------------------------------
 
 
+def _truncate_at_death(events_df: pl.DataFrame) -> pl.DataFrame:
+    """Drop rows strictly after each subject's earliest ``MEDS_DEATH`` row (#257/#265).
+
+    ``<=`` keeps the death row itself, so ``MEDS_DEATH`` remains answerable as a query code and the
+    death timestamp remains a valid prediction time.  Subjects with no death row are unaffected.
+    Shared by Stage 4 labeling (:func:`evaluate_index_df`) and Stage 0
+    (:func:`_read_prediction_time_shard`) so the two stages can't drift on the death rule.
+    """
+    death_time = (
+        pl.col(DataSchema.time_name)
+        .filter(pl.col(DataSchema.code_name) == death_code)
+        .min()
+        .over(DataSchema.subject_id_name)
+    )
+    return events_df.filter(death_time.is_null() | (pl.col(DataSchema.time_name) <= death_time))
+
+
 def evaluate_index_df(
     index_df: pl.DataFrame,
     events_df: pl.DataFrame,
@@ -416,14 +433,8 @@ def evaluate_index_df(
 
     # Truncate each subject's record at death (see docstring, #257).  Must happen before *both*
     # consumers of events_df below — max_time_per_subject and the join_asof right side — or a
-    # post-death event could still asof-match into an occurrence.  ``<=`` keeps the death row.
-    death_time = (
-        pl.col(DataSchema.time_name)
-        .filter(pl.col(DataSchema.code_name) == death_code)
-        .min()
-        .over(DataSchema.subject_id_name)
-    )
-    events_df = events_df.filter(death_time.is_null() | (pl.col(DataSchema.time_name) <= death_time))
+    # post-death event could still asof-match into an occurrence.
+    events_df = _truncate_at_death(events_df)
 
     max_time_per_subject = events_df.group_by(DataSchema.subject_id_name).agg(
         pl.col(DataSchema.time_name).max().alias("max_time")
@@ -956,21 +967,26 @@ def label_one_shard(
 def _read_prediction_time_shard(file_path: str | Path, shard: str) -> pl.DataFrame:
     """Read one shard's distinct ``(subject_id, time)`` rows, tagged with ``shard``.
 
-    Reads only ``subject_id``/``time`` (Stage 0 never needs event payloads).  Null-``time`` rows (e.g.
-    MEDS static measurements like demographics) are dropped: they are not valid prediction times for
-    the downstream strict-after asof rule (``evaluate_index_df``'s
-    ``join_asof(..., allow_exact_matches=False)``), and — because ``sort(["subject_id", "time"])``
-    places nulls first — an unfiltered null would otherwise claim ``prediction_time_index = 0`` and
-    inflate ``n_prediction_times`` past the eligibility boundary.  ``time`` is cast to
-    ``pl.Datetime("us")`` for the same reason as :func:`_read_event_shard`: it must share a dtype
-    with the events frame's ``time`` column for ``join_asof`` to match against.  Dedups to distinct
-    ``(subject_id, time)`` so the per-subject row count is a count of *prediction times*, not
-    events.
+    Reads ``subject_id``/``time`` plus ``code`` — the latter solely so :func:`_truncate_at_death`
+    can drop post-death rows (#265): a timestamp strictly after a subject's ``MEDS_DEATH`` row is
+    unobservable under Stage 4's death rule (every window from it is censored), so it must not be a
+    prediction time nor count toward eligibility.  Truncation runs before the ``code`` column is
+    dropped and before the dedup.  Null-``time`` rows (e.g. MEDS static measurements like
+    demographics) are dropped: they are not valid prediction times for the downstream strict-after
+    asof rule (``evaluate_index_df``'s ``join_asof(..., allow_exact_matches=False)``), and —
+    because ``sort(["subject_id", "time"])`` places nulls first — an unfiltered null would
+    otherwise claim ``prediction_time_index = 0`` and inflate ``n_prediction_times`` past the
+    eligibility boundary.  ``time`` is cast to ``pl.Datetime("us")`` for the same reason as
+    :func:`_read_event_shard`: it must share a dtype with the events frame's ``time`` column for
+    ``join_asof`` to match against.  Dedups to distinct ``(subject_id, time)`` so the per-subject
+    row count is a count of *prediction times*, not events.
     """
     return (
-        pl.read_parquet(file_path, columns=["subject_id", "time"])
+        pl.read_parquet(file_path, columns=["subject_id", "time", "code"])
         .filter(pl.col("time").is_not_null())
         .with_columns(pl.col("time").cast(pl.Datetime("us")))
+        .pipe(_truncate_at_death)
+        .select(["subject_id", "time"])
         .unique()
         .with_columns(pl.lit(shard).alias("shard"))
     )
@@ -998,6 +1014,8 @@ def _prediction_time_cache_valid(
 
     Reuse requires *all* of:
     - the sidecar exists, parses, and its recorded ``min`` matches the requested ``min``;
+    - the sidecar records ``death_truncation: true`` — pre-#265 caches lack the field and were
+      built without post-death filtering, so they are stale;
     - the counts parquet exists and every map partition named in the sidecar exists;
     - the counts parquet agrees with the sidecar totals: ``counts.height == meta["n_subjects"]`` and
       ``sum(n_prediction_times) == meta["n_prediction_time_rows"]``.
@@ -1015,6 +1033,8 @@ def _prediction_time_cache_valid(
     except (json.JSONDecodeError, OSError):
         return False
     if meta.get("min_prediction_times_per_subject") != min_prediction_times_per_subject:
+        return False
+    if meta.get("death_truncation") is not True:
         return False
 
     shards = meta.get("shards")
@@ -1160,6 +1180,9 @@ def build_prediction_times(
     _atomic_write_json(
         {
             "min_prediction_times_per_subject": min_prediction_times_per_subject,
+            # Records that post-death rows were truncated (#265); its absence marks a pre-fix cache
+            # so _prediction_time_cache_valid forces a rebuild rather than silently reusing it.
+            "death_truncation": True,
             "split": split,
             "shards": written_shards,
             "n_subjects": eligible.height,

--- a/tests/sampler/test_stage0_prediction_times.py
+++ b/tests/sampler/test_stage0_prediction_times.py
@@ -5,7 +5,8 @@ has subject 1 (5 distinct times, eligible), subject 2 (3, eligible at the bounda
 (2, dropped) — so the ``+1`` boundary and the eligibility filter are both exercised.
 
 Covers the gapless+dedup index (invariant 2), eligibility, invariant 4 (no subject spans shards),
-shard partitioning, null-time dropping, and the cache reuse / invalidation / overwrite paths.
+shard partitioning, null-time dropping, death truncation (#265), and the cache reuse /
+invalidation / overwrite paths.
 """
 
 import json
@@ -14,6 +15,7 @@ from pathlib import Path
 
 import polars as pl
 import pytest
+from meds import death_code
 
 from every_query.generate_tasks import sample_tasks as st
 from every_query.generate_tasks.sample_tasks import (
@@ -212,3 +214,54 @@ class TestStage0:
 
         counts = pl.read_parquet(prediction_time_counts_path(artifacts_dir, "train"))
         assert dict(zip(counts["subject_id"], counts["n_prediction_times"], strict=True)) == {1: 3}
+
+    def test_post_death_times_are_dropped_and_dont_count_toward_eligibility(
+        self, tmp_path, artifacts_dir, subject_events, write_split_shards
+    ):
+        # Subject 1: 5 distinct times, MEDS_DEATH at day 2 ⇒ days 3-4 truncated, 3 remain (still
+        # eligible; the death timestamp itself is kept as a prediction time). Subject 2: 3 distinct
+        # times, MEDS_DEATH at day 1 ⇒ 2 remain — without truncation it would clear the
+        # eligibility bar on post-death timestamps alone (#265's inflation case).
+        events = pl.concat(
+            [
+                subject_events(1, 5, base=self.BASE),
+                pl.DataFrame(
+                    {"subject_id": [1], "time": [self.BASE + timedelta(days=2)], "code": [death_code]}
+                ),
+                subject_events(2, 3, base=self.BASE),
+                pl.DataFrame(
+                    {"subject_id": [2], "time": [self.BASE + timedelta(days=1)], "code": [death_code]}
+                ),
+            ]
+        )
+        path_to_data = write_split_shards(tmp_path, {"0": events})
+        n = build_prediction_times(path_to_data, artifacts_dir, "train", self.MIN)
+        assert n == 1
+
+        pmap = pl.read_parquet(prediction_times_path(artifacts_dir, "train", "0"))
+        assert pmap["subject_id"].unique().to_list() == [1]
+        s1 = pmap.filter(pl.col("subject_id") == 1).sort("prediction_time_index")
+        assert s1["time"].to_list() == [self.BASE + timedelta(days=i) for i in range(3)]
+
+        counts = pl.read_parquet(prediction_time_counts_path(artifacts_dir, "train"))
+        assert dict(zip(counts["subject_id"], counts["n_prediction_times"], strict=True)) == {1: 3}
+
+    def test_pre_death_truncation_cache_is_rebuilt(self, path_to_data, artifacts_dir, monkeypatch):
+        build_prediction_times(path_to_data, artifacts_dir, "train", self.MIN)
+        # Simulate a pre-#265 cache: sidecar without the death_truncation field.
+        meta_fp = prediction_times_meta_path(artifacts_dir, "train")
+        meta = json.loads(meta_fp.read_text())
+        del meta["death_truncation"]
+        meta_fp.write_text(json.dumps(meta))
+
+        calls = {"n": 0}
+        real = st._read_prediction_time_shard
+
+        def _spy(*args, **kwargs):
+            calls["n"] += 1
+            return real(*args, **kwargs)
+
+        monkeypatch.setattr(st, "_read_prediction_time_shard", _spy)
+        n = build_prediction_times(path_to_data, artifacts_dir, "train", self.MIN)
+        assert n == 2
+        assert calls["n"] == 1  # stale sidecar ⇒ rebuild, not silent reuse


### PR DESCRIPTION
## Summary
- Extract the #264 inline death filter into a shared `_truncate_at_death` helper used by both `evaluate_index_df` (Stage 4) and `_read_prediction_time_shard` (Stage 0), so the two stages can't drift on the death rule.
- Stage 0 now reads the `code` column and drops rows strictly after each subject's earliest `MEDS_DEATH` row before deduping — post-death timestamps are no longer valid prediction times and no longer inflate `n_prediction_times` toward the eligibility bar.
- Add `death_truncation: true` to `_prediction_times_meta.json` and require it in `_prediction_time_cache_valid`: pre-fix caches lack the field and are rebuilt instead of silently reused.

Closes #265.

## Tests
- New: post-death timestamps excluded from the map and counts (including the eligibility-inflation case where a subject clears the bar only via post-death rows; the death timestamp itself stays a valid prediction time), and a pre-fix sidecar forces a rebuild.
- Existing `TestDeathTruncation` (Stage 4, #264) passes unchanged, covering the extracted helper.
- `uv run pytest tests/sampler/` — 120 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)