### PR TITLE
Add in-training task-level AUROC tracking via sampled pos/neg pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,9 +235,18 @@ EQ_sample_task_tracking_pairs \
 # pairs land at $TASK_TRACKING_DIR/tuning/0.parquet
 ```
 
-Then uncomment the `task_auroc_tracking` callback block in
-`src/every_query/train/configs/config.yaml` and point its `task_labels_dir` at
-`$TASK_TRACKING_DIR` (or override on the CLI). Notes:
+Then enable the callback via its Hydra config group and point `task_labels_dir` at
+`$TASK_TRACKING_DIR`:
+
+```bash
+EQ_train +callbacks=task_auroc \
+	++trainer.callbacks.task_auroc_tracking.config.task_labels_dir="$TASK_TRACKING_DIR"
+```
+
+`+callbacks=task_auroc` composes `configs/callbacks/task_auroc.yaml` into the callbacks list.
+It is off by default — `config.yaml` ships `task_auroc_tracking: null`, and `values_as_list`
+drops `None` entries, so a plain `EQ_train` (e.g. when EveryQuery is used as a dependency) runs
+without it and without needing any tracking pairs. Notes:
 
 - The split is locked to `tuning` on purpose — tracking mirrors `tuning/loss` checkpointing, so
     it is not configurable. Sample the pairs with `split=tuning`.
@@ -246,7 +255,8 @@ Then uncomment the `task_auroc_tracking` callback block in
     never logs the metric (training is unaffected).
 - Under DDP it scores on rank 0 only (the tracking set is identical on every rank), and the
     parquet is read once at setup — re-sampling mid-run requires a restart.
-- To disable it entirely, leave the callback block commented out (the default).
+- To disable it entirely, just omit `+callbacks=task_auroc` (the default). The mandatory
+    `task_labels_dir: ???` only errors when the group is actually enabled.
 
 ### 4. Predict
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Every production module lives under a submodule that reflects its role:
 ```
 src/every_query/
 ├── preprocessing/      → EQ_process_data        (raw MEDS → tensorized cohort)
-├── generate_tasks/     → EQ_generate_training_tasks + EQ_generate_evaluation_tasks (TaskQuerySchema parquets: scattered for PT, dense for eval)
+├── generate_tasks/     → EQ_generate_training_tasks + EQ_generate_evaluation_tasks + EQ_sample_task_tracking_pairs (TaskQuerySchema parquets: scattered for PT, dense for eval, pos/neg pairs for in-training AUROC)
 ├── train/              → EQ_train               (train the model)
 ├── predict/            → EQ_predict             (inference; consumes TaskQuerySchema, emits PredictionSchema)
 │   └── external_tasks/                         (ACES + composite aggregation — currently `python -m` only;
@@ -56,14 +56,15 @@ that lands with each CLI on `dev` today — unit tests (fast, `tests/test_<name>
 or `tests/test_<module>.py`), CLI smoke tests (`tests/test_cli_smoke.py`, `--help`-exits-0),
 and end-to-end subprocess tests that run the real script against a fixture cohort.
 
-| Script                         | Stage            | Purpose                                                                                                                 | Tests                                                                                                                    |
-| ------------------------------ | ---------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
-| `EQ_process_data`              | preprocessing    | Orchestrate MEDS-transforms + `meds-torch-data` tensorization                                                           | smoke; E2E via `test_process_data.py` + `test_e2e_foundation.py`                                                         |
-| `EQ_generate_training_tasks`   | PT task labels   | Sample `N` tasks × `M` contexts (scattered `(query, duration_days)`), label via single-pass asof                        | smoke; unit `tests/sampler/`; E2E `test_generate_tasks.py`                                                               |
-| `EQ_generate_evaluation_tasks` | eval task labels | Sample `K` prediction times per subject, cross-join with `(codes × durations)` grid for dense evaluation shape          | smoke; E2E `test_generate_evaluation_tasks_cli.py`                                                                       |
-| `EQ_train`                     | training         | Train the ModernBERT encoder on the labeled tasks                                                                       | smoke; unit `test_training.py`; E2E `test_train_cli.py` + `test_train.py`; signal test `tests/training_validity/` (slow) |
-| `EQ_predict`                   | inference        | Consume a `TaskQuerySchema` parquet dir + checkpoint, emit a `PredictionSchema` parquet (`censor_prob`, `occurs_prob`)  | smoke; E2E `test_predict_cli.py` (row-order preserved); exercised by `tests/training_validity/` (slow)                   |
-| `EQ_evaluate`                  | metrics          | Consume a `PredictionSchema` parquet, write per-`(query, duration_days)` metrics (`occurs_auroc`, `censor_auroc`, etc.) | smoke; E2E `test_evaluate_cli.py`; exercised by `tests/training_validity/` (slow)                                        |
+| Script                          | Stage            | Purpose                                                                                                                 | Tests                                                                                                                    |
+| ------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------ |
+| `EQ_process_data`               | preprocessing    | Orchestrate MEDS-transforms + `meds-torch-data` tensorization                                                           | smoke; E2E via `test_process_data.py` + `test_e2e_foundation.py`                                                         |
+| `EQ_generate_training_tasks`    | PT task labels   | Sample `N` tasks × `M` contexts (scattered `(query, duration_days)`), label via single-pass asof                        | smoke; unit `tests/sampler/`; E2E `test_generate_tasks.py`                                                               |
+| `EQ_generate_evaluation_tasks`  | eval task labels | Sample `K` prediction times per subject, cross-join with `(codes × durations)` grid for dense evaluation shape          | smoke; E2E `test_generate_evaluation_tasks_cli.py`                                                                       |
+| `EQ_sample_task_tracking_pairs` | AUROC tracking   | Sample one pos + one neg row per `(query, duration_days)` from the dense eval labels for cheap in-training AUROC        | smoke; E2E `test_sample_task_tracking_pairs_cli.py`                                                                      |
+| `EQ_train`                      | training         | Train the ModernBERT encoder on the labeled tasks                                                                       | smoke; unit `test_training.py`; E2E `test_train_cli.py` + `test_train.py`; signal test `tests/training_validity/` (slow) |
+| `EQ_predict`                    | inference        | Consume a `TaskQuerySchema` parquet dir + checkpoint, emit a `PredictionSchema` parquet (`censor_prob`, `occurs_prob`)  | smoke; E2E `test_predict_cli.py` (row-order preserved); exercised by `tests/training_validity/` (slow)                   |
+| `EQ_evaluate`                   | metrics          | Consume a `PredictionSchema` parquet, write per-`(query, duration_days)` metrics (`occurs_auroc`, `censor_auroc`, etc.) | smoke; E2E `test_evaluate_cli.py`; exercised by `tests/training_validity/` (slow)                                        |
 
 The legacy four-stage evaluator (`every_query.evaluate.eval`, with `gen_index_times`, `gen_task`, `select_model` siblings) has been deleted; recover from git history if needed. [#83](https://github.com/payalchandak/EveryQuery/issues/83) tracks the cross-model leaderboard, which now lives in the `EveryQueryExperiments` repo.
 
@@ -211,6 +212,41 @@ EQ_train \
 
 - `output_dir` is a required Hydra arg that is a base path you supply with `output_dir=`, e.g. `=$TRAINING_OUTPUT_DIR`. Hydra appends `<YYYY-MM-DD>/<HH-MM-SS>` for per-run uniqueness.
 - If you want to override more parameters for training refer to `src/every_query/train/configs/config.yaml`
+
+#### Optional: in-training macro-AUROC tracking
+
+`EQ_train` can log a cheap, macro-averaged per-task AUROC estimate every validation pass
+(`tuning/occurs_auroc_macro_sampled`, plus `..._n_tasks` for how many tasks contributed) via
+`TaskAurocTrackingCallback`. Instead of scoring the whole tuning split, it scores a fixed,
+offline-sampled parquet of exactly one positive + one negative row per `(query, duration_days)`
+task. Because a task's AUROC equals `P(score(pos) > score(neg))` for a random pos/neg pair, the
+win/tie/loss on that one pair is an unbiased (high-variance) estimate; macro-averaging across
+tasks gives macro AUROC at `O(n_tasks)` forward examples. It is **tracking-only** — it does not
+affect `tuning/loss`-driven checkpointing or early stopping.
+
+First sample the tracking pairs once from the dense **tuning**-split eval labels (output of
+`EQ_generate_evaluation_tasks`):
+
+```bash
+EQ_sample_task_tracking_pairs \
+	eval_labels_dir="$EVAL_TASKS_DIR/eval" \
+	out_dir="$TASK_TRACKING_DIR" \
+	split=tuning
+# pairs land at $TASK_TRACKING_DIR/tuning/0.parquet
+```
+
+Then uncomment the `task_auroc_tracking` callback block in
+`src/every_query/train/configs/config.yaml` and point its `task_labels_dir` at
+`$TASK_TRACKING_DIR` (or override on the CLI). Notes:
+
+- The split is locked to `tuning` on purpose — tracking mirrors `tuning/loss` checkpointing, so
+    it is not configurable. Sample the pairs with `split=tuning`.
+- Out-of-vocab query codes (not in the model vocab) are skipped at scoring; the callback warns at
+    setup and you'll see a smaller `..._n_tasks`. An empty tracking set logs a warning and simply
+    never logs the metric (training is unaffected).
+- Under DDP it scores on rank 0 only (the tracking set is identical on every rank), and the
+    parquet is read once at setup — re-sampling mid-run requires a restart.
+- To disable it entirely, leave the callback block commented out (the default).
 
 ### 4. Predict
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,6 +74,7 @@ every_query = ["**/*.yaml"]
 EQ_process_data = "every_query.preprocessing.__main__:main"
 EQ_generate_training_tasks = "every_query.generate_tasks.sample_tasks:main"
 EQ_generate_evaluation_tasks = "every_query.generate_tasks.sample_evaluation_tasks:main"
+EQ_sample_task_tracking_pairs = "every_query.generate_tasks.sample_task_tracking_pairs:main"
 EQ_train = "every_query.train.train:main"
 EQ_predict = "every_query.predict.predict:main"
 # EQ_evaluate points at the single-stage evaluator (consumes a PredictionSchema

--- a/src/every_query/generate_tasks/README.md
+++ b/src/every_query/generate_tasks/README.md
@@ -43,8 +43,8 @@ different row distributions:
     row into a single small parquet (2 rows/task). Registered as
     `EQ_sample_task_tracking_pairs` and runnable as
     `python -m every_query.generate_tasks.sample_task_tracking_pairs`. Feeds
-    `EveryQueryLightningModule`'s optional in-training task-tracking dataloader — see
-    `lightning_module.task_auroc_tracking` in `train/configs/config.yaml`.
+    the optional in-training `TaskAurocTrackingCallback` — see
+    `trainer.callbacks.task_auroc_tracking` in `train/configs/config.yaml`.
 
 - **`configs/sample_training_tasks_config.yaml`** / **`configs/sample_evaluation_tasks_config.yaml`**
     / **`configs/sample_task_tracking_pairs_config.yaml`**
@@ -137,7 +137,7 @@ EQ_sample_task_tracking_pairs \
 
 This is a one-time offline step; the resulting `$TASK_TRACKING_DIR/tuning/0.parquet` is
 small (2 rows per task) and fixed for the duration of a training run — point
-`lightning_module.task_auroc_tracking.config.task_labels_dir` at `$TASK_TRACKING_DIR` to
+`trainer.callbacks.task_auroc_tracking.config.task_labels_dir` at `$TASK_TRACKING_DIR` to
 have `EQ_train` log a macro-averaged, per-task-sampled AUROC (`tuning/occurs_auroc_macro_sampled`)
 every validation pass, without paying the cost of scoring the full tuning split.
 

--- a/src/every_query/generate_tasks/README.md
+++ b/src/every_query/generate_tasks/README.md
@@ -37,7 +37,17 @@ different row distributions:
     `EQ_generate_evaluation_tasks` and runnable as
     `python -m every_query.generate_tasks.sample_evaluation_tasks`.
 
+- **`sample_task_tracking_pairs.py`** — compact per-task AUROC-tracking sampler.
+    Consumes `EQ_generate_evaluation_tasks`'s labeled output (typically `split=tuning`)
+    and, per `(query, duration_days)` task, samples exactly one positive + one negative
+    row into a single small parquet (2 rows/task). Registered as
+    `EQ_sample_task_tracking_pairs` and runnable as
+    `python -m every_query.generate_tasks.sample_task_tracking_pairs`. Feeds
+    `EveryQueryLightningModule`'s optional in-training task-tracking dataloader — see
+    `lightning_module.task_auroc_tracking` in `train/configs/config.yaml`.
+
 - **`configs/sample_training_tasks_config.yaml`** / **`configs/sample_evaluation_tasks_config.yaml`**
+    / **`configs/sample_task_tracking_pairs_config.yaml`**
     — shipped Hydra configs. Path roots (`data_dir`, `out_dir`, and `query_codes` — pass the
     metadata root dir to load the full universe) are **required Hydra args** — no `.env`/env-var
     fallback (see [#235](https://github.com/payalchandak/EveryQuery/issues/235)). Pass them as
@@ -50,6 +60,8 @@ different row distributions:
 preprocessing/     →  generate_tasks/                   →  train/      →  predict/   →  evaluate/
 EQ_process_data       EQ_generate_training_tasks           EQ_train       EQ_predict     EQ_evaluate
                       EQ_generate_evaluation_tasks ────────────────────►  (inference input)
+                      EQ_generate_evaluation_tasks(split=tuning)
+                        → EQ_sample_task_tracking_pairs ──►  (in-training tracking input)
 ```
 
 Both endpoints consume:
@@ -110,6 +122,25 @@ EQ_generate_evaluation_tasks -m \
 	input_shard=0,1,2,... split=held_out
 ```
 
+### Task-tracking pairs — one compact parquet for in-training AUROC monitoring
+
+```bash
+# First, generate dense tuning-split labels the same way as above (note split=tuning):
+EQ_generate_evaluation_tasks -m \
+	input_shard=0,1,2,... split=tuning \
+	query_codes=$TENSORIZED_COHORT_DIR durations=[30,90,180,365,731]
+
+# Then sample one pos/neg pair per task from that output:
+EQ_sample_task_tracking_pairs \
+	eval_labels_dir=$EVAL_TASKS_DIR/eval out_dir=$TASK_TRACKING_DIR split=tuning
+```
+
+This is a one-time offline step; the resulting `$TASK_TRACKING_DIR/tuning/0.parquet` is
+small (2 rows per task) and fixed for the duration of a training run — point
+`lightning_module.task_auroc_tracking.config.task_labels_dir` at `$TASK_TRACKING_DIR` to
+have `EQ_train` log a macro-averaged, per-task-sampled AUROC (`tuning/occurs_auroc_macro_sampled`)
+every validation pass, without paying the cost of scoring the full tuning split.
+
 ## Determinism & restartability
 
 All training draws derive from `seed` via `utils.seeds.derive_seed`, splitting the **query
@@ -118,7 +149,10 @@ so they reproduce independently for a fixed seed. Stage 4 writes each shard via 
 `os.replace`, so a present `{shard}.parquet` is always complete; reruns skip finished shards
 (idempotent), and `overwrite=true` forces relabeling. The evaluation generator has only a
 prediction-time axis (codes and durations are caller-specified), so its seed derives on
-`(seed, split, input_shard)` and each worker writes idempotently.
+`(seed, split, input_shard)` and each worker writes idempotently. The task-tracking
+sampler derives its per-(task, class) sample key on `(seed, "task_tracking_pairs", split)`
+and writes its single output file atomically the same way; it skips work if the output
+already exists unless `overwrite=true`.
 
 ## Related
 

--- a/src/every_query/generate_tasks/configs/sample_task_tracking_pairs_config.yaml
+++ b/src/every_query/generate_tasks/configs/sample_task_tracking_pairs_config.yaml
@@ -4,9 +4,9 @@
 # (point `eval_labels_dir` at that command's `{out_dir}/eval` root, typically generated
 # with `split=tuning`) and samples exactly one positive + one negative labeled row per
 # `(query, duration_days)` task into a single compact parquet. That parquet is small
-# enough (2 rows per task) to be read every validation pass by
-# `EveryQueryLightningModule`'s task-tracking dataloader, giving a cheap unbiased-but-
-# high-variance estimate of per-task AUROC without scoring the whole tuning split.
+# enough (2 rows per task) to be read every validation pass by the training-time
+# `TaskAurocTrackingCallback`, giving a cheap unbiased-but-high-variance estimate of
+# per-task AUROC without scoring the whole tuning split.
 #
 # Usage:
 #   EQ_sample_task_tracking_pairs \

--- a/src/every_query/generate_tasks/configs/sample_task_tracking_pairs_config.yaml
+++ b/src/every_query/generate_tasks/configs/sample_task_tracking_pairs_config.yaml
@@ -1,0 +1,25 @@
+# Hydra config for the per-task AUROC tracking-pair sampler.
+#
+# Consumes the dense per-shard label parquets written by `EQ_generate_evaluation_tasks`
+# (point `eval_labels_dir` at that command's `{out_dir}/eval` root, typically generated
+# with `split=tuning`) and samples exactly one positive + one negative labeled row per
+# `(query, duration_days)` task into a single compact parquet. That parquet is small
+# enough (2 rows per task) to be read every validation pass by
+# `EveryQueryLightningModule`'s task-tracking dataloader, giving a cheap unbiased-but-
+# high-variance estimate of per-task AUROC without scoring the whole tuning split.
+#
+# Usage:
+#   EQ_sample_task_tracking_pairs \
+#       eval_labels_dir=$EVAL_TASKS_DIR/eval out_dir=$TASK_TRACKING_DIR split=tuning
+
+eval_labels_dir: ??? # {eval_labels_dir}/{split}/*.parquet must exist (from EQ_generate_evaluation_tasks)
+out_dir: ??? # pairs land at {out_dir}/{split}/0.parquet
+
+split: tuning
+seed: 1
+overwrite: false
+
+hydra:
+  output_subdir: null
+  job:
+    chdir: false

--- a/src/every_query/generate_tasks/sample_task_tracking_pairs.py
+++ b/src/every_query/generate_tasks/sample_task_tracking_pairs.py
@@ -158,7 +158,7 @@ def _read_eval_labels(eval_labels_dir: Path, split: str) -> pl.DataFrame:
     parquets = sorted(split_dir.glob("*.parquet"))
     if not parquets:
         raise FileNotFoundError(f"No parquet files found under {split_dir}")
-    return pl.concat([pl.read_parquet(fp) for fp in parquets], how="vertical")
+    return pl.scan_parquet(parquets).collect()
 
 
 def _out_fp(out_dir: Path, split: str) -> Path:
@@ -188,6 +188,12 @@ def run(
     sample_seed = derive_seed(seed, "task_tracking_pairs", split)
     pairs = sample_task_tracking_pairs(labels_df, seed=sample_seed)
     n_tasks = pairs.height // 2
+    if n_tasks == 0:
+        logger.warning(
+            "No task survived tracking-pair sampling (every task lacked a positive or negative "
+            "example); writing an empty file to %s — in-training AUROC tracking will be a no-op.",
+            _out_fp(out_dir, split),
+        )
     logger.info("Sampled %d pos/neg pairs (%d tasks) for tracking.", pairs.height, n_tasks)
 
     aligned = TaskQuerySchema.align(pairs.to_arrow())

--- a/src/every_query/generate_tasks/sample_task_tracking_pairs.py
+++ b/src/every_query/generate_tasks/sample_task_tracking_pairs.py
@@ -1,0 +1,228 @@
+"""Per-task pos/neg pair sampler for cheap in-training AUROC tracking.
+
+Consumes the dense per-shard label parquets written by ``EQ_generate_evaluation_tasks``
+(typically with ``split=tuning``) and, for each ``(query, duration_days)`` task, samples
+exactly one row with ``boolean_value=True`` and one with ``boolean_value=False``.  Tasks
+missing either class are dropped (AUROC is undefined for a single-class task; mirrors
+``evaluate/metrics.py``'s ``_auroc_or_none``).
+
+The output is a single small parquet — two rows per surviving task — meant to be read by
+``EveryQueryLightningModule``'s task-tracking dataloader every validation pass.  Because
+AUROC for a task equals ``P(score(positive) > score(negative))`` for a random positive/
+negative pair, scoring this one pair per task gives an unbiased (if high-variance)
+per-task AUROC estimate; macro-averaging the resulting win/tie/loss indicators across
+tasks estimates macro AUROC at a cost of ``O(n_tasks)`` forward passes instead of
+``O(tuning-split size)``.
+
+Pipeline position:
+``EQ_generate_evaluation_tasks(split=tuning) -> EQ_sample_task_tracking_pairs -> EQ_train``.
+"""
+
+import logging
+from importlib.resources import files
+from pathlib import Path
+
+import hydra
+import polars as pl
+from omegaconf import DictConfig
+
+from every_query.data.schema import TaskQuerySchema
+from every_query.generate_tasks.sample_tasks import _atomic_write_parquet, _require_path_arg
+from every_query.utils.seeds import derive_seed
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Pure primitive
+# ---------------------------------------------------------------------------
+
+
+def sample_task_tracking_pairs(labels_df: pl.DataFrame, seed: int) -> pl.DataFrame:
+    """Sample one positive + one negative labeled row per ``(query, duration_days)`` task.
+
+    Args:
+        labels_df: ``TaskQuerySchema``-shaped rows with a non-null-filterable
+            ``boolean_value`` column (rows with a null ``boolean_value``, i.e. censored,
+            are dropped before sampling — the label is undefined there).
+        seed: PRNG seed.  Deterministic in ``(labels_df, seed)``.
+
+    Returns:
+        A frame with the same columns as ``labels_df``, restricted to exactly two rows
+        (one ``True``, one ``False``) per task that had both classes available. Tasks
+        with only one class present are dropped entirely (a warning is logged with the
+        drop count). Sorted by ``(query, duration_days, boolean_value)``.
+
+    Examples:
+        >>> from datetime import datetime
+        >>> df = pl.DataFrame({
+        ...     "subject_id": [1, 2, 3, 4, 5],
+        ...     "prediction_time": [datetime(2024, 1, i) for i in range(1, 6)],
+        ...     "query": ["A", "A", "A", "B", "B"],
+        ...     "duration_days": pl.Series([30.0, 30.0, 30.0, 30.0, 30.0], dtype=pl.Float32),
+        ...     "boolean_value": [True, True, False, True, True],
+        ... })
+        >>> out = sample_task_tracking_pairs(df, seed=0)
+
+        Task ``A`` has both classes, so it survives with exactly 2 rows; task ``B`` is
+        all-positive and is dropped entirely:
+
+        >>> sorted(out["query"].unique().to_list())
+        ['A']
+        >>> out.height
+        2
+        >>> sorted(out["boolean_value"].to_list())
+        [False, True]
+
+        Determinism — same seed, same output:
+
+        >>> a = sample_task_tracking_pairs(df, seed=42)
+        >>> b = sample_task_tracking_pairs(df, seed=42)
+        >>> a.equals(b)
+        True
+
+        Empty input yields an empty frame:
+
+        >>> sample_task_tracking_pairs(df.head(0), seed=0).height
+        0
+    """
+    required = {
+        TaskQuerySchema.subject_id_name,
+        TaskQuerySchema.prediction_time_name,
+        TaskQuerySchema.query_name,
+        TaskQuerySchema.duration_days_name,
+        TaskQuerySchema.boolean_value_name,
+    }
+    missing = required - set(labels_df.columns)
+    if missing:
+        raise ValueError(f"labels_df is missing required column(s) {sorted(missing)}")
+
+    label_col = TaskQuerySchema.boolean_value_name
+    task_cols = [TaskQuerySchema.query_name, TaskQuerySchema.duration_days_name]
+
+    labeled = labels_df.filter(pl.col(label_col).is_not_null())
+    if labeled.height == 0:
+        return labeled
+
+    # Per-(task, class) sample: derive a per-row hash key from
+    # (subject_id, prediction_time, query, duration_days, seed), rank within each
+    # (task, class) group by that key, and keep rank 0 — same deterministic-without-
+    # positional-bias trick as sample_evaluation_tasks.sample_prediction_times_per_subject.
+    ranked = (
+        labeled.with_columns(
+            pl.concat_str(
+                [
+                    pl.col(TaskQuerySchema.subject_id_name).cast(pl.Utf8),
+                    pl.col(TaskQuerySchema.prediction_time_name).cast(pl.Utf8),
+                    pl.col(TaskQuerySchema.query_name).cast(pl.Utf8),
+                    pl.col(TaskQuerySchema.duration_days_name).cast(pl.Utf8),
+                    pl.lit(str(seed)),
+                ],
+                separator="|",
+            )
+            .hash()
+            .alias("_sample_key")
+        )
+        .sort([*task_cols, label_col, "_sample_key"])
+        .with_columns(pl.int_range(0, pl.len()).over([*task_cols, label_col]).alias("_rank"))
+    )
+
+    selected = ranked.filter(pl.col("_rank") == 0).drop(["_sample_key", "_rank"])
+
+    counts = selected.group_by(task_cols).agg(pl.col(label_col).n_unique().alias("_n_classes"))
+    complete_tasks = counts.filter(pl.col("_n_classes") == 2).select(task_cols)
+
+    n_total_tasks = counts.height
+    n_dropped = n_total_tasks - complete_tasks.height
+    if n_dropped:
+        logger.warning(
+            "Dropped %d/%d tracked task(s) missing a positive or negative example.",
+            n_dropped,
+            n_total_tasks,
+        )
+
+    return (
+        selected.join(complete_tasks, on=task_cols, how="semi")
+        .sort([*task_cols, label_col])
+        .select(labels_df.columns)
+    )
+
+
+# ---------------------------------------------------------------------------
+# I/O helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_eval_labels(eval_labels_dir: Path, split: str) -> pl.DataFrame:
+    split_dir = eval_labels_dir / split
+    parquets = sorted(split_dir.glob("*.parquet"))
+    if not parquets:
+        raise FileNotFoundError(f"No parquet files found under {split_dir}")
+    return pl.concat([pl.read_parquet(fp) for fp in parquets], how="vertical")
+
+
+def _out_fp(out_dir: Path, split: str) -> Path:
+    return out_dir / split / "0.parquet"
+
+
+def run(
+    eval_labels_dir: Path,
+    out_dir: Path,
+    split: str,
+    seed: int,
+    overwrite: bool = False,
+) -> Path | None:
+    """Sample task-tracking pairs for one split and write them to a single parquet.
+
+    Returns the written parquet path, or ``None`` if output existed and
+    ``overwrite=False``.
+    """
+    out_fp = _out_fp(out_dir, split)
+    if not overwrite and out_fp.exists():
+        logger.info("Task tracking pairs already exist at %s, skipping.", out_fp)
+        return None
+
+    labels_df = _read_eval_labels(eval_labels_dir, split)
+    logger.info("Loaded %d labeled eval rows from %s", labels_df.height, eval_labels_dir / split)
+
+    sample_seed = derive_seed(seed, "task_tracking_pairs", split)
+    pairs = sample_task_tracking_pairs(labels_df, seed=sample_seed)
+    n_tasks = pairs.height // 2
+    logger.info("Sampled %d pos/neg pairs (%d tasks) for tracking.", pairs.height, n_tasks)
+
+    aligned = TaskQuerySchema.align(pairs.to_arrow())
+    _atomic_write_parquet(pl.from_arrow(aligned), out_fp)
+    logger.info("Wrote %d task-tracking rows to %s", pairs.height, out_fp)
+    return out_fp
+
+
+# ---------------------------------------------------------------------------
+# Hydra entry point
+# ---------------------------------------------------------------------------
+
+
+CONFIGS = str(files("every_query") / "generate_tasks" / "configs")
+
+
+@hydra.main(version_base=None, config_path=CONFIGS, config_name="sample_task_tracking_pairs_config")
+def main(cfg: DictConfig) -> None:
+    """Produce one compact task-tracking-pairs parquet for one split.
+
+    Usage:
+        EQ_sample_task_tracking_pairs \\
+            eval_labels_dir=$EVAL_TASKS_DIR/eval out_dir=$TASK_TRACKING_DIR split=tuning
+    """
+    eval_labels_dir = _require_path_arg(cfg.get("eval_labels_dir"), "eval_labels_dir")
+    out_dir = _require_path_arg(cfg.get("out_dir"), "out_dir")
+
+    run(
+        eval_labels_dir=eval_labels_dir,
+        out_dir=out_dir,
+        split=cfg.get("split", "tuning"),
+        seed=int(cfg.seed),
+        overwrite=bool(cfg.get("overwrite", False)),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/src/every_query/generate_tasks/sample_task_tracking_pairs.py
+++ b/src/every_query/generate_tasks/sample_task_tracking_pairs.py
@@ -7,7 +7,7 @@ missing either class are dropped (AUROC is undefined for a single-class task; mi
 ``evaluate/metrics.py``'s ``_auroc_or_none``).
 
 The output is a single small parquet — two rows per surviving task — meant to be read by
-``EveryQueryLightningModule``'s task-tracking dataloader every validation pass.  Because
+the training-time ``TaskAurocTrackingCallback`` every validation pass.  Because
 AUROC for a task equals ``P(score(positive) > score(negative))`` for a random positive/
 negative pair, scoring this one pair per task gives an unbiased (if high-variance)
 per-task AUROC estimate; macro-averaging the resulting win/tie/loss indicators across
@@ -192,7 +192,7 @@ def run(
         logger.warning(
             "No task survived tracking-pair sampling (every task lacked a positive or negative "
             "example); writing an empty file to %s — in-training AUROC tracking will be a no-op.",
-            _out_fp(out_dir, split),
+            out_fp,
         )
     logger.info("Sampled %d pos/neg pairs (%d tasks) for tracking.", pairs.height, n_tasks)
 

--- a/src/every_query/generate_tasks/sample_task_tracking_pairs.py
+++ b/src/every_query/generate_tasks/sample_task_tracking_pairs.py
@@ -108,6 +108,8 @@ def sample_task_tracking_pairs(labels_df: pl.DataFrame, seed: int) -> pl.DataFra
     # (subject_id, prediction_time, query, duration_days, seed), rank within each
     # (task, class) group by that key, and keep rank 0 — same deterministic-without-
     # positional-bias trick as sample_evaluation_tasks.sample_prediction_times_per_subject.
+    # (Not df.sample(): that's positional, so re-sharding/reordering the input changes the
+    # pick for the same seed; hashing row identity is stable across both.)
     ranked = (
         labeled.with_columns(
             pl.concat_str(

--- a/src/every_query/model/lightning_module.py
+++ b/src/every_query/model/lightning_module.py
@@ -1,4 +1,5 @@
 import copy
+import dataclasses
 import logging
 import re
 from collections.abc import Callable, Iterator
@@ -12,7 +13,7 @@ import torch.nn.parameter
 from meds import held_out_split, train_split, tuning_split
 from torchmetrics.classification import BinaryAUROC
 
-from every_query.data.dataset import EveryQueryBatch
+from every_query.data.dataset import EveryQueryBatch, EveryQueryPytorchDataset
 
 from .model import EveryQueryModel, EveryQueryOutput
 
@@ -122,11 +123,19 @@ class EveryQueryLightningModule(L.LightningModule):
         model: EveryQueryModel,
         optimizer: Callable[[Iterator[torch.nn.parameter.Parameter]], torch.optim.Optimizer] | None = None,
         LR_scheduler: Callable[[torch.optim.Optimizer], torch.optim.lr_scheduler._LRScheduler] | None = None,
+        task_auroc_tracking: dict[str, Any] | None = None,
     ):
         super().__init__()
         self.model = model
         self.optimizer_factory = optimizer
         self.LR_scheduler_factory = LR_scheduler
+
+        # Optional cheap per-task AUROC tracking (see `_compute_sampled_task_auroc`).
+        # Expected shape: {"config": <instantiated meds_torchdata.MEDSTorchDataConfig
+        # whose task_labels_dir points at every_query.generate_tasks.sample_task_tracking_pairs
+        # output>, "batch_size": int}. None disables the feature entirely (default).
+        self.task_tracking_cfg = task_auroc_tracking
+        self._task_tracking_loader: torch.utils.data.DataLoader | None = None
 
         self.metrics = {
             train_split: {},
@@ -153,6 +162,23 @@ class EveryQueryLightningModule(L.LightningModule):
         for split in (tuning_split, held_out_split, "predict"):
             for m in self.metrics.get(split, {}).values():
                 m.to("cpu")
+
+        if (
+            self.task_tracking_cfg is not None
+            and stage in ("fit", "validate")
+            and self._task_tracking_loader is None
+        ):
+            # Built once — the tracking labels are a fixed, offline-generated file (see
+            # every_query.generate_tasks.sample_task_tracking_pairs), so there's no need to
+            # re-read/re-instantiate it every validation epoch.
+            dataset = EveryQueryPytorchDataset(self.task_tracking_cfg["config"], split=tuning_split)
+            self._task_tracking_loader = torch.utils.data.DataLoader(
+                dataset,
+                batch_size=self.task_tracking_cfg.get("batch_size", 256),
+                shuffle=False,
+                collate_fn=dataset.collate,
+                num_workers=0,
+            )
 
     def _update_metric(self, name: str, split: str, **kwargs):
         metric = self.metrics.get(split, {}).get(name)
@@ -192,8 +218,84 @@ class EveryQueryLightningModule(L.LightningModule):
 
             metric.reset()
 
+    @staticmethod
+    def _move_batch_to_device(batch: EveryQueryBatch, device: torch.device) -> EveryQueryBatch:
+        """Move every tensor field of a dataclass batch to ``device``, leaving non-tensor fields as-is.
+
+        Generic over ``EveryQueryBatch``'s (and its ``MEDSTorchBatch`` base's) exact field set, so it
+        doesn't need to be kept in sync with upstream ``meds_torchdata`` changes.
+        """
+        updates = {
+            f.name: value.to(device)
+            for f in dataclasses.fields(batch)
+            if isinstance(value := getattr(batch, f.name), torch.Tensor)
+        }
+        return dataclasses.replace(batch, **updates)
+
+    @torch.no_grad()
+    def _compute_sampled_task_auroc(self):
+        """Log a cheap, macro-averaged per-task AUROC estimate from precomputed pos/neg pairs.
+
+        Scores the fixed task-tracking dataloader built in ``setup()`` (one positive + one
+        negative row per ``(query, duration_days)`` task — see
+        ``every_query.generate_tasks.sample_task_tracking_pairs``). For each task with both
+        rows present, computes the win/tie/loss indicator
+        ``1(prob_pos > prob_neg) + 0.5 * 1(prob_pos == prob_neg)`` — an unbiased single-sample
+        estimate of that task's true AUROC (``AUROC = P(score(pos) > score(neg))``).
+        Macro-averaging those indicators across tasks estimates the per-task-averaged AUROC
+        computed offline in ``evaluate/metrics.py`` at a cost of ``O(n_tasks)`` forward
+        examples instead of ``O(tuning-split size)``. No-op if tracking isn't configured.
+        """
+        loader = self._task_tracking_loader
+        if loader is None:
+            return
+
+        was_training = self.model.training
+        self.model.eval()
+
+        probs_by_task: dict[tuple[int, float], dict[int, float]] = {}
+        try:
+            for batch in loader:
+                batch = self._move_batch_to_device(batch, self.device)
+                _, outputs = self.model(batch)
+                # Squeeze only dim 1 (not `outputs.occurs_probs`'s bare `.squeeze()`), so a
+                # trailing partial batch of size 1 doesn't collapse to a 0-d scalar — same
+                # guard `_log_metrics` applies above.
+                probs = outputs.occurs_logits.detach().cpu().squeeze(1).sigmoid().float().tolist()
+                queries = batch.query.detach().cpu().tolist()
+                durations = batch.duration_days.detach().cpu().tolist()
+                labels = batch.occurs.detach().cpu().tolist()
+                for query, duration, label, prob in zip(queries, durations, labels, probs, strict=True):
+                    probs_by_task.setdefault((query, duration), {})[int(label)] = prob
+        finally:
+            if was_training:
+                self.model.train()
+
+        indicators = []
+        for task_probs in probs_by_task.values():
+            if 1 not in task_probs or 0 not in task_probs:
+                continue
+            pos_prob, neg_prob = task_probs[1], task_probs[0]
+            if pos_prob > neg_prob:
+                indicators.append(1.0)
+            elif pos_prob < neg_prob:
+                indicators.append(0.0)
+            else:
+                indicators.append(0.5)
+
+        if not indicators:
+            return
+
+        self.log(
+            "tuning/occurs_auroc_macro_sampled",
+            sum(indicators) / len(indicators),
+            sync_dist=True,
+        )
+        self.log("tuning/occurs_auroc_macro_sampled_n_tasks", float(len(indicators)), sync_dist=True)
+
     def on_validation_epoch_end(self):
         self._on_epoch_end(tuning_split)
+        self._compute_sampled_task_auroc()
 
     def on_test_epoch_end(self):
         self._on_epoch_end(held_out_split)

--- a/src/every_query/model/lightning_module.py
+++ b/src/every_query/model/lightning_module.py
@@ -1,5 +1,4 @@
 import copy
-import dataclasses
 import logging
 import re
 from collections.abc import Callable, Iterator
@@ -13,7 +12,7 @@ import torch.nn.parameter
 from meds import held_out_split, train_split, tuning_split
 from torchmetrics.classification import BinaryAUROC
 
-from every_query.data.dataset import EveryQueryBatch, EveryQueryPytorchDataset
+from every_query.data.dataset import EveryQueryBatch
 
 from .model import EveryQueryModel, EveryQueryOutput
 
@@ -123,7 +122,6 @@ class EveryQueryLightningModule(L.LightningModule):
         model: EveryQueryModel,
         optimizer: Callable[[Iterator[torch.nn.parameter.Parameter]], torch.optim.Optimizer] | None = None,
         LR_scheduler: Callable[[torch.optim.Optimizer], torch.optim.lr_scheduler._LRScheduler] | None = None,
-        task_auroc_tracking: dict[str, Any] | None = None,
         grad_norm_log_every_n_steps: int = 1000,
     ):
         super().__init__()
@@ -133,13 +131,6 @@ class EveryQueryLightningModule(L.LightningModule):
         # Logging knob only — intentionally kept out of save_hyperparameters so old
         # checkpoints load unchanged and load_from_checkpoint needs no edits.
         self.grad_norm_log_every_n_steps = grad_norm_log_every_n_steps
-
-        # Optional cheap per-task AUROC tracking (see `_compute_sampled_task_auroc`).
-        # Expected shape: {"config": <instantiated meds_torchdata.MEDSTorchDataConfig
-        # whose task_labels_dir points at every_query.generate_tasks.sample_task_tracking_pairs
-        # output>, "batch_size": int}. None disables the feature entirely (default).
-        self.task_tracking_cfg = task_auroc_tracking
-        self._task_tracking_loader: torch.utils.data.DataLoader | None = None
 
         self.metrics = {
             train_split: {},
@@ -166,23 +157,6 @@ class EveryQueryLightningModule(L.LightningModule):
         for split in (tuning_split, held_out_split, "predict"):
             for m in self.metrics.get(split, {}).values():
                 m.to("cpu")
-
-        if (
-            self.task_tracking_cfg is not None
-            and stage in ("fit", "validate")
-            and self._task_tracking_loader is None
-        ):
-            # Built once — the tracking labels are a fixed, offline-generated file (see
-            # every_query.generate_tasks.sample_task_tracking_pairs), so there's no need to
-            # re-read/re-instantiate it every validation epoch.
-            dataset = EveryQueryPytorchDataset(self.task_tracking_cfg["config"], split=tuning_split)
-            self._task_tracking_loader = torch.utils.data.DataLoader(
-                dataset,
-                batch_size=self.task_tracking_cfg.get("batch_size", 256),
-                shuffle=False,
-                collate_fn=dataset.collate,
-                num_workers=0,
-            )
 
     def _update_metric(self, name: str, split: str, **kwargs):
         metric = self.metrics.get(split, {}).get(name)
@@ -222,84 +196,8 @@ class EveryQueryLightningModule(L.LightningModule):
 
             metric.reset()
 
-    @staticmethod
-    def _move_batch_to_device(batch: EveryQueryBatch, device: torch.device) -> EveryQueryBatch:
-        """Move every tensor field of a dataclass batch to ``device``, leaving non-tensor fields as-is.
-
-        Generic over ``EveryQueryBatch``'s (and its ``MEDSTorchBatch`` base's) exact field set, so it
-        doesn't need to be kept in sync with upstream ``meds_torchdata`` changes.
-        """
-        updates = {
-            f.name: value.to(device)
-            for f in dataclasses.fields(batch)
-            if isinstance(value := getattr(batch, f.name), torch.Tensor)
-        }
-        return dataclasses.replace(batch, **updates)
-
-    @torch.no_grad()
-    def _compute_sampled_task_auroc(self):
-        """Log a cheap, macro-averaged per-task AUROC estimate from precomputed pos/neg pairs.
-
-        Scores the fixed task-tracking dataloader built in ``setup()`` (one positive + one
-        negative row per ``(query, duration_days)`` task — see
-        ``every_query.generate_tasks.sample_task_tracking_pairs``). For each task with both
-        rows present, computes the win/tie/loss indicator
-        ``1(prob_pos > prob_neg) + 0.5 * 1(prob_pos == prob_neg)`` — an unbiased single-sample
-        estimate of that task's true AUROC (``AUROC = P(score(pos) > score(neg))``).
-        Macro-averaging those indicators across tasks estimates the per-task-averaged AUROC
-        computed offline in ``evaluate/metrics.py`` at a cost of ``O(n_tasks)`` forward
-        examples instead of ``O(tuning-split size)``. No-op if tracking isn't configured.
-        """
-        loader = self._task_tracking_loader
-        if loader is None:
-            return
-
-        was_training = self.model.training
-        self.model.eval()
-
-        probs_by_task: dict[tuple[int, float], dict[int, float]] = {}
-        try:
-            for batch in loader:
-                batch = self._move_batch_to_device(batch, self.device)
-                _, outputs = self.model(batch)
-                # Squeeze only dim 1 (not `outputs.occurs_probs`'s bare `.squeeze()`), so a
-                # trailing partial batch of size 1 doesn't collapse to a 0-d scalar — same
-                # guard `_log_metrics` applies above.
-                probs = outputs.occurs_logits.detach().cpu().squeeze(1).sigmoid().float().tolist()
-                queries = batch.query.detach().cpu().tolist()
-                durations = batch.duration_days.detach().cpu().tolist()
-                labels = batch.occurs.detach().cpu().tolist()
-                for query, duration, label, prob in zip(queries, durations, labels, probs, strict=True):
-                    probs_by_task.setdefault((query, duration), {})[int(label)] = prob
-        finally:
-            if was_training:
-                self.model.train()
-
-        indicators = []
-        for task_probs in probs_by_task.values():
-            if 1 not in task_probs or 0 not in task_probs:
-                continue
-            pos_prob, neg_prob = task_probs[1], task_probs[0]
-            if pos_prob > neg_prob:
-                indicators.append(1.0)
-            elif pos_prob < neg_prob:
-                indicators.append(0.0)
-            else:
-                indicators.append(0.5)
-
-        if not indicators:
-            return
-
-        self.log(
-            "tuning/occurs_auroc_macro_sampled",
-            sum(indicators) / len(indicators),
-            sync_dist=True,
-        )
-        self.log("tuning/occurs_auroc_macro_sampled_n_tasks", float(len(indicators)), sync_dist=True)
-
     def on_validation_epoch_end(self):
         self._on_epoch_end(tuning_split)
-        self._compute_sampled_task_auroc()
 
     def on_test_epoch_end(self):
         self._on_epoch_end(held_out_split)

--- a/src/every_query/model/task_auroc_callback.py
+++ b/src/every_query/model/task_auroc_callback.py
@@ -1,0 +1,134 @@
+"""Cheap in-training per-task AUROC tracking, as a Lightning ``Callback``.
+
+Scores a fixed, offline-sampled parquet of one positive + one negative row per
+``(query, duration_days)`` task (see
+``every_query.generate_tasks.sample_task_tracking_pairs``) every validation pass and logs
+``tuning/occurs_auroc_macro_sampled``.  Because a task's AUROC equals
+``P(score(pos) > score(neg))`` for a random pos/neg pair, the win/tie/loss indicator on that
+one pair is an unbiased (high-variance) estimate; macro-averaging across tasks estimates
+macro AUROC at ``O(n_tasks)`` forward examples instead of ``O(tuning-split size)``.
+
+Lives as a ``Callback`` (not on the ``LightningModule``) so it wires in via
+``trainer.callbacks`` like the other cross-cutting concerns, and so its typed ``__init__``
+fails fast on a misconfigured hydra block — nothing here is checkpoint-relevant.
+"""
+
+import logging
+
+import torch
+from lightning.pytorch import Callback
+from lightning.pytorch.utilities import move_data_to_device
+from meds_torchdata import MEDSTorchDataConfig
+from torch.utils.data import DataLoader
+
+from every_query.data.dataset import EveryQueryBatch, EveryQueryPytorchDataset
+
+logger = logging.getLogger(__name__)
+
+
+class TaskAurocTrackingCallback(Callback):
+    """Log ``tuning/occurs_auroc_macro_sampled`` from a fixed pos/neg pair set each val epoch.
+
+    Args:
+        config: an instantiated ``MEDSTorchDataConfig`` whose ``task_labels_dir`` points at
+            the output of ``EQ_sample_task_tracking_pairs``.
+        batch_size: dataloader batch size for the (small) tracking set.
+        split: split subdir the pairs were sampled into — must match the sampler's ``split``.
+    """
+
+    def __init__(self, config: MEDSTorchDataConfig, batch_size: int = 256, split: str = "tuning"):
+        super().__init__()
+        self.config = config
+        self.batch_size = batch_size
+        self.split = split
+        self._loader: DataLoader | None = None
+
+    def setup(self, trainer, pl_module, stage=None):
+        # Built once — the tracking labels are a fixed, offline-generated file, so there's no
+        # need to re-read/re-instantiate it every validation epoch.
+        if stage not in ("fit", "validate") or self._loader is not None:
+            return
+
+        dataset = EveryQueryPytorchDataset(self.config, split=self.split)
+
+        # Out-of-vocab query codes encode to PAD_INDEX (0); distinct OOV tasks would otherwise
+        # collide there and corrupt the estimate, so they're skipped at scoring — warn here so
+        # a silently-shrunk tracking set is visible.
+        queries = dataset.query.to_list() if dataset.query is not None else []
+        n_oov = sum(1 for q in queries if q not in dataset.code_to_index)
+        if n_oov:
+            logger.warning(
+                "%d/%d task-tracking rows have out-of-vocab query codes; they are skipped "
+                "(untrainable, and would otherwise collide at PAD_INDEX).",
+                n_oov,
+                len(queries),
+            )
+
+        if len(dataset) == 0:
+            logger.warning(
+                "Task-tracking dataset for split=%r is empty; %r will not be logged.",
+                self.split,
+                "tuning/occurs_auroc_macro_sampled",
+            )
+            return
+
+        self._loader = DataLoader(
+            dataset,
+            batch_size=self.batch_size,
+            shuffle=False,
+            collate_fn=dataset.collate,
+            num_workers=0,
+        )
+
+    def on_validation_epoch_end(self, trainer, pl_module):
+        # Rank 0 only: the tracking set is tiny and identical on every rank, so sharding buys
+        # nothing; scoring it N times and all-reducing identical scalars is pure waste. Logging
+        # with rank_zero_only=True / sync_dist=False keeps this off the collective path (a
+        # naive is_global_zero gate + sync_dist=True would deadlock).
+        if self._loader is None or not trainer.is_global_zero:
+            return
+        self._compute_and_log(pl_module.model, pl_module.device, pl_module.log)
+
+    def _compute_and_log(self, model, device, log_fn):
+        """Score the pair set and log the macro win/tie/loss AUROC estimate.
+
+        Precondition: called inside Lightning's eval loop, so ``model`` is already in eval mode
+        (``no_grad`` covers the numerics regardless).
+        """
+        probs_by_task: dict[tuple[int, float], dict[int, float]] = {}
+        with torch.no_grad():
+            for batch in self._loader:
+                batch = move_data_to_device(batch, device)
+                _, outputs = model(batch)
+                # Squeeze only dim 1 so a trailing size-1 batch doesn't collapse to a 0-d scalar.
+                probs = outputs.occurs_logits.detach().cpu().squeeze(1).sigmoid().float().tolist()
+                queries = batch.query.detach().cpu().tolist()
+                durations = batch.duration_days.detach().cpu().tolist()
+                labels = batch.occurs.detach().cpu().tolist()
+                for query, duration, label, prob in zip(queries, durations, labels, probs, strict=True):
+                    if query == EveryQueryBatch.PAD_INDEX:
+                        continue  # OOV/pad — see setup() warning
+                    probs_by_task.setdefault((query, duration), {})[int(label)] = prob
+
+        indicators = []
+        for task_probs in probs_by_task.values():
+            if 1 not in task_probs or 0 not in task_probs:
+                continue
+            pos_prob, neg_prob = task_probs[1], task_probs[0]
+            indicators.append(1.0 if pos_prob > neg_prob else 0.0 if pos_prob < neg_prob else 0.5)
+
+        if not indicators:
+            return
+
+        log_fn(
+            "tuning/occurs_auroc_macro_sampled",
+            sum(indicators) / len(indicators),
+            rank_zero_only=True,
+            sync_dist=False,
+        )
+        log_fn(
+            "tuning/occurs_auroc_macro_sampled_n_tasks",
+            float(len(indicators)),
+            rank_zero_only=True,
+            sync_dist=False,
+        )

--- a/src/every_query/model/task_auroc_callback.py
+++ b/src/every_query/model/task_auroc_callback.py
@@ -18,6 +18,7 @@ import logging
 import torch
 from lightning.pytorch import Callback
 from lightning.pytorch.utilities import move_data_to_device
+from meds import tuning_split
 from meds_torchdata import MEDSTorchDataConfig
 from torch.utils.data import DataLoader
 
@@ -29,18 +30,20 @@ logger = logging.getLogger(__name__)
 class TaskAurocTrackingCallback(Callback):
     """Log ``tuning/occurs_auroc_macro_sampled`` from a fixed pos/neg pair set each val epoch.
 
+    Always scores the ``tuning`` split — tracking mirrors ``tuning/loss`` checkpointing, so the
+    split is intentionally fixed and not configurable (the tracking pairs must be sampled into
+    ``{task_labels_dir}/tuning/`` via ``EQ_sample_task_tracking_pairs split=tuning``).
+
     Args:
         config: an instantiated ``MEDSTorchDataConfig`` whose ``task_labels_dir`` points at
             the output of ``EQ_sample_task_tracking_pairs``.
         batch_size: dataloader batch size for the (small) tracking set.
-        split: split subdir the pairs were sampled into — must match the sampler's ``split``.
     """
 
-    def __init__(self, config: MEDSTorchDataConfig, batch_size: int = 256, split: str = "tuning"):
+    def __init__(self, config: MEDSTorchDataConfig, batch_size: int = 256):
         super().__init__()
         self.config = config
         self.batch_size = batch_size
-        self.split = split
         self._loader: DataLoader | None = None
 
     def setup(self, trainer, pl_module, stage=None):
@@ -49,7 +52,7 @@ class TaskAurocTrackingCallback(Callback):
         if stage not in ("fit", "validate") or self._loader is not None:
             return
 
-        dataset = EveryQueryPytorchDataset(self.config, split=self.split)
+        dataset = EveryQueryPytorchDataset(self.config, split=tuning_split)
 
         # Out-of-vocab query codes encode to PAD_INDEX (0); distinct OOV tasks would otherwise
         # collide there and corrupt the estimate, so they're skipped at scoring — warn here so
@@ -66,8 +69,7 @@ class TaskAurocTrackingCallback(Callback):
 
         if len(dataset) == 0:
             logger.warning(
-                "Task-tracking dataset for split=%r is empty; %r will not be logged.",
-                self.split,
+                "Task-tracking dataset (tuning split) is empty; %r will not be logged.",
                 "tuning/occurs_auroc_macro_sampled",
             )
             return

--- a/src/every_query/train/configs/callbacks/task_auroc.yaml
+++ b/src/every_query/train/configs/callbacks/task_auroc.yaml
@@ -1,0 +1,17 @@
+# @package trainer.callbacks
+#
+# Opt-in cheap in-training macro-AUROC tracking. Enable with `EQ_train +callbacks=task_auroc`
+# and set the tracking-pairs location, e.g.:
+#   EQ_train +callbacks=task_auroc \
+#     ++trainer.callbacks.task_auroc_tracking.config.task_labels_dir=$TASK_TRACKING_DIR
+# See EQ_sample_task_tracking_pairs for producing the pairs (split=tuning).
+task_auroc_tracking:
+  _target_: every_query.model.task_auroc_callback.TaskAurocTrackingCallback
+  batch_size: 256
+  config:
+    _target_: meds_torchdata.MEDSTorchDataConfig
+    tensorized_cohort_dir: ${datamodule.config.tensorized_cohort_dir}
+    task_labels_dir: ??? # output of EQ_sample_task_tracking_pairs
+    static_inclusion_mode: ${datamodule.config.static_inclusion_mode}
+    seq_sampling_strategy: ${datamodule.config.seq_sampling_strategy}
+    max_seq_len: ${datamodule.config.max_seq_len}

--- a/src/every_query/train/configs/config.yaml
+++ b/src/every_query/train/configs/config.yaml
@@ -113,7 +113,6 @@ trainer:
     # task_auroc_tracking:
     #   _target_: every_query.model.task_auroc_callback.TaskAurocTrackingCallback
     #   batch_size: 256
-    #   split: tuning # must match the split EQ_sample_task_tracking_pairs wrote
     #   config:
     #     _target_: meds_torchdata.MEDSTorchDataConfig
     #     tensorized_cohort_dir: ${datamodule.config.tensorized_cohort_dir}

--- a/src/every_query/train/configs/config.yaml
+++ b/src/every_query/train/configs/config.yaml
@@ -64,6 +64,20 @@ lightning_module:
     num_warmup_steps: ${int_prod:0.05,${.num_training_steps}} # ~10% of training steps
     num_training_steps: ${trainer.max_steps}
     num_cycles: 0.5
+  # Optional: cheap, macro-averaged per-task AUROC tracking. Scores a fixed, offline-
+  # sampled parquet of one positive + one negative row per (query, duration_days) task
+  # (see EQ_sample_task_tracking_pairs) every validation pass, logging
+  # tuning/occurs_auroc_macro_sampled. Leave the whole block unset/null to disable — it
+  # does not affect tuning/loss-driven checkpointing or early stopping either way.
+  # task_auroc_tracking:
+  #   config:
+  #     _target_: meds_torchdata.MEDSTorchDataConfig
+  #     tensorized_cohort_dir: ${datamodule.config.tensorized_cohort_dir}
+  #     task_labels_dir: ??? # output of EQ_sample_task_tracking_pairs
+  #     static_inclusion_mode: ${datamodule.config.static_inclusion_mode}
+  #     seq_sampling_strategy: ${datamodule.config.seq_sampling_strategy}
+  #     max_seq_len: ${datamodule.config.max_seq_len}
+  #   batch_size: 256
 
 trainer:
   _target_: lightning.pytorch.trainer.Trainer

--- a/src/every_query/train/configs/config.yaml
+++ b/src/every_query/train/configs/config.yaml
@@ -65,20 +65,6 @@ lightning_module:
     num_warmup_steps: ${int_prod:0.05,${.num_training_steps}} # ~10% of training steps
     num_training_steps: ${trainer.max_steps}
     num_cycles: 0.5
-  # Optional: cheap, macro-averaged per-task AUROC tracking. Scores a fixed, offline-
-  # sampled parquet of one positive + one negative row per (query, duration_days) task
-  # (see EQ_sample_task_tracking_pairs) every validation pass, logging
-  # tuning/occurs_auroc_macro_sampled. Leave the whole block unset/null to disable — it
-  # does not affect tuning/loss-driven checkpointing or early stopping either way.
-  # task_auroc_tracking:
-  #   config:
-  #     _target_: meds_torchdata.MEDSTorchDataConfig
-  #     tensorized_cohort_dir: ${datamodule.config.tensorized_cohort_dir}
-  #     task_labels_dir: ??? # output of EQ_sample_task_tracking_pairs
-  #     static_inclusion_mode: ${datamodule.config.static_inclusion_mode}
-  #     seq_sampling_strategy: ${datamodule.config.seq_sampling_strategy}
-  #     max_seq_len: ${datamodule.config.max_seq_len}
-  #   batch_size: 256
 
 trainer:
   _target_: lightning.pytorch.trainer.Trainer
@@ -119,6 +105,22 @@ trainer:
       stopping_threshold: null # stop training immediately once the monitored quantity reaches this
       divergence_threshold: null # stop training as soon as the monitored quantity becomes worse than this
       check_on_train_epoch_end: false # set to false so that early stopping is checked after each validation loop
+    # Optional: cheap, macro-averaged per-task AUROC tracking. Scores a fixed, offline-sampled
+    # parquet of one positive + one negative row per (query, duration_days) task (see
+    # EQ_sample_task_tracking_pairs) every validation pass, logging
+    # tuning/occurs_auroc_macro_sampled. Comment out the whole block to disable — it does not
+    # affect tuning/loss-driven checkpointing or early stopping either way.
+    # task_auroc_tracking:
+    #   _target_: every_query.model.task_auroc_callback.TaskAurocTrackingCallback
+    #   batch_size: 256
+    #   split: tuning # must match the split EQ_sample_task_tracking_pairs wrote
+    #   config:
+    #     _target_: meds_torchdata.MEDSTorchDataConfig
+    #     tensorized_cohort_dir: ${datamodule.config.tensorized_cohort_dir}
+    #     task_labels_dir: ??? # output of EQ_sample_task_tracking_pairs
+    #     static_inclusion_mode: ${datamodule.config.static_inclusion_mode}
+    #     seq_sampling_strategy: ${datamodule.config.seq_sampling_strategy}
+    #     max_seq_len: ${datamodule.config.max_seq_len}
   default_root_dir: ${hydra:runtime.output_dir} # single source of truth: run.dir OR sweep.dir/subdir
   min_epochs: 0 # prevents early stopping
   max_epochs: null # We don't control the max epochs, we control the max steps.

--- a/src/every_query/train/configs/config.yaml
+++ b/src/every_query/train/configs/config.yaml
@@ -105,21 +105,11 @@ trainer:
       stopping_threshold: null # stop training immediately once the monitored quantity reaches this
       divergence_threshold: null # stop training as soon as the monitored quantity becomes worse than this
       check_on_train_epoch_end: false # set to false so that early stopping is checked after each validation loop
-    # Optional: cheap, macro-averaged per-task AUROC tracking. Scores a fixed, offline-sampled
-    # parquet of one positive + one negative row per (query, duration_days) task (see
-    # EQ_sample_task_tracking_pairs) every validation pass, logging
-    # tuning/occurs_auroc_macro_sampled. Comment out the whole block to disable — it does not
-    # affect tuning/loss-driven checkpointing or early stopping either way.
-    # task_auroc_tracking:
-    #   _target_: every_query.model.task_auroc_callback.TaskAurocTrackingCallback
-    #   batch_size: 256
-    #   config:
-    #     _target_: meds_torchdata.MEDSTorchDataConfig
-    #     tensorized_cohort_dir: ${datamodule.config.tensorized_cohort_dir}
-    #     task_labels_dir: ??? # output of EQ_sample_task_tracking_pairs
-    #     static_inclusion_mode: ${datamodule.config.static_inclusion_mode}
-    #     seq_sampling_strategy: ${datamodule.config.seq_sampling_strategy}
-    #     max_seq_len: ${datamodule.config.max_seq_len}
+    # Optional: cheap, macro-averaged per-task AUROC tracking (tuning/occurs_auroc_macro_sampled).
+    # Off by default (null → dropped by values_as_list). Enable with `+callbacks=task_auroc` and
+    # point its task_labels_dir at EQ_sample_task_tracking_pairs output. Tracking-only — never
+    # affects tuning/loss-driven checkpointing or early stopping.
+    task_auroc_tracking: null
   default_root_dir: ${hydra:runtime.output_dir} # single source of truth: run.dir OR sweep.dir/subdir
   min_epochs: 0 # prevents early stopping
   max_epochs: null # We don't control the max epochs, we control the max steps.

--- a/src/every_query/train/train.py
+++ b/src/every_query/train/train.py
@@ -39,7 +39,9 @@ def int_prod(x: int, y: int) -> int:
 
 
 def values_as_list(**kwargs) -> list[Any]:
-    return list(kwargs.values())
+    # Drop None so an optional callback can be toggled off with `<name>: null` instead of
+    # deleting/commenting its config block.
+    return [v for v in kwargs.values() if v is not None]
 
 
 def save_resolved_config(cfg: DictConfig, fp: Path) -> bool:

--- a/tests/test_lightning_logic.py
+++ b/tests/test_lightning_logic.py
@@ -6,7 +6,6 @@ and the relationship between raw logits and predicted probabilities.
 """
 
 from functools import partial
-from unittest.mock import patch
 
 import pytest
 import torch
@@ -14,6 +13,7 @@ import torch
 from every_query.data.dataset import EveryQueryBatch
 from every_query.model import EveryQueryOutput
 from every_query.model.lightning_module import EveryQueryLightningModule
+from every_query.model.task_auroc_callback import TaskAurocTrackingCallback
 
 _CONFIGURED_WD = 0.01
 
@@ -159,67 +159,54 @@ def _make_tracking_batch(queries: list[int], durations: list[float], occurs: lis
 
 
 class TestSampledTaskAurocTracking:
-    """``_compute_sampled_task_auroc`` — macro win/tie/loss AUROC over precomputed pairs.
+    """``TaskAurocTrackingCallback._compute_and_log`` — macro win/tie/loss AUROC over pairs.
 
-    Each task in the tracking set contributes exactly one positive and one negative row;
-    per-task AUROC collapses to an indicator on which of the two scored higher.
+    Each task in the tracking set contributes exactly one positive and one negative row; per-task AUROC
+    collapses to an indicator on which of the two scored higher.
     """
 
-    def test_no_op_when_tracking_not_configured(self, demo_model):
-        module = EveryQueryLightningModule(model=demo_model)
-        assert module._task_tracking_loader is None
+    @staticmethod
+    def _run(model, batches):
+        """Score ``batches`` with ``model`` via the callback, returning the logged metrics dict."""
+        cb = TaskAurocTrackingCallback(config=None)
+        cb._loader = batches
+        logged = {}
+        cb._compute_and_log(
+            model,
+            torch.device("cpu"),
+            lambda name, value, **kw: logged.__setitem__(name, value),
+        )
+        return logged
 
-        with patch.object(module, "log") as mock_log:
-            module._compute_sampled_task_auroc()
-
-        mock_log.assert_not_called()
+    def test_no_op_when_loader_empty(self):
+        assert self._run(_StubOccursModel([]), []) == {}
 
     def test_macro_average_win_tie_loss(self):
         # Task 10: neg logit -10 (~0 prob), pos logit +10 (~1 prob) -> win  (indicator 1.0)
         # Task 20: neg logit +10 (~1 prob), pos logit -10 (~0 prob) -> loss (indicator 0.0)
         # Task 30: neg logit  0.0,          pos logit  0.0 (tie)    -> tie  (indicator 0.5)
-        queries = [10, 10, 20, 20, 30, 30]
-        durations = [7.0] * 6
-        occurs = [0, 1, 0, 1, 0, 1]
+        batch = _make_tracking_batch([10, 10, 20, 20, 30, 30], [7.0] * 6, [0, 1, 0, 1, 0, 1])
         logits = [-10.0, 10.0, 10.0, -10.0, 0.0, 0.0]
 
-        module = EveryQueryLightningModule(model=_StubOccursModel(logits))
-        module._task_tracking_loader = [_make_tracking_batch(queries, durations, occurs)]
-
-        logged = {}
-        with patch.object(
-            module, "log", side_effect=lambda name, value, **kw: logged.__setitem__(name, value)
-        ):
-            module._compute_sampled_task_auroc()
+        logged = self._run(_StubOccursModel(logits), [batch])
 
         assert logged["tuning/occurs_auroc_macro_sampled_n_tasks"] == 3.0
         assert logged["tuning/occurs_auroc_macro_sampled"] == pytest.approx((1.0 + 0.0 + 0.5) / 3)
 
     def test_tasks_missing_a_class_are_dropped(self):
         # Task 10 has both classes (win); task 20 only has a positive row and is dropped.
-        queries = [10, 10, 20]
-        durations = [7.0, 7.0, 7.0]
-        occurs = [0, 1, 1]
+        batch = _make_tracking_batch([10, 10, 20], [7.0, 7.0, 7.0], [0, 1, 1])
         logits = [-10.0, 10.0, 0.0]
 
-        module = EveryQueryLightningModule(model=_StubOccursModel(logits))
-        module._task_tracking_loader = [_make_tracking_batch(queries, durations, occurs)]
-
-        logged = {}
-        with patch.object(
-            module, "log", side_effect=lambda name, value, **kw: logged.__setitem__(name, value)
-        ):
-            module._compute_sampled_task_auroc()
+        logged = self._run(_StubOccursModel(logits), [batch])
 
         assert logged["tuning/occurs_auroc_macro_sampled_n_tasks"] == 1.0
         assert logged["tuning/occurs_auroc_macro_sampled"] == pytest.approx(1.0)
 
-    def test_restores_model_train_mode(self):
-        module = EveryQueryLightningModule(model=_StubOccursModel([0.0, 0.0]))
-        module.model.train()
-        module._task_tracking_loader = [_make_tracking_batch([10, 10], [7.0, 7.0], [0, 1])]
+    def test_oov_query_rows_are_skipped(self):
+        # Both tasks are out-of-vocab (query == PAD_INDEX 0); without the guard their pos/neg
+        # probs collide into one bogus (0, 7.0) task. They must be dropped, leaving no metric.
+        batch = _make_tracking_batch([0, 0, 0, 0], [7.0] * 4, [0, 1, 0, 1])
+        logits = [-10.0, 10.0, 10.0, -10.0]
 
-        with patch.object(module, "log"):
-            module._compute_sampled_task_auroc()
-
-        assert module.model.training is True
+        assert self._run(_StubOccursModel(logits), [batch]) == {}

--- a/tests/test_lightning_logic.py
+++ b/tests/test_lightning_logic.py
@@ -6,9 +6,13 @@ and the relationship between raw logits and predicted probabilities.
 """
 
 from functools import partial
+from unittest.mock import patch
 
+import pytest
 import torch
 
+from every_query.data.dataset import EveryQueryBatch
+from every_query.model import EveryQueryOutput
 from every_query.model.lightning_module import EveryQueryLightningModule
 
 _CONFIGURED_WD = 0.01
@@ -117,3 +121,105 @@ class TestPredictProbsEqualSigmoidOfLogits:
         assert torch.allclose(preds["censor_probs"], expected), (
             f"censor_probs mismatch:\n  predict_step: {preds['censor_probs']}\n  sigmoid(logits): {expected}"
         )
+
+
+class _StubOccursModel(torch.nn.Module):
+    """Fake model returning ``EveryQueryOutput`` built from a queue of caller-pinned occurs logits.
+
+    Ignores the batch's actual sequence data entirely — each ``forward`` call consumes
+    ``batch.query.shape[0]`` logits off the front of the queue (in the order the test
+    enqueued them) so tests can pin exact per-row probabilities without a real transformer.
+    """
+
+    def __init__(self, logits: list[float]):
+        super().__init__()
+        self._dummy_param = torch.nn.Parameter(torch.zeros(1))
+        self._logits = list(logits)
+
+    def forward(self, batch: EveryQueryBatch):
+        n = batch.query.shape[0]
+        row_logits = torch.tensor(self._logits[:n], dtype=torch.float32).unsqueeze(1)
+        self._logits = self._logits[n:]
+        outputs = EveryQueryOutput(last_hidden_state=None, occurs_logits=row_logits)
+        return torch.tensor(0.0), outputs
+
+
+def _make_tracking_batch(queries: list[int], durations: list[float], occurs: list[int]) -> EveryQueryBatch:
+    n = len(queries)
+    seq_len = 2
+    return EveryQueryBatch(
+        code=torch.zeros(n, seq_len, dtype=torch.long),
+        numeric_value=torch.zeros(n, seq_len),
+        numeric_value_mask=torch.zeros(n, seq_len, dtype=torch.bool),
+        time_delta_days=torch.zeros(n, seq_len),
+        occurs=torch.tensor(occurs, dtype=torch.long),
+        query=torch.tensor(queries, dtype=torch.long),
+        duration_days=torch.tensor(durations, dtype=torch.float32),
+    )
+
+
+class TestSampledTaskAurocTracking:
+    """``_compute_sampled_task_auroc`` — macro win/tie/loss AUROC over precomputed pairs.
+
+    Each task in the tracking set contributes exactly one positive and one negative row;
+    per-task AUROC collapses to an indicator on which of the two scored higher.
+    """
+
+    def test_no_op_when_tracking_not_configured(self, demo_model):
+        module = EveryQueryLightningModule(model=demo_model)
+        assert module._task_tracking_loader is None
+
+        with patch.object(module, "log") as mock_log:
+            module._compute_sampled_task_auroc()
+
+        mock_log.assert_not_called()
+
+    def test_macro_average_win_tie_loss(self):
+        # Task 10: neg logit -10 (~0 prob), pos logit +10 (~1 prob) -> win  (indicator 1.0)
+        # Task 20: neg logit +10 (~1 prob), pos logit -10 (~0 prob) -> loss (indicator 0.0)
+        # Task 30: neg logit  0.0,          pos logit  0.0 (tie)    -> tie  (indicator 0.5)
+        queries = [10, 10, 20, 20, 30, 30]
+        durations = [7.0] * 6
+        occurs = [0, 1, 0, 1, 0, 1]
+        logits = [-10.0, 10.0, 10.0, -10.0, 0.0, 0.0]
+
+        module = EveryQueryLightningModule(model=_StubOccursModel(logits))
+        module._task_tracking_loader = [_make_tracking_batch(queries, durations, occurs)]
+
+        logged = {}
+        with patch.object(
+            module, "log", side_effect=lambda name, value, **kw: logged.__setitem__(name, value)
+        ):
+            module._compute_sampled_task_auroc()
+
+        assert logged["tuning/occurs_auroc_macro_sampled_n_tasks"] == 3.0
+        assert logged["tuning/occurs_auroc_macro_sampled"] == pytest.approx((1.0 + 0.0 + 0.5) / 3)
+
+    def test_tasks_missing_a_class_are_dropped(self):
+        # Task 10 has both classes (win); task 20 only has a positive row and is dropped.
+        queries = [10, 10, 20]
+        durations = [7.0, 7.0, 7.0]
+        occurs = [0, 1, 1]
+        logits = [-10.0, 10.0, 0.0]
+
+        module = EveryQueryLightningModule(model=_StubOccursModel(logits))
+        module._task_tracking_loader = [_make_tracking_batch(queries, durations, occurs)]
+
+        logged = {}
+        with patch.object(
+            module, "log", side_effect=lambda name, value, **kw: logged.__setitem__(name, value)
+        ):
+            module._compute_sampled_task_auroc()
+
+        assert logged["tuning/occurs_auroc_macro_sampled_n_tasks"] == 1.0
+        assert logged["tuning/occurs_auroc_macro_sampled"] == pytest.approx(1.0)
+
+    def test_restores_model_train_mode(self):
+        module = EveryQueryLightningModule(model=_StubOccursModel([0.0, 0.0]))
+        module.model.train()
+        module._task_tracking_loader = [_make_tracking_batch([10, 10], [7.0, 7.0], [0, 1])]
+
+        with patch.object(module, "log"):
+            module._compute_sampled_task_auroc()
+
+        assert module.model.training is True

--- a/tests/test_lightning_logic.py
+++ b/tests/test_lightning_logic.py
@@ -9,6 +9,7 @@ from functools import partial
 
 import pytest
 import torch
+from meds_torchdata import MEDSTorchDataConfig
 
 from every_query.data.dataset import EveryQueryBatch
 from every_query.model import EveryQueryOutput
@@ -210,3 +211,40 @@ class TestSampledTaskAurocTracking:
         logits = [-10.0, 10.0, 10.0, -10.0]
 
         assert self._run(_StubOccursModel(logits), [batch]) == {}
+
+
+class TestCallbackHydraWiring:
+    """The ``trainer.callbacks.task_auroc_tracking`` block ships commented out, so nothing else ever resolves
+    its ``_target_`` paths or constructor args.
+
+    This mirrors that block and instantiates it so a renamed arg, typo'd import path, or MEDSTorchDataConfig
+    drift fails a test instead of silently passing CI.
+    """
+
+    def test_instantiates_callback_and_nested_config(self, tmp_path):
+        import hydra
+
+        # MEDSTorchDataConfig validates that both dirs exist.
+        cohort_dir = tmp_path / "cohort"
+        cohort_dir.mkdir()
+        tracking_dir = tmp_path / "tracking"
+        tracking_dir.mkdir()
+
+        cfg = {
+            "_target_": "every_query.model.task_auroc_callback.TaskAurocTrackingCallback",
+            "batch_size": 256,
+            "config": {
+                "_target_": "meds_torchdata.MEDSTorchDataConfig",
+                "tensorized_cohort_dir": str(cohort_dir),
+                "task_labels_dir": str(tracking_dir),
+                "static_inclusion_mode": "omit",
+                "seq_sampling_strategy": "to_end",
+                "max_seq_len": 256,
+            },
+        }
+
+        callback = hydra.utils.instantiate(cfg)
+
+        assert isinstance(callback, TaskAurocTrackingCallback)
+        assert callback.batch_size == 256
+        assert isinstance(callback.config, MEDSTorchDataConfig)

--- a/tests/test_sample_task_tracking_pairs_cli.py
+++ b/tests/test_sample_task_tracking_pairs_cli.py
@@ -1,0 +1,130 @@
+"""Subprocess integration test for ``EQ_sample_task_tracking_pairs``.
+
+Chains onto ``EQ_generate_evaluation_tasks(split=tuning)`` (already covered by
+``test_generate_evaluation_tasks_cli.py``) to exercise the second, new stage that
+compacts a dense per-shard label grid down to one positive + one negative row per
+``(query, duration_days)`` task — the input ``EveryQueryLightningModule``'s optional
+task-tracking dataloader reads.
+
+Checks:
+1. Invokes both CLIs in sequence against the session's preprocessed cohort.
+2. Verifies the output parquet is ``TaskQuerySchema``-conformant.
+3. Verifies the pairing invariant: every surviving task has exactly one ``True`` row
+   and one ``False`` row (when the demo cohort produces any tasks at all — like the
+   sibling evaluation-tasks test, this is not guaranteed to be non-empty).
+4. Verifies determinism — two runs with the same seed produce identical output.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import polars as pl
+import pyarrow.parquet as pq
+
+from conftest import run_and_check
+from every_query.data.schema import TaskQuerySchema
+
+if TYPE_CHECKING:
+    from pathlib import Path
+
+
+def _generate_tuning_eval_labels(intermediate: Path, out_dir: Path, seed: int) -> Path:
+    run_and_check(
+        [
+            "EQ_generate_evaluation_tasks",
+            f"data_dir={intermediate!s}",
+            f"out_dir={out_dir!s}",
+            "split=tuning",
+            "input_shard=0",
+            "prediction_times_per_subject=3",
+            "min_context_per_subject=1",
+            "query_codes=[HR,TEMP]",
+            "durations=[1,7,30]",
+            f"seed={seed}",
+        ],
+        timeout=120.0,
+    )
+    return out_dir / "eval"
+
+
+def test_eq_sample_task_tracking_pairs_end_to_end(
+    eq_preprocessed_dataset: Path,
+    tmp_path: Path,
+) -> None:
+    """CLI writes a TaskQuerySchema parquet with exactly one pos + one neg row per surviving task."""
+    intermediate = eq_preprocessed_dataset.parent / "intermediate"
+    eval_out = tmp_path / "eval_tasks"
+    tracking_out = tmp_path / "task_tracking"
+
+    eval_labels_dir = _generate_tuning_eval_labels(intermediate, eval_out, seed=42)
+
+    run_and_check(
+        [
+            "EQ_sample_task_tracking_pairs",
+            f"eval_labels_dir={eval_labels_dir!s}",
+            f"out_dir={tracking_out!s}",
+            "split=tuning",
+            "seed=1",
+        ],
+        timeout=60.0,
+    )
+
+    pairs_fp = tracking_out / "tuning" / "0.parquet"
+    assert pairs_fp.is_file(), f"expected {pairs_fp} to exist"
+
+    TaskQuerySchema.align(pq.read_table(pairs_fp))
+
+    pairs = pl.read_parquet(pairs_fp)
+    assert pairs[TaskQuerySchema.boolean_value_name].null_count() == 0, (
+        "task-tracking pairs should never contain censored (null boolean_value) rows"
+    )
+
+    if pairs.height > 0:
+        task_cols = [TaskQuerySchema.query_name, TaskQuerySchema.duration_days_name]
+        per_task = pairs.group_by(task_cols).agg(
+            n_rows=pl.len(),
+            n_classes=pl.col(TaskQuerySchema.boolean_value_name).n_unique(),
+        )
+        assert (per_task["n_rows"] == 2).all(), (
+            f"every tracked task should contribute exactly 2 rows, got: {per_task}"
+        )
+        assert (per_task["n_classes"] == 2).all(), (
+            f"every tracked task should have one positive and one negative row, got: {per_task}"
+        )
+
+
+def test_eq_sample_task_tracking_pairs_deterministic(
+    eq_preprocessed_dataset: Path,
+    tmp_path: Path,
+) -> None:
+    """Two runs with the same seed produce equivalent parquet contents (row-for-row)."""
+    intermediate = eq_preprocessed_dataset.parent / "intermediate"
+    eval_out = tmp_path / "eval_tasks"
+    eval_labels_dir = _generate_tuning_eval_labels(intermediate, eval_out, seed=7)
+
+    out_a = tmp_path / "a"
+    out_b = tmp_path / "b"
+    for out in (out_a, out_b):
+        run_and_check(
+            [
+                "EQ_sample_task_tracking_pairs",
+                f"eval_labels_dir={eval_labels_dir!s}",
+                f"out_dir={out!s}",
+                "split=tuning",
+                "seed=3",
+            ],
+            timeout=60.0,
+        )
+
+    sort_cols = [
+        TaskQuerySchema.subject_id_name,
+        TaskQuerySchema.prediction_time_name,
+        TaskQuerySchema.query_name,
+        TaskQuerySchema.duration_days_name,
+    ]
+    df_a = pl.read_parquet(out_a / "tuning" / "0.parquet").sort(sort_cols)
+    df_b = pl.read_parquet(out_b / "tuning" / "0.parquet").sort(sort_cols)
+    assert df_a.equals(df_b), (
+        "EQ_sample_task_tracking_pairs should be deterministic in (seed, split, eval_labels_dir)"
+    )


### PR DESCRIPTION
## Summary
This PR introduces a lightweight mechanism for tracking per-task AUROC during training without scoring the entire tuning split. It adds a new pipeline stage (`EQ_sample_task_tracking_pairs`) that pre-computes one positive and one negative example per task, and integrates task-level AUROC computation into the Lightning training loop.

## Key Changes

- **New module: `sample_task_tracking_pairs.py`**
  - Consumes dense per-shard label parquets from `EQ_generate_evaluation_tasks` (typically `split=tuning`)
  - Samples exactly one positive and one negative row per `(query, duration_days)` task
  - Outputs a compact single parquet (2 rows per surviving task) for efficient repeated reads
  - Drops tasks missing either class (AUROC undefined for single-class tasks)
  - Uses deterministic seeding to ensure reproducibility

- **Lightning module enhancements (`lightning_module.py`)**
  - Added optional `task_auroc_tracking` configuration parameter
  - Implemented `_compute_sampled_task_auroc()` method that:
    - Scores the fixed task-tracking dataloader every validation epoch
    - Computes per-task AUROC as a win/tie/loss indicator from one pos/neg pair
    - Macro-averages indicators across tasks to estimate per-task-averaged AUROC
    - Logs `tuning/occurs_auroc_macro_sampled` and task count metrics
  - Added `_move_batch_to_device()` helper for generic tensor field movement
  - Integrated tracking computation into `on_validation_epoch_end()`

- **Configuration and documentation**
  - Added `sample_task_tracking_pairs_config.yaml` with required/optional parameters
  - Updated `train/configs/config.yaml` with commented example of task tracking setup
  - Updated `generate_tasks/README.md` with pipeline diagram and usage examples
  - Registered `EQ_sample_task_tracking_pairs` CLI entry point in `pyproject.toml`

- **Comprehensive test coverage (`test_sample_task_tracking_pairs_cli.py`, `test_lightning_logic.py`)**
  - End-to-end CLI integration test chaining `EQ_generate_evaluation_tasks` → `EQ_sample_task_tracking_pairs`
  - Schema conformance validation
  - Pairing invariant verification (exactly one True + one False per task)
  - Determinism verification across runs
  - Unit tests for sampled AUROC computation with stubbed model
  - Tests for win/tie/loss indicator calculation and macro-averaging
  - Tests for incomplete task filtering and model training mode restoration

## Implementation Details

- **Deterministic sampling**: Uses hash-based ranking within (task, class) groups to avoid positional bias, mirroring the approach in `sample_evaluation_tasks`
- **Unbiased AUROC estimation**: Single-pair AUROC estimate `P(score(pos) > score(neg))` is unbiased but high-variance; macro-averaging across tasks provides a cheap alternative to scoring the full tuning split
- **No-op when unconfigured**: Feature is entirely optional; leaving `task_auroc_tracking` unset disables it without affecting loss-driven checkpointing or early stopping
- **Efficient dataloader**: Built once in `setup()` and reused across validation epochs since tracking labels are offline-generated and fixed

https://claude.ai/code/session_01R9YdMeThQJUujVz6GYK9Fy