### PR TITLE
Shuffle tuning-split task labels so limit_val_batches sees a representative slice

### DIFF
--- a/src/every_query/data/dataset.py
+++ b/src/every_query/data/dataset.py
@@ -7,7 +7,7 @@ import numpy as np
 import polars as pl
 import pyarrow.parquet as pq
 import torch
-from meds import DataSchema, LabelSchema
+from meds import DataSchema, LabelSchema, tuning_split
 from meds_torchdata import MEDSPytorchDataset
 from meds_torchdata.config import MEDSTorchDataConfig
 from meds_torchdata.types import BatchMode, MEDSTorchBatch
@@ -392,7 +392,15 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
             return pl.read_parquet(fp, columns=label_cols, use_pyarrow=True)
 
         logger.info(f"Reading tasks from {self.config.task_labels_fps}")
-        return pl.concat([read_df(fp) for fp in self.config.task_labels_fps], how="vertical")
+        df = pl.concat([read_df(fp) for fp in self.config.task_labels_fps], how="vertical")
+        if self.split == tuning_split:
+            # The label shards are sorted by (subject_id, query, prediction_time) and the val
+            # dataloader doesn't shuffle, so `limit_val_batches` would otherwise only ever see the
+            # first shard's lowest subject_ids.  Fixed seed keeps tuning/loss comparable across
+            # runs and resumes.  Note: EQ_predict split=tuning output inherits this shuffled row
+            # order (still correct — identifiers travel with each row).
+            df = df.sample(fraction=1.0, shuffle=True, seed=0)
+        return df
 
     def encode_query(self, code_name: str) -> int:
         """Encode query using the canonical code vocabulary mapping."""

--- a/tests/test_dataset_logic.py
+++ b/tests/test_dataset_logic.py
@@ -231,3 +231,55 @@ class TestDifferentQueryStringProducesDifferentIndex:
             f"Position 0 for sample 1 should carry encoded {query_b!r} ({enc_b}), "
             f"got {batch.code[1, 0].item()}"
         )
+
+
+class TestTuningLabelsShuffled:
+    """``labels_df`` must deterministically shuffle rows for the tuning split only.
+
+    The sampler writes label shards sorted by ``(subject_id, query, prediction_time)`` and the
+    val dataloader doesn't shuffle, so without this ``limit_val_batches`` would only ever see
+    the first shard's lowest subject_ids.  Train/held_out keep file order (train shuffles at the
+    sampler level; ``EQ_predict`` relies on order-preserving iteration).
+    """
+
+    def _dataset(self, tensorized_cohort_dir, task_labels_dir, split):
+        from meds_torchdata.config import MEDSTorchDataConfig
+
+        cfg = MEDSTorchDataConfig(
+            tensorized_cohort_dir=str(tensorized_cohort_dir),
+            task_labels_dir=str(task_labels_dir),
+            max_seq_len=64,
+            seq_sampling_strategy="to_end",
+            static_inclusion_mode="omit",
+            batch_mode="SM",
+        )
+        return EveryQueryPytorchDataset(cfg, split=split)
+
+    def test_tuning_shuffled_train_not(self, tensorized_cohort_dir, task_labels_dir):
+        import polars as pl
+        from meds import train_split, tuning_split
+
+        file_order = pl.concat(
+            [
+                pl.read_parquet(fp, columns=["subject_id", "prediction_time", "query"])
+                for fp in sorted(task_labels_dir.rglob("*.parquet"))
+            ]
+        )
+        key_cols = file_order.columns
+
+        train_ds = self._dataset(tensorized_cohort_dir, task_labels_dir, train_split)
+        assert train_ds.labels_df.select(key_cols).equals(file_order), (
+            "train labels_df must preserve file order"
+        )
+
+        tuning_ds = self._dataset(tensorized_cohort_dir, task_labels_dir, tuning_split)
+        tuning_labels = tuning_ds.labels_df.select(key_cols)
+        assert not tuning_labels.equals(file_order), "tuning labels_df must be shuffled"
+        assert tuning_labels.sort(key_cols).equals(file_order.sort(key_cols)), (
+            "shuffle must be a permutation — same rows, different order"
+        )
+
+        again = self._dataset(tensorized_cohort_dir, task_labels_dir, tuning_split)
+        assert again.labels_df.select(key_cols).equals(tuning_labels), (
+            "tuning shuffle must be deterministic (fixed seed)"
+        )


### PR DESCRIPTION
## Problem

`tuning/loss` (the checkpoint/early-stopping monitor) is computed on `limit_val_batches: 100` × `batch_size: 128` = 12,800 rows, and the val dataloader iterates without shuffling. The sampler's label shards are written sorted by `(subject_id, query, prediction_time)` (`evaluate_index_df`), and the dataset concatenates them in file order — so validation only ever saw the **first shard's lowest subject_ids**, a fixed, non-representative patient subsample. This is one reason tracked tuning loss doesn't move with per-task AUROC computed post hoc over the full tuning split.

## Fix

In `EveryQueryPytorchDataset.labels_df`, deterministically shuffle the concatenated label DataFrame (`.sample(fraction=1.0, shuffle=True, seed=0)`) **for the tuning split only**:

- **train** — untouched; the train dataloader already shuffles at the sampler level.
- **held_out** — untouched; `EQ_predict` relies on order-preserving iteration and its output row order matching the input labels file.
- Fixed seed keeps `tuning/loss` comparable across runs and resumes.

Load-time (rather than generation-time) shuffling fixes both the within-shard subject sort and the single-shard bias, and requires no regeneration of existing task-label artifacts.

## Notes

- `EQ_predict split=tuning` output rows now come out in shuffled order — still correct (identifiers travel with each row), just no longer matching the label file's row order.
- `tuning/loss` curves from runs before this change are not comparable to new runs (different validation slice).

## Tests

New `TestTuningLabelsShuffled` in `tests/test_dataset_logic.py`: train `labels_df` preserves file order; tuning `labels_df` is a permutation in a different order; the shuffle is deterministic across dataset instances. Also ran `test_sampler_dataset_integration.py`, `test_task_seq_bounds.py`, `test_predict_logic.py`, `test_train.py` — all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)