### PR TITLE
Add num_workers override to EQ_predict

### DIFF
--- a/src/every_query/predict/configs/predict.yaml
+++ b/src/every_query/predict/configs/predict.yaml
@@ -55,6 +55,13 @@ save_embeddings: false
 # the saved training ``resolved_config.yaml``.
 batch_size: null
 
+# Optional: override the dataloader worker count for inference.  Defaults to null,
+# which reuses the training run's ``datamodule.num_workers`` (typically 1).  With
+# large task frames a single worker starves the GPU building per-row sequences;
+# raising this (e.g. to the SLURM cpus-per-task) is usually the biggest throughput
+# win.  Does not touch the saved training ``resolved_config.yaml``.
+num_workers: null
+
 hydra:
   output_subdir: null
   job:

--- a/src/every_query/predict/predict.py
+++ b/src/every_query/predict/predict.py
@@ -520,6 +520,9 @@ def main(cfg: DictConfig) -> None:
     batch_size_override = cfg.get("batch_size")
     if batch_size_override is not None:
         train_cfg.datamodule.batch_size = int(batch_size_override)
+    num_workers_override = cfg.get("num_workers")
+    if num_workers_override is not None:
+        train_cfg.datamodule.num_workers = int(num_workers_override)
     train_cfg.datamodule.config.task_labels_dir = str(tasks_dir)
     D = instantiate(train_cfg.datamodule)
 

--- a/tests/test_predict_cli.py
+++ b/tests/test_predict_cli.py
@@ -220,6 +220,50 @@ def test_eq_predict_batch_size_override(
     assert set(df["query"].to_list()) == set(_QUERY_CODES)
 
 
+def test_eq_predict_num_workers_override(
+    eq_trained_model_dir: Path,
+    predict_tasks_dir: Path,
+    tmp_path: Path,
+) -> None:
+    """``num_workers=N`` overrides the inherited training ``datamodule.num_workers``.
+
+    Runs predict with ``num_workers=2`` (multi-worker dataloading) against the same
+    fixture as the baseline test and asserts the output is still
+    ``PredictionSchema``-conformant with the expected row count and bounded
+    probabilities.  The override path mutates ``train_cfg`` in memory only;
+    ``resolved_config.yaml`` on disk is untouched.
+    """
+    output_parquet = tmp_path / "predictions.parquet"
+
+    env = os.environ.copy()
+    env["PATH"] = _VENV_BIN + os.pathsep + env.get("PATH", "")
+
+    cmd = [
+        "EQ_predict",
+        f"model_run_dir={eq_trained_model_dir}",
+        f"tasks_dir={predict_tasks_dir}",
+        f"output_parquet={output_parquet}",
+        "num_workers=2",
+    ]
+    result = subprocess.run(cmd, capture_output=True, text=True, env=env, timeout=300)
+    assert result.returncode == 0, (
+        f"EQ_predict failed (rc={result.returncode})\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+    assert output_parquet.exists(), "EQ_predict did not produce the output parquet"
+
+    table = pq.read_table(output_parquet)
+    PredictionSchema.align(table)
+
+    df = pl.from_arrow(table)
+    assert df.height == len(_QUERY_CODES), (
+        f"Expected {len(_QUERY_CODES)} prediction rows (one per query), got {df.height}"
+    )
+    for col in ("censor_prob", "occurs_prob"):
+        col_min = float(df[col].min())
+        col_max = float(df[col].max())
+        assert 0.0 <= col_min <= col_max <= 1.0, f"{col} not in [0,1]: min={col_min} max={col_max}"
+
+
 def test_eq_predict_save_embeddings(
     eq_trained_model_dir: Path,
     predict_tasks_dir: Path,


### PR DESCRIPTION
## Summary
- Add an optional `num_workers` config key to `EQ_predict`, mirroring the existing `batch_size` override: when set, it overrides the inherited training `datamodule.num_workers` in memory only (the run dir's `resolved_config.yaml` is untouched).
- Motivation: training runs default to `num_workers: 1`, and a single dataloader worker starves the GPU building per-row sequences on large task frames (e.g. ~12M-row eval task sets), making the worker count the dominant inference-throughput knob alongside `batch_size`.

## Changes
- `src/every_query/predict/configs/predict.yaml` — new optional `num_workers: null` key with doc comment.
- `src/every_query/predict/predict.py` — two-line override next to the existing `batch_size` override.
- `tests/test_predict_cli.py` — `test_eq_predict_num_workers_override`, mirroring the `batch_size` override test with `num_workers=2`.

## Testing
- `uv run pytest tests/test_predict_cli.py::test_eq_predict_num_workers_override` passes locally (77s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)