### PR TITLE
Extract sampled macro-AUROC into a torchmetrics Metric

### DIFF
--- a/src/every_query/model/README.md
+++ b/src/every_query/model/README.md
@@ -12,6 +12,11 @@ shape, no Hydra entry points, no configs.
     PyTorch Lightning with `training_step` / `validation_step` / `predict_step`. Shared between
     training and inference — the same LightningModule's `predict_step` is what `predict/` will
     use at inference time.
+- **`task_auroc_callback.py`** — `TaskAurocTrackingCallback`. A Lightning `Callback` owning the
+    dataloader over the offline-sampled pos/neg tracking pairs, plus the forward pass that scores
+    them each validation epoch. Scores on rank 0 only.
+- **`sampled_macro_auroc.py`** — `SampledMacroAUROC`. The `torchmetrics.Metric` the callback feeds:
+    accumulates scored rows and macro-averages the per-task win/tie/loss indicator.
 
 Call through the package so stage submodules don't need to know the file layout:
 

--- a/src/every_query/model/sampled_macro_auroc.py
+++ b/src/every_query/model/sampled_macro_auroc.py
@@ -12,6 +12,7 @@ This class only owns the accumulate-and-score half.
 
 import torch
 from torchmetrics import Metric
+from torchmetrics.utilities.data import dim_zero_cat
 
 from every_query.data.dataset import EveryQueryBatch
 
@@ -52,6 +53,8 @@ class SampledMacroAUROC(Metric):
         super().__init__(sync_on_compute=False)
         # add_state defaults to persistent=False, so none of this lands in state_dict and
         # existing checkpoints are unaffected.
+        # dist_reduce_fx is declared for shape-correctness only — it never runs, because
+        # sync_on_compute=False above means this metric is never synced across ranks.
         self.add_state("query", default=[], dist_reduce_fx="cat")
         self.add_state("duration", default=[], dist_reduce_fx="cat")
         self.add_state("label", default=[], dist_reduce_fx="cat")
@@ -100,12 +103,14 @@ class SampledMacroAUROC(Metric):
             (1.0, 1)
         """
         probs_by_task: dict[tuple[int, float], dict[int, float]] = {}
-        if self.query:
+        # len() rather than truthiness: after a _sync_dist these states are tensors, not lists,
+        # and `if self.query:` on a multi-element tensor raises.
+        if len(self.query):
             rows = zip(
-                torch.cat(self.query).tolist(),
-                torch.cat(self.duration).tolist(),
-                torch.cat(self.label).tolist(),
-                torch.cat(self.prob).tolist(),
+                dim_zero_cat(self.query).tolist(),
+                dim_zero_cat(self.duration).tolist(),
+                dim_zero_cat(self.label).tolist(),
+                dim_zero_cat(self.prob).tolist(),
                 strict=True,
             )
             for q, duration, label, prob in rows:

--- a/src/every_query/model/sampled_macro_auroc.py
+++ b/src/every_query/model/sampled_macro_auroc.py
@@ -1,0 +1,125 @@
+"""Macro-averaged sampled AUROC as a ``torchmetrics.Metric``.
+
+A task's AUROC equals ``P(score(pos) > score(neg))`` for a random pos/neg pair, so the
+win/tie/loss indicator on a single offline-sampled pair is an unbiased (high-variance)
+estimate of it.  Macro-averaging those indicators across tasks estimates macro AUROC at
+``O(n_tasks)`` forward examples instead of ``O(split size)``.
+
+The pairs are fed in by ``TaskAurocTrackingCallback``, which owns the dataloader over the
+offline-sampled pair set (see ``every_query.generate_tasks.sample_task_tracking_pairs``).
+This class only owns the accumulate-and-score half.
+"""
+
+import torch
+from torchmetrics import Metric
+
+from every_query.data.dataset import EveryQueryBatch
+
+
+class SampledMacroAUROC(Metric):
+    """Accumulate scored pos/neg rows, then macro-average the per-task win/tie/loss indicator.
+
+    A task is keyed by ``(query, duration_days)`` and contributes one indicator only if both a
+    positive and a negative row were seen for it; tasks missing a class are dropped.
+
+    Examples:
+        >>> m = SampledMacroAUROC()
+        >>> query = torch.tensor([10, 10, 20, 20, 30, 30])
+        >>> duration = torch.tensor([7.0] * 6)
+        >>> occurs = torch.tensor([0, 1, 0, 1, 0, 1])
+        >>> probs = torch.tensor([0.1, 0.9, 0.9, 0.1, 0.5, 0.5])
+        >>> m.update(query, duration, occurs, probs)
+        >>> out = m.compute()
+
+        Task 10 wins (1.0), task 20 loses (0.0), task 30 ties (0.5):
+
+        >>> float(out["auroc"]) == (1.0 + 0.0 + 0.5) / 3
+        True
+        >>> int(out["n_tasks"])
+        3
+
+        With nothing usable, ``auroc`` is NaN and callers skip logging on ``n_tasks == 0``:
+
+        >>> out = SampledMacroAUROC().compute()
+        >>> bool(out["auroc"].isnan()), int(out["n_tasks"])
+        (True, 0)
+    """
+
+    def __init__(self):
+        # sync_on_compute=False is load-bearing: the tracking pair set is tiny and identical on
+        # every rank, so TaskAurocTrackingCallback scores it on rank 0 only.  A syncing compute()
+        # would enter a collective that only rank 0 reaches, and deadlock.
+        super().__init__(sync_on_compute=False)
+        # add_state defaults to persistent=False, so none of this lands in state_dict and
+        # existing checkpoints are unaffected.
+        self.add_state("query", default=[], dist_reduce_fx="cat")
+        self.add_state("duration", default=[], dist_reduce_fx="cat")
+        self.add_state("label", default=[], dist_reduce_fx="cat")
+        self.add_state("prob", default=[], dist_reduce_fx="cat")
+
+    def update(
+        self,
+        query: torch.Tensor,
+        duration_days: torch.Tensor,
+        occurs: torch.Tensor,
+        occurs_probs: torch.Tensor,
+    ) -> None:
+        """Record one batch of scored rows, dropping out-of-vocab queries.
+
+        Out-of-vocab query codes all encode to ``PAD_INDEX``, so distinct OOV tasks would
+        otherwise collide onto one key and corrupt the estimate.
+
+        Examples:
+            >>> m = SampledMacroAUROC()
+            >>> m.update(
+            ...     torch.tensor([0, 11]), torch.tensor([7.0, 7.0]),
+            ...     torch.tensor([1, 1]), torch.tensor([0.5, 0.5]),
+            ... )
+            >>> m.query[0].tolist()
+            [11]
+        """
+        keep = query != EveryQueryBatch.PAD_INDEX
+        self.query.append(query[keep].cpu())
+        self.duration.append(duration_days[keep].cpu())
+        self.label.append(occurs[keep].cpu())
+        self.prob.append(occurs_probs[keep].cpu())
+
+    def compute(self) -> dict[str, torch.Tensor]:
+        """Macro-average the per-task indicator over tasks that saw both classes.
+
+        Examples:
+            Tasks missing a class are excluded — task 20 here has only a positive row:
+
+            >>> m = SampledMacroAUROC()
+            >>> m.update(
+            ...     torch.tensor([10, 10, 20]), torch.tensor([7.0, 7.0, 7.0]),
+            ...     torch.tensor([0, 1, 1]), torch.tensor([0.1, 0.9, 0.5]),
+            ... )
+            >>> out = m.compute()
+            >>> float(out["auroc"]), int(out["n_tasks"])
+            (1.0, 1)
+        """
+        probs_by_task: dict[tuple[int, float], dict[int, float]] = {}
+        if self.query:
+            rows = zip(
+                torch.cat(self.query).tolist(),
+                torch.cat(self.duration).tolist(),
+                torch.cat(self.label).tolist(),
+                torch.cat(self.prob).tolist(),
+                strict=True,
+            )
+            for q, duration, label, prob in rows:
+                probs_by_task.setdefault((q, duration), {})[int(label)] = prob
+
+        indicators = []
+        for task_probs in probs_by_task.values():
+            if 0 not in task_probs or 1 not in task_probs:
+                continue
+            pos, neg = task_probs[1], task_probs[0]
+            indicators.append(1.0 if pos > neg else 0.0 if pos < neg else 0.5)
+
+        auroc = sum(indicators) / len(indicators) if indicators else float("nan")
+        return {
+            "auroc": torch.tensor(auroc),
+            "n_tasks": torch.tensor(float(len(indicators))),
+        }

--- a/src/every_query/model/sampled_macro_auroc.py
+++ b/src/every_query/model/sampled_macro_auroc.py
@@ -114,7 +114,17 @@ class SampledMacroAUROC(Metric):
                 strict=True,
             )
             for q, duration, label, prob in rows:
-                probs_by_task.setdefault((q, duration), {})[int(label)] = prob
+                task_probs = probs_by_task.setdefault((q, duration), {})
+                if int(label) in task_probs:
+                    raise ValueError(
+                        f"Task {(q, duration)} saw more than one row with occurs={int(label)}. "
+                        "This metric keys one probability per (task, class), so extra rows would "
+                        "be silently dropped and the estimate would reflect only the last one. "
+                        "sample_task_tracking_pairs emits exactly one positive and one negative "
+                        "per task; if that changed to k pairs, group the probs into lists here "
+                        "and average the indicator over the pos x neg combinations."
+                    )
+                task_probs[int(label)] = prob
 
         indicators = []
         for task_probs in probs_by_task.values():

--- a/src/every_query/model/sampled_macro_auroc.py
+++ b/src/every_query/model/sampled_macro_auroc.py
@@ -5,6 +5,10 @@ win/tie/loss indicator on a single offline-sampled pair is an unbiased (high-var
 estimate of it.  Macro-averaging those indicators across tasks estimates macro AUROC at
 ``O(n_tasks)`` forward examples instead of ``O(split size)``.
 
+Scores are compared, never calibrated, so any monotonic transform of the model output works.
+The callback passes raw logits deliberately: ``sigmoid`` saturates to exactly 1.0 (logit >= 17
+in fp32, >= 6.5 in bf16), which would collapse a correctly-ranked pair into a tie.
+
 The pairs are fed in by ``TaskAurocTrackingCallback``, which owns the dataloader over the
 offline-sampled pair set (see ``every_query.generate_tasks.sample_task_tracking_pairs``).
 This class only owns the accumulate-and-score half.
@@ -28,8 +32,8 @@ class SampledMacroAUROC(Metric):
         >>> query = torch.tensor([10, 10, 20, 20, 30, 30])
         >>> duration = torch.tensor([7.0] * 6)
         >>> occurs = torch.tensor([0, 1, 0, 1, 0, 1])
-        >>> probs = torch.tensor([0.1, 0.9, 0.9, 0.1, 0.5, 0.5])
-        >>> m.update(query, duration, occurs, probs)
+        >>> scores = torch.tensor([0.1, 0.9, 0.9, 0.1, 0.5, 0.5])
+        >>> m.update(query, duration, occurs, scores)
         >>> out = m.compute()
 
         Task 10 wins (1.0), task 20 loses (0.0), task 30 ties (0.5):
@@ -58,16 +62,19 @@ class SampledMacroAUROC(Metric):
         self.add_state("query", default=[], dist_reduce_fx="cat")
         self.add_state("duration", default=[], dist_reduce_fx="cat")
         self.add_state("label", default=[], dist_reduce_fx="cat")
-        self.add_state("prob", default=[], dist_reduce_fx="cat")
+        self.add_state("score", default=[], dist_reduce_fx="cat")
 
     def update(
         self,
         query: torch.Tensor,
         duration_days: torch.Tensor,
         occurs: torch.Tensor,
-        occurs_probs: torch.Tensor,
+        occurs_scores: torch.Tensor,
     ) -> None:
         """Record one batch of scored rows, dropping out-of-vocab queries.
+
+        ``occurs_scores`` is any monotonic score -- the callback passes logits.  Only the
+        pos-vs-neg comparison is used, so calibration is irrelevant here.
 
         Out-of-vocab query codes all encode to ``PAD_INDEX``, so distinct OOV tasks would
         otherwise collide onto one key and corrupt the estimate.
@@ -85,7 +92,7 @@ class SampledMacroAUROC(Metric):
         self.query.append(query[keep].cpu())
         self.duration.append(duration_days[keep].cpu())
         self.label.append(occurs[keep].cpu())
-        self.prob.append(occurs_probs[keep].cpu())
+        self.score.append(occurs_scores[keep].cpu())
 
     def compute(self) -> dict[str, torch.Tensor]:
         """Macro-average the per-task indicator over tasks that saw both classes.
@@ -102,7 +109,7 @@ class SampledMacroAUROC(Metric):
             >>> float(out["auroc"]), int(out["n_tasks"])
             (1.0, 1)
         """
-        probs_by_task: dict[tuple[int, float], dict[int, float]] = {}
+        scores_by_task: dict[tuple[int, float], dict[int, float]] = {}
         # len() rather than truthiness: after a _sync_dist these states are tensors, not lists,
         # and `if self.query:` on a multi-element tensor raises.
         if len(self.query):
@@ -110,27 +117,27 @@ class SampledMacroAUROC(Metric):
                 dim_zero_cat(self.query).tolist(),
                 dim_zero_cat(self.duration).tolist(),
                 dim_zero_cat(self.label).tolist(),
-                dim_zero_cat(self.prob).tolist(),
+                dim_zero_cat(self.score).tolist(),
                 strict=True,
             )
-            for q, duration, label, prob in rows:
-                task_probs = probs_by_task.setdefault((q, duration), {})
-                if int(label) in task_probs:
+            for q, duration, label, score in rows:
+                task_scores = scores_by_task.setdefault((q, duration), {})
+                if int(label) in task_scores:
                     raise ValueError(
                         f"Task {(q, duration)} saw more than one row with occurs={int(label)}. "
-                        "This metric keys one probability per (task, class), so extra rows would "
-                        "be silently dropped and the estimate would reflect only the last one. "
+                        "This metric keys one score per (task, class), so extra rows would be "
+                        "silently dropped and the estimate would reflect only the last one. "
                         "sample_task_tracking_pairs emits exactly one positive and one negative "
-                        "per task; if that changed to k pairs, group the probs into lists here "
+                        "per task; if that changed to k pairs, group the scores into lists here "
                         "and average the indicator over the pos x neg combinations."
                     )
-                task_probs[int(label)] = prob
+                task_scores[int(label)] = score
 
         indicators = []
-        for task_probs in probs_by_task.values():
-            if 0 not in task_probs or 1 not in task_probs:
+        for task_scores in scores_by_task.values():
+            if 0 not in task_scores or 1 not in task_scores:
                 continue
-            pos, neg = task_probs[1], task_probs[0]
+            pos, neg = task_scores[1], task_scores[0]
             indicators.append(1.0 if pos > neg else 0.0 if pos < neg else 0.5)
 
         auroc = sum(indicators) / len(indicators) if indicators else float("nan")

--- a/src/every_query/model/task_auroc_callback.py
+++ b/src/every_query/model/task_auroc_callback.py
@@ -3,14 +3,15 @@
 Scores a fixed, offline-sampled parquet of one positive + one negative row per
 ``(query, duration_days)`` task (see
 ``every_query.generate_tasks.sample_task_tracking_pairs``) every validation pass and logs
-``tuning/occurs_auroc_macro_sampled``.  Because a task's AUROC equals
-``P(score(pos) > score(neg))`` for a random pos/neg pair, the win/tie/loss indicator on that
-one pair is an unbiased (high-variance) estimate; macro-averaging across tasks estimates
-macro AUROC at ``O(n_tasks)`` forward examples instead of ``O(tuning-split size)``.
+``tuning/occurs_auroc_macro_sampled``.  The scoring itself lives in
+``every_query.model.sampled_macro_auroc.SampledMacroAUROC``; this callback owns the
+dataloader over the pair set and the forward pass that feeds it.
 
 Lives as a ``Callback`` (not on the ``LightningModule``) so it wires in via
-``trainer.callbacks`` like the other cross-cutting concerns, and so its typed ``__init__``
-fails fast on a misconfigured hydra block — nothing here is checkpoint-relevant.
+``trainer.callbacks`` like the other cross-cutting concerns, and because the pairs are a
+separate dataset over a separate ``task_labels_dir`` — a ``LightningModule`` restored by
+``load_from_checkpoint`` reconstructs from hparams alone and could not supply that path.
+Nothing here is checkpoint-relevant.
 """
 
 import logging
@@ -22,7 +23,8 @@ from meds import tuning_split
 from meds_torchdata import MEDSTorchDataConfig
 from torch.utils.data import DataLoader
 
-from every_query.data.dataset import EveryQueryBatch, EveryQueryPytorchDataset
+from every_query.data.dataset import EveryQueryPytorchDataset
+from every_query.model.sampled_macro_auroc import SampledMacroAUROC
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +46,7 @@ class TaskAurocTrackingCallback(Callback):
         super().__init__()
         self.config = config
         self.batch_size = batch_size
+        self.metric = SampledMacroAUROC()
         self._loader: DataLoader | None = None
 
     def setup(self, trainer, pl_module, stage=None):
@@ -97,40 +100,37 @@ class TaskAurocTrackingCallback(Callback):
         Precondition: called inside Lightning's eval loop, so ``model`` is already in eval mode
         (``no_grad`` covers the numerics regardless).
         """
-        probs_by_task: dict[tuple[int, float], dict[int, float]] = {}
-        with torch.no_grad():
-            for batch in self._loader:
-                batch = move_data_to_device(batch, device)
-                _, outputs = model(batch)
-                # Squeeze only dim 1 so a trailing size-1 batch doesn't collapse to a 0-d scalar.
-                probs = outputs.occurs_logits.detach().cpu().squeeze(1).sigmoid().float().tolist()
-                queries = batch.query.detach().cpu().tolist()
-                durations = batch.duration_days.detach().cpu().tolist()
-                labels = batch.occurs.detach().cpu().tolist()
-                for query, duration, label, prob in zip(queries, durations, labels, probs, strict=True):
-                    if query == EveryQueryBatch.PAD_INDEX:
-                        continue  # OOV/pad — see setup() warning
-                    probs_by_task.setdefault((query, duration), {})[int(label)] = prob
+        try:
+            with torch.no_grad():
+                for batch in self._loader:
+                    batch = move_data_to_device(batch, device)
+                    _, outputs = model(batch)
+                    # Squeeze only dim 1 so a trailing size-1 batch doesn't collapse to a 0-d scalar.
+                    probs = outputs.occurs_logits.detach().squeeze(1).sigmoid().float()
+                    self.metric.update(
+                        query=batch.query.detach(),
+                        duration_days=batch.duration_days.detach(),
+                        occurs=batch.occurs.detach(),
+                        occurs_probs=probs,
+                    )
 
-        indicators = []
-        for task_probs in probs_by_task.values():
-            if 1 not in task_probs or 0 not in task_probs:
-                continue
-            pos_prob, neg_prob = task_probs[1], task_probs[0]
-            indicators.append(1.0 if pos_prob > neg_prob else 0.0 if pos_prob < neg_prob else 0.5)
+            scores = self.metric.compute()
+            if scores["n_tasks"] == 0:
+                return
 
-        if not indicators:
-            return
-
-        log_fn(
-            "tuning/occurs_auroc_macro_sampled",
-            sum(indicators) / len(indicators),
-            rank_zero_only=True,
-            sync_dist=False,
-        )
-        log_fn(
-            "tuning/occurs_auroc_macro_sampled_n_tasks",
-            float(len(indicators)),
-            rank_zero_only=True,
-            sync_dist=False,
-        )
+            log_fn(
+                "tuning/occurs_auroc_macro_sampled",
+                float(scores["auroc"]),
+                rank_zero_only=True,
+                sync_dist=False,
+            )
+            log_fn(
+                "tuning/occurs_auroc_macro_sampled_n_tasks",
+                float(scores["n_tasks"]),
+                rank_zero_only=True,
+                sync_dist=False,
+            )
+        finally:
+            # Reset in `finally` so a mid-epoch failure can't leak this epoch's rows into the next
+            # validation pass and silently skew the estimate.
+            self.metric.reset()

--- a/src/every_query/model/task_auroc_callback.py
+++ b/src/every_query/model/task_auroc_callback.py
@@ -106,27 +106,30 @@ class TaskAurocTrackingCallback(Callback):
                     batch = move_data_to_device(batch, device)
                     _, outputs = model(batch)
                     # Squeeze only dim 1 so a trailing size-1 batch doesn't collapse to a 0-d scalar.
-                    probs = outputs.occurs_logits.detach().squeeze(1).sigmoid().float()
+                    # Rank on logits, not sigmoid(logits): AUROC only compares scores, and sigmoid
+                    # saturates to exactly 1.0 (logit >= 17 in fp32, >= 6.5 in bf16), which turns a
+                    # correctly-ranked pair into a spurious tie and drags the estimate toward 0.5.
+                    scores = outputs.occurs_logits.detach().squeeze(1).float()
                     self.metric.update(
                         query=batch.query.detach(),
                         duration_days=batch.duration_days.detach(),
                         occurs=batch.occurs.detach(),
-                        occurs_probs=probs,
+                        occurs_scores=scores,
                     )
 
-            scores = self.metric.compute()
-            if scores["n_tasks"] == 0:
+            result = self.metric.compute()
+            if result["n_tasks"] == 0:
                 return
 
             log_fn(
                 "tuning/occurs_auroc_macro_sampled",
-                float(scores["auroc"]),
+                float(result["auroc"]),
                 rank_zero_only=True,
                 sync_dist=False,
             )
             log_fn(
                 "tuning/occurs_auroc_macro_sampled_n_tasks",
-                float(scores["n_tasks"]),
+                float(result["n_tasks"]),
                 rank_zero_only=True,
                 sync_dist=False,
             )

--- a/tests/test_lightning_logic.py
+++ b/tests/test_lightning_logic.py
@@ -280,15 +280,14 @@ class TestTaskAurocCallbackLogging:
         assert logged["tuning/occurs_auroc_macro_sampled"] == pytest.approx(0.5)
 
     def test_state_does_not_leak_across_calls(self):
-        # The callback resets the metric each pass; a second identical pass must log the same
-        # n_tasks rather than double-counting.
-        batch = _make_tracking_batch([10, 10], [7.0, 7.0], [0, 1])
+        # Each pass scores a *different* task, so rows leaked from pass 1 would surface as
+        # n_tasks == 2 on pass 2.  (Re-scoring the same task would pass either way.)
         cb = TaskAurocTrackingCallback(config=None)
-        cb._loader = [batch]
         logged = {}
         log_fn = lambda name, value, **kw: logged.__setitem__(name, value)  # noqa: E731
 
-        for _ in range(2):
+        for query in (10, 20):
+            cb._loader = [_make_tracking_batch([query, query], [7.0, 7.0], [0, 1])]
             cb._compute_and_log(_StubOccursModel([-10.0, 10.0]), torch.device("cpu"), log_fn)
 
         assert logged["tuning/occurs_auroc_macro_sampled_n_tasks"] == 1.0

--- a/tests/test_lightning_logic.py
+++ b/tests/test_lightning_logic.py
@@ -235,6 +235,19 @@ class TestSampledMacroAUROC:
         assert out["n_tasks"] == 1.0
         assert float(out["auroc"]) == pytest.approx(1.0)
 
+    def test_raises_on_duplicate_row_for_a_task_class(self):
+        # Guards the coupling to sample_task_tracking_pairs' one-pos-one-neg-per-task output:
+        # keying one prob per (task, class) would silently drop all but the last row.
+        m = SampledMacroAUROC()
+        m.update(
+            query=torch.tensor([10, 10, 10, 10], dtype=torch.long),
+            duration_days=torch.tensor([7.0, 7.0, 7.0, 7.0]),
+            occurs=torch.tensor([0, 1, 0, 1], dtype=torch.long),
+            occurs_probs=torch.tensor([0.1, 0.9, 0.8, 0.2]),
+        )
+        with pytest.raises(ValueError, match="more than one row"):
+            m.compute()
+
     def test_reset_clears_state(self):
         m = SampledMacroAUROC()
         m.update(

--- a/tests/test_lightning_logic.py
+++ b/tests/test_lightning_logic.py
@@ -133,14 +133,15 @@ class _StubOccursModel(torch.nn.Module):
     enqueued them) so tests can pin exact per-row probabilities without a real transformer.
     """
 
-    def __init__(self, logits: list[float]):
+    def __init__(self, logits: list[float], dtype: torch.dtype = torch.float32):
         super().__init__()
         self._dummy_param = torch.nn.Parameter(torch.zeros(1))
         self._logits = list(logits)
+        self._dtype = dtype
 
     def forward(self, batch: EveryQueryBatch):
         n = batch.query.shape[0]
-        row_logits = torch.tensor(self._logits[:n], dtype=torch.float32).unsqueeze(1)
+        row_logits = torch.tensor(self._logits[:n], dtype=self._dtype).unsqueeze(1)
         self._logits = self._logits[n:]
         outputs = EveryQueryOutput(last_hidden_state=None, occurs_logits=row_logits)
         return torch.tensor(0.0), outputs
@@ -168,14 +169,14 @@ class TestSampledMacroAUROC:
     """
 
     @staticmethod
-    def _scored(queries, durations, occurs, probs):
+    def _scored(queries, durations, occurs, scores):
         """Feed one batch of rows into a fresh metric and return its ``compute()`` dict."""
         m = SampledMacroAUROC()
         m.update(
             query=torch.tensor(queries, dtype=torch.long),
             duration_days=torch.tensor(durations, dtype=torch.float32),
             occurs=torch.tensor(occurs, dtype=torch.long),
-            occurs_probs=torch.tensor(probs, dtype=torch.float32),
+            occurs_scores=torch.tensor(scores, dtype=torch.float32),
         )
         return m.compute()
 
@@ -228,7 +229,7 @@ class TestSampledMacroAUROC:
                 query=torch.tensor([10], dtype=torch.long),
                 duration_days=torch.tensor([7.0]),
                 occurs=torch.tensor([occurs], dtype=torch.long),
-                occurs_probs=torch.tensor([prob]),
+                occurs_scores=torch.tensor([prob]),
             )
 
         out = m.compute()
@@ -243,7 +244,7 @@ class TestSampledMacroAUROC:
             query=torch.tensor([10, 10, 10, 10], dtype=torch.long),
             duration_days=torch.tensor([7.0, 7.0, 7.0, 7.0]),
             occurs=torch.tensor([0, 1, 0, 1], dtype=torch.long),
-            occurs_probs=torch.tensor([0.1, 0.9, 0.8, 0.2]),
+            occurs_scores=torch.tensor([0.1, 0.9, 0.8, 0.2]),
         )
         with pytest.raises(ValueError, match="more than one row"):
             m.compute()
@@ -254,7 +255,7 @@ class TestSampledMacroAUROC:
             query=torch.tensor([10, 10], dtype=torch.long),
             duration_days=torch.tensor([7.0, 7.0]),
             occurs=torch.tensor([0, 1], dtype=torch.long),
-            occurs_probs=torch.tensor([0.1, 0.9]),
+            occurs_scores=torch.tensor([0.1, 0.9]),
         )
         assert m.compute()["n_tasks"] == 1.0
 
@@ -291,6 +292,27 @@ class TestTaskAurocCallbackLogging:
 
         assert logged["tuning/occurs_auroc_macro_sampled_n_tasks"] == 2.0
         assert logged["tuning/occurs_auroc_macro_sampled"] == pytest.approx(0.5)
+
+    def test_ranks_on_logits_so_saturating_scores_are_not_tied(self):
+        # sigmoid(logit) hits exactly 1.0 at >=6.5 in bf16 and >=17 in fp32, so scoring on
+        # probabilities turns a correctly-ranked pair into a tie and reports 0.5 instead of 1.0.
+        # AUROC only ranks, so the callback must hand the metric raw logits.
+        for dtype, (neg_logit, pos_logit) in (
+            (torch.bfloat16, (9.0, 14.0)),
+            (torch.float32, (20.0, 25.0)),
+        ):
+            neg_p = torch.tensor(neg_logit, dtype=dtype).sigmoid()
+            pos_p = torch.tensor(pos_logit, dtype=dtype).sigmoid()
+            assert neg_p == pos_p, (
+                f"{dtype} logits {neg_logit}/{pos_logit} must collide under sigmoid for this test to bite"
+            )
+
+            batch = _make_tracking_batch([10, 10], [7.0, 7.0], [0, 1])
+            logged = self._run(_StubOccursModel([neg_logit, pos_logit], dtype=dtype), [batch])
+
+            assert logged["tuning/occurs_auroc_macro_sampled"] == pytest.approx(1.0), (
+                f"{dtype}: pos logit {pos_logit} outranks neg {neg_logit}, so this is a win, not a tie"
+            )
 
     def test_state_does_not_leak_across_calls(self):
         # Each pass scores a *different* task, so rows leaked from pass 1 would surface as

--- a/tests/test_lightning_logic.py
+++ b/tests/test_lightning_logic.py
@@ -14,6 +14,7 @@ from meds_torchdata import MEDSTorchDataConfig
 from every_query.data.dataset import EveryQueryBatch
 from every_query.model import EveryQueryOutput
 from every_query.model.lightning_module import EveryQueryLightningModule
+from every_query.model.sampled_macro_auroc import SampledMacroAUROC
 from every_query.model.task_auroc_callback import TaskAurocTrackingCallback
 
 _CONFIGURED_WD = 0.01
@@ -159,12 +160,98 @@ def _make_tracking_batch(queries: list[int], durations: list[float], occurs: lis
     )
 
 
-class TestSampledTaskAurocTracking:
-    """``TaskAurocTrackingCallback._compute_and_log`` — macro win/tie/loss AUROC over pairs.
+class TestSampledMacroAUROC:
+    """``SampledMacroAUROC`` — macro win/tie/loss AUROC over pos/neg pairs.
 
     Each task in the tracking set contributes exactly one positive and one negative row; per-task AUROC
     collapses to an indicator on which of the two scored higher.
     """
+
+    @staticmethod
+    def _scored(queries, durations, occurs, probs):
+        """Feed one batch of rows into a fresh metric and return its ``compute()`` dict."""
+        m = SampledMacroAUROC()
+        m.update(
+            query=torch.tensor(queries, dtype=torch.long),
+            duration_days=torch.tensor(durations, dtype=torch.float32),
+            occurs=torch.tensor(occurs, dtype=torch.long),
+            occurs_probs=torch.tensor(probs, dtype=torch.float32),
+        )
+        return m.compute()
+
+    def test_no_tasks_when_never_updated(self):
+        out = SampledMacroAUROC().compute()
+        assert out["n_tasks"] == 0
+        assert out["auroc"].isnan()
+
+    def test_macro_average_win_tie_loss(self):
+        # Task 10: neg ~0 prob, pos ~1 prob -> win  (indicator 1.0)
+        # Task 20: neg ~1 prob, pos ~0 prob -> loss (indicator 0.0)
+        # Task 30: neg and pos equal        -> tie  (indicator 0.5)
+        out = self._scored(
+            [10, 10, 20, 20, 30, 30],
+            [7.0] * 6,
+            [0, 1, 0, 1, 0, 1],
+            [0.1, 0.9, 0.9, 0.1, 0.5, 0.5],
+        )
+
+        assert out["n_tasks"] == 3.0
+        assert float(out["auroc"]) == pytest.approx((1.0 + 0.0 + 0.5) / 3)
+
+    def test_tasks_missing_a_class_are_dropped(self):
+        # Task 10 has both classes (win); task 20 only has a positive row and is dropped.
+        out = self._scored([10, 10, 20], [7.0, 7.0, 7.0], [0, 1, 1], [0.1, 0.9, 0.5])
+
+        assert out["n_tasks"] == 1.0
+        assert float(out["auroc"]) == pytest.approx(1.0)
+
+    def test_same_query_at_different_durations_are_distinct_tasks(self):
+        # (query, duration_days) is the task key — query 10 at 7d and at 30d must not merge.
+        out = self._scored([10, 10, 10, 10], [7.0, 7.0, 30.0, 30.0], [0, 1, 0, 1], [0.1, 0.9, 0.9, 0.1])
+
+        assert out["n_tasks"] == 2.0
+        assert float(out["auroc"]) == pytest.approx(0.5)  # one win, one loss
+
+    def test_oov_query_rows_are_skipped(self):
+        # Both tasks are out-of-vocab (query == PAD_INDEX 0); without the guard their pos/neg
+        # probs collide into one bogus (0, 7.0) task. They must be dropped, leaving no tasks.
+        out = self._scored([0, 0, 0, 0], [7.0] * 4, [0, 1, 0, 1], [0.1, 0.9, 0.9, 0.1])
+
+        assert out["n_tasks"] == 0
+        assert out["auroc"].isnan()
+
+    def test_accumulates_across_batches(self):
+        # A task's pos and neg rows can land in different batches; pairing happens at compute().
+        m = SampledMacroAUROC()
+        for occurs, prob in ((0, 0.1), (1, 0.9)):
+            m.update(
+                query=torch.tensor([10], dtype=torch.long),
+                duration_days=torch.tensor([7.0]),
+                occurs=torch.tensor([occurs], dtype=torch.long),
+                occurs_probs=torch.tensor([prob]),
+            )
+
+        out = m.compute()
+        assert out["n_tasks"] == 1.0
+        assert float(out["auroc"]) == pytest.approx(1.0)
+
+    def test_reset_clears_state(self):
+        m = SampledMacroAUROC()
+        m.update(
+            query=torch.tensor([10, 10], dtype=torch.long),
+            duration_days=torch.tensor([7.0, 7.0]),
+            occurs=torch.tensor([0, 1], dtype=torch.long),
+            occurs_probs=torch.tensor([0.1, 0.9]),
+        )
+        assert m.compute()["n_tasks"] == 1.0
+
+        m.reset()
+
+        assert m.compute()["n_tasks"] == 0
+
+
+class TestTaskAurocCallbackLogging:
+    """``TaskAurocTrackingCallback._compute_and_log`` — the loader/forward/log shell around the metric."""
 
     @staticmethod
     def _run(model, batches):
@@ -182,35 +269,29 @@ class TestSampledTaskAurocTracking:
     def test_no_op_when_loader_empty(self):
         assert self._run(_StubOccursModel([]), []) == {}
 
-    def test_macro_average_win_tie_loss(self):
-        # Task 10: neg logit -10 (~0 prob), pos logit +10 (~1 prob) -> win  (indicator 1.0)
-        # Task 20: neg logit +10 (~1 prob), pos logit -10 (~0 prob) -> loss (indicator 0.0)
-        # Task 30: neg logit  0.0,          pos logit  0.0 (tie)    -> tie  (indicator 0.5)
-        batch = _make_tracking_batch([10, 10, 20, 20, 30, 30], [7.0] * 6, [0, 1, 0, 1, 0, 1])
-        logits = [-10.0, 10.0, 10.0, -10.0, 0.0, 0.0]
-
-        logged = self._run(_StubOccursModel(logits), [batch])
-
-        assert logged["tuning/occurs_auroc_macro_sampled_n_tasks"] == 3.0
-        assert logged["tuning/occurs_auroc_macro_sampled"] == pytest.approx((1.0 + 0.0 + 0.5) / 3)
-
-    def test_tasks_missing_a_class_are_dropped(self):
-        # Task 10 has both classes (win); task 20 only has a positive row and is dropped.
-        batch = _make_tracking_batch([10, 10, 20], [7.0, 7.0, 7.0], [0, 1, 1])
-        logits = [-10.0, 10.0, 0.0]
-
-        logged = self._run(_StubOccursModel(logits), [batch])
-
-        assert logged["tuning/occurs_auroc_macro_sampled_n_tasks"] == 1.0
-        assert logged["tuning/occurs_auroc_macro_sampled"] == pytest.approx(1.0)
-
-    def test_oov_query_rows_are_skipped(self):
-        # Both tasks are out-of-vocab (query == PAD_INDEX 0); without the guard their pos/neg
-        # probs collide into one bogus (0, 7.0) task. They must be dropped, leaving no metric.
-        batch = _make_tracking_batch([0, 0, 0, 0], [7.0] * 4, [0, 1, 0, 1])
+    def test_logs_metric_from_scored_batch(self):
+        # Task 10: neg logit -10 (~0 prob) vs pos logit +10 (~1 prob) -> win; task 20 -> loss.
+        batch = _make_tracking_batch([10, 10, 20, 20], [7.0] * 4, [0, 1, 0, 1])
         logits = [-10.0, 10.0, 10.0, -10.0]
 
-        assert self._run(_StubOccursModel(logits), [batch]) == {}
+        logged = self._run(_StubOccursModel(logits), [batch])
+
+        assert logged["tuning/occurs_auroc_macro_sampled_n_tasks"] == 2.0
+        assert logged["tuning/occurs_auroc_macro_sampled"] == pytest.approx(0.5)
+
+    def test_state_does_not_leak_across_calls(self):
+        # The callback resets the metric each pass; a second identical pass must log the same
+        # n_tasks rather than double-counting.
+        batch = _make_tracking_batch([10, 10], [7.0, 7.0], [0, 1])
+        cb = TaskAurocTrackingCallback(config=None)
+        cb._loader = [batch]
+        logged = {}
+        log_fn = lambda name, value, **kw: logged.__setitem__(name, value)  # noqa: E731
+
+        for _ in range(2):
+            cb._compute_and_log(_StubOccursModel([-10.0, 10.0]), torch.device("cpu"), log_fn)
+
+        assert logged["tuning/occurs_auroc_macro_sampled_n_tasks"] == 1.0
 
 
 class TestCallbackHydraWiring:


### PR DESCRIPTION
## What

`TaskAurocTrackingCallback` did two unrelated jobs: it owned the `DataLoader` over the offline-sampled pos/neg tracking pairs, *and* it hand-rolled metric accumulation in a `probs_by_task: dict[tuple[int, float], dict[int, float]]` dict-of-dicts, pairing rows and computing the macro win/tie/loss estimate inline in `_compute_and_log`.

That second job is what `torchmetrics.Metric` exists for. This PR moves it into a new `SampledMacroAUROC` (`src/every_query/model/sampled_macro_auroc.py`): accumulation becomes `add_state` lists of scored rows, the pairing becomes `compute()`, the per-epoch clear becomes `reset()`, and the OOV `PAD_INDEX` filter becomes a tensor mask in `update()`. The callback keeps the loader and forward pass and drops to a shell around `update`/`compute`/`reset`.

To be precise about what did *not* change: the `probs_by_task` dict-of-dicts still exists, rebuilt from the state lists on each `compute()`. It moved from the callback into the metric; it was not vectorized away. The tracking set is tiny (one pos/neg pair per task) and a Python grouping loop is the clearest thing that works, so that's deliberate — but don't come to this PR looking for a vectorized grouping.

The wins are the state lifecycle (`reset()` at a defined point rather than an ad-hoc dict clear), standalone testability without a fake `log_fn`, cross-batch accumulation, and the OOV mask.

## Why not put the metric on the LightningModule

The suggested reference ([`MEDS_EIC_AR`'s `NextCodeMetrics`](https://github.com/mmcdermott/MEDS_EIC_AR/blob/main/src/MEDS_EIC_AR/training/module.py)) is a `Metric` updated from batches that already flow through `validation_step`. Our tracking pairs don't — they're a separate dataset over a separate `task_labels_dir`, needing their own loader and forward pass. So the reference pattern applies to the accumulate/compute half only.

The loader stays in the callback because `EveryQueryLightningModule.load_from_checkpoint` reconstructs the module from hparams alone and could not supply the tracking dir — a module owning that path would have a metric it structurally cannot populate on restore.

## Behavior

No user-facing change. Class name, hydra `_target_`, and both logged metric names (`tuning/occurs_auroc_macro_sampled`, `..._n_tasks`) are unchanged, so neither `configs/callbacks/task_auroc.yaml` nor `config.yaml` needed an edit, and logged values are identical.

Two details worth a reviewer's eye:

- **`sync_on_compute=False` is load-bearing.** The callback gates scoring on `trainer.is_global_zero` (the pair set is tiny and identical on every rank), so a syncing `compute()` would enter a collective only rank 0 reaches and deadlock. Commented as such in `__init__`. The `dist_reduce_fx="cat"` on each `add_state` never runs as a consequence, and is commented to say so rather than implying working all-gather.
- **`add_state` defaults to `persistent=False`**, so metric state stays out of `state_dict` and existing checkpoints are unaffected.

`compute()` reads its state through torchmetrics' `dim_zero_cat`, which accepts both the list shape (today) and the concatenated-tensor shape a `_sync_dist` would leave behind — so flipping `sync_on_compute` stays a config decision instead of a `compute()`-time crash.

The `metric.reset()` sits in a `finally` so a mid-epoch failure can't leak rows into the next validation pass and silently skew the estimate.

## Tests

Split in two. `TestSampledMacroAUROC` drives the metric directly with tensors — no fake `log_fn` — and adds cases the old suite couldn't reach cheaply: accumulation across batches (a task's pos and neg rows landing in different batches, which is what `compute()`-time pairing buys), `reset()` clearing state, and same-query-different-duration staying distinct tasks. `TestTaskAurocCallbackLogging` keeps a thin check that the shell logs and doesn't leak state across passes; each pass scores a *different* task, so leaked rows surface as `n_tasks == 2`. Mutation-checked: commenting out `metric.reset()` fails it with `assert 2.0 == 1.0`.

Full suite passes locally (`--ignore=tests/training_validity`), plus doctests on the new module and ruff.

**Not verified locally, needs a cluster run:** the multi-GPU DDP path. That's the one thing that would catch a `sync_on_compute` regression, and its failure mode is a deadlock rather than a wrong number.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
