### PR TITLE
Stage 4 labeling: censoring beats occurrence; death is fully observed

### DIFF
--- a/src/every_query/generate_tasks/redesign-spec.md
+++ b/src/every_query/generate_tasks/redesign-spec.md
@@ -299,22 +299,23 @@ A patient context is a `(subject_idx, prediction_time_index)` pair; the timestam
 #### Labeling rule
 
 For each `(subject_id, prediction_time)` row, examine the window `(prediction_time, prediction_time + duration_days]`
-(invariant 6: open lower bound via `join_asof(..., allow_exact_matches=False)`, closed upper bound). Resolve occurrence first;
-censoring applies only when the event did **not** occur in the observed window:
+(invariant 6: open lower bound via `join_asof(..., allow_exact_matches=False)`, closed upper bound). **Censoring is
+resolved first**: if the window closes after the record ends and the subject is not known dead by the window end, the
+label is `null` regardless of any earlier occurrence. Otherwise, occurrence decides:
 
-| occurs in observed window | censored | `boolean_value` |
-| ------------------------- | -------- | --------------- |
-| yes                       | —        | True            |
-| no                        | yes      | null            |
-| no                        | no       | False           |
+| censored | occurs in window | `boolean_value` |
+| -------- | ---------------- | --------------- |
+| yes      | —                | null            |
+| no       | yes              | True            |
+| no       | no               | False           |
 
-- **occurs** — an event with the query `code` falls strictly within the *observed* window
-    `(prediction_time, min(prediction_time + duration_days, max_time[subject_id])]`. Label `True`, even if
-    the window extends past the end of record.
-- **censored** — not occurred **and** `prediction_time + duration_days > max_time[subject_id]` (the record
-    ends before the window closes; the unobserved tail is unknown). Label `null`.
-- **does not occur** — not occurred and the full window is observed
-    (`prediction_time + duration_days <= max_time[subject_id]`). Label `False`.
+- **censored** — `prediction_time + duration_days > max_time[subject_id]` **and** the subject has no `MEDS_DEATH`
+    row at or before the window end (the record ends before the window closes; the unobserved tail is unknown). Label
+    `null`. Resolved *before* occurrence: an event observed earlier in the window does **not** override the unknown tail.
+- **occurs** — not censored, and an event with the query `code` falls strictly within
+    `(prediction_time, prediction_time + duration_days]`. Label `True`.
+- **does not occur** — not censored, and no matching event in the window. Label `False`. This includes a subject who is
+    dead by the window end: death is terminal, so the record is complete and a non-occurrence is a genuine negative.
 
 **Float-duration implementation note.** `polars.duration(days=...)` expects integer day expressions, so a
 float `duration_days` window must be added as e.g.

--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -376,14 +376,21 @@ def evaluate_index_df(
     """Label an index DataFrame with the single nullable ``boolean_value`` column via a single ``join_asof``.
 
     Three-valued semantics (matches ``TaskQuerySchema`` + ``LabelSchema``'s nullable
-    ``boolean_value``):
+    ``boolean_value``).  Let ``window_end = prediction_time + duration_days``.  **Censoring is
+    resolved first** — an unobserved tail yields ``null`` even when the query already occurred
+    within the observed span:
 
-        - ``boolean_value = True``: an event with matching ``query`` code fell strictly
-          within ``(prediction_time, prediction_time + duration_days]``, even if the window
-          extends past ``max_time[subject_id]``.
-        - ``boolean_value = null``: no matching event in the observed window **and**
-          ``(prediction_time + duration_days) > max_time[subject_id]`` (censored).
-        - ``boolean_value = False``: no matching event and the full window is observed.
+        - ``boolean_value = null`` (censored): the record ends before the window closes
+          (``window_end > max_time[subject_id]``) **and** the subject is not known dead by
+          ``window_end``.  The unobserved tail is unknown, so the label is unknown — this takes
+          priority over an occurrence in the observed part of the window.
+        - ``boolean_value = True``: not censored, and an event with matching ``query`` code fell
+          strictly within ``(prediction_time, window_end]``.
+        - ``boolean_value = False``: not censored, and no matching event in that window.
+
+    A subject is observed through ``window_end`` when either ``window_end <= max_time`` (the
+    record spans the whole window) or the subject's ``MEDS_DEATH`` timestamp is ``<= window_end``:
+    death is terminal, so nothing can occur afterward and a non-occurrence is a genuine ``False``.
 
     The ``>`` on event time is enforced with ``join_asof(..., allow_exact_matches=False)``, which
     excludes exact-key matches from ``strategy="forward"``'s default ``>=`` search, leaving a
@@ -391,9 +398,10 @@ def evaluate_index_df(
 
     Death is terminal (#257): events timestamped strictly after a subject's ``MEDS_DEATH`` row
     (the earliest one, if duplicated) are dropped before labeling, so they neither extend
-    ``max_time`` nor satisfy an occurrence match.  The death row itself is kept, so
-    ``MEDS_DEATH`` remains answerable as a query code; subjects with no death row are
-    unaffected.  This is a no-op when ``MEDS_DEATH`` is already the last recorded event.
+    ``max_time`` nor satisfy an occurrence match; and because the record cannot continue past
+    death, a window closing at or after the death timestamp counts as fully observed (a
+    non-occurrence there is ``False``, not censored).  The death row itself is kept, so
+    ``MEDS_DEATH`` remains answerable as a query code; subjects with no death row are unaffected.
 
     Args:
         index_df: Output of ``build_index_df``. Must have columns ``subject_id``, ``prediction_time``,
@@ -432,12 +440,18 @@ def evaluate_index_df(
         return empty_task_query_df().select(out_cols)
 
     # Truncate each subject's record at death (see docstring, #257).  Must happen before *both*
-    # consumers of events_df below — max_time_per_subject and the join_asof right side — or a
+    # consumers of events_df below — subject_end_times and the join_asof right side — or a
     # post-death event could still asof-match into an occurrence.
     events_df = _truncate_at_death(events_df)
 
-    max_time_per_subject = events_df.group_by(DataSchema.subject_id_name).agg(
-        pl.col(DataSchema.time_name).max().alias("max_time")
+    subject_end_times = events_df.group_by(DataSchema.subject_id_name).agg(
+        pl.col(DataSchema.time_name).max().alias("max_time"),
+        # Death row is kept by _truncate_at_death, so its (earliest) timestamp is still here;
+        # null for subjects with no death row.
+        pl.col(DataSchema.time_name)
+        .filter(pl.col(DataSchema.code_name) == death_code)
+        .min()
+        .alias("death_time"),
     )
 
     # Left side: index rows sorted by (subject_id, query, prediction_time).  ``join_asof``
@@ -496,9 +510,9 @@ def evaluate_index_df(
         strategy="forward",
         allow_exact_matches=False,
     )
-    joined = joined.join(max_time_per_subject, on=TaskQuerySchema.subject_id_name, how="left")
+    joined = joined.join(subject_end_times, on=TaskQuerySchema.subject_id_name, how="left")
 
-    # Rows whose subject is not present in max_time_per_subject come out of the left join with
+    # Rows whose subject is not present in subject_end_times come out of the left join with
     # max_time=null.  Both pipelines build index_df and events_df from the same shard, so this
     # can only mean mismatched inputs (e.g. a stale _prediction_times cache) — raise rather than
     # launder the mismatch into censored labels (see docstring Raises).
@@ -512,17 +526,23 @@ def evaluate_index_df(
 
     duration_expr = pl.duration(seconds=pl.col(TaskQuerySchema.duration_days_name) * 86_400)
     window_end = pl.col(TaskQuerySchema.prediction_time_name) + duration_expr
-    censored = window_end > pl.col("max_time")
+    # death_time is null for subjects who never die; `null <= window_end` is null, which would
+    # poison the OR (null | False = null) and mislabel a living subject's past-max_time window as
+    # False instead of censored. fill_null(False) means "no death row => death rescue never fires".
+    observed = (pl.col("death_time") <= window_end).fill_null(False) | (window_end <= pl.col("max_time"))
+    censored = ~observed
     event_in_window = pl.col(DataSchema.time_name).is_not_null() & (
         pl.col(DataSchema.time_name) <= window_end
     )
 
-    # Occurrence takes priority: True even if the window extends past max_time (spec §Stage 4).
+    # Censoring takes priority (spec §Stage 4): an unobserved tail is null even if a matching
+    # event occurred in the observed part of the window.  A subject dead by window_end is never
+    # censored (observed via death_time), so their non-occurrence falls through to False.
     boolean_value = (
-        pl.when(event_in_window)
-        .then(pl.lit(True))
-        .when(censored)
+        pl.when(censored)
         .then(pl.lit(None, dtype=pl.Boolean))
+        .when(event_in_window)
+        .then(pl.lit(True))
         .otherwise(pl.lit(False))
     )
 

--- a/tests/sampler/test_stage4_labeling.py
+++ b/tests/sampler/test_stage4_labeling.py
@@ -1,8 +1,11 @@
 """Stage 4: per-shard labeling — ``evaluate_index_df`` (pure core) + ``label_one_shard`` (worker).
 
-Covers the three-valued label (True / False / null-censored), strict-``>`` at prediction_time,
-inclusive window-end, the unknown-subject raise, dtype normalization on the event-shard read path,
-the worker's skip/overwrite/atomicity behavior, and stale-temp cleanup.  Gap tests pin the
+Covers the three-valued label (True / False / null-censored) with **censoring resolved before
+occurrence** (an unobserved tail is null even if the query occurred in the observed span) and
+**death as a fully-observed terminus** (a subject dead by the window end is never censored — a
+non-occurrence is a genuine False).  Also pins strict-``>`` at prediction_time, inclusive
+window-end, the unknown-subject raise, dtype normalization on the event-shard read path, the
+worker's skip/overwrite/atomicity behavior, and stale-temp cleanup.  Gap tests pin the
 forward-only asof direction (past events don't count) and query-code isolation.
 """
 
@@ -230,12 +233,19 @@ class TestEvaluateIndexDfEdgeCases:
         assert result["boolean_value"].to_list() == [True]
 
 
-class TestDeathTruncation:
-    """Death is terminal (#257): events after a subject's ``MEDS_DEATH`` row are unobservable.
+class TestLabelContract:
+    """The full three-valued label contract for ``evaluate_index_df`` (redesign-spec.md §Stage 4).
 
-    Truncation happens inside ``evaluate_index_df`` on ``events_df`` itself, so it affects both
-    ``max_time`` (censoring boundary) and occurrence matching, while the death row itself stays
-    queryable.
+    Two priority rules drive every case, both pinned here:
+
+      1. **Censoring beats occurrence.** For a subject not known dead, a window that closes after
+         ``max_time`` is ``null`` even if the query occurred in the observed span.
+      2. **Death is a fully-observed terminus.** A subject dead by the window end (earliest
+         ``MEDS_DEATH`` ``<= window_end``) is never censored; death truncates post-death events so
+         they neither match nor extend ``max_time``, while the death row itself stays queryable.
+
+    Each case is a single index row over a single subject, so the resolved label is unambiguously
+    the contract row under test.  ``day N`` abbreviates ``BASE + N days``; ``prediction_time = BASE``.
     """
 
     BASE = datetime(2020, 1, 1)
@@ -254,185 +264,113 @@ class TestDeathTruncation:
         assert result.height == 1
         return result["boolean_value"].to_list()[0]
 
-    def test_death_as_last_event_is_a_noop(self):
-        """Regression guard: ``MEDS_DEATH`` already last → identical to pre-#257 behavior.
+    def _events(self, rows: list[tuple[int, str]]) -> pl.DataFrame:
+        """Build a single-subject events frame from ``(day_offset, code)`` tuples."""
+        return pl.DataFrame(
+            {
+                "subject_id": [1] * len(rows),
+                "time": [self.BASE + timedelta(days=d) for d, _ in rows],
+                "code": [c for _, c in rows],
+            }
+        )
 
-        ``max_time = death (day 10)``; the 30d window runs past it with no matching event → null.
+    # -- Living subject (no MEDS_DEATH row) -------------------------------------------------------
+
+    def test_alive_occurs_in_fully_observed_window_is_true(self):
+        """Occurrence + fully-observed window → ``True``.
+
+        ``A`` at day 3 is in ``(day 0, day 7]``; the day-100 event pushes ``max_time`` past the
+        window (day 7 <= day 100) so the window is fully observed and occurrence decides.
         """
-        events = pl.DataFrame(
-            {
-                "subject_id": [1, 1],
-                "time": [self.BASE + timedelta(days=3), self.BASE + timedelta(days=10)],
-                "code": ["B", death_code],
-            }
-        )
-        assert self._label(events, query="A", duration_days=30.0) is None
+        events = self._events([(3, "A"), (100, "X")])
+        assert self._label(events, query="A", duration_days=7.0) is True
 
-    def test_event_after_death_neither_matches_nor_extends_max_time(self):
-        """The drift case: a post-death event (day 20) must be invisible.
+    def test_alive_no_occurrence_fully_observed_is_false(self):
+        """No occurrence + fully-observed window → ``False``.
 
-        - query "A" (the post-death code, in the 30d window): must not match → and because
-          ``max_time`` is now the death time (day 10) < window end (day 30), the label is
-          null (censored), not True and not False.
-        - query "B" with a 5d window fully observed before death: still False (truncation
-          doesn't disturb pre-death labeling).
+        The only event (day 100) keeps ``max_time`` past the day-7 window; no ``A`` occurs in it.
         """
-        events = pl.DataFrame(
-            {
-                "subject_id": [1, 1, 1],
-                "time": [
-                    self.BASE + timedelta(days=3),
-                    self.BASE + timedelta(days=10),
-                    self.BASE + timedelta(days=20),  # post-death drift row
-                ],
-                "code": ["C", death_code, "A"],
-            }
-        )
-        assert self._label(events, query="A", duration_days=30.0) is None
-        assert self._label(events, query="B", duration_days=5.0) is False
-
-    def test_death_code_itself_is_still_queryable(self):
-        """A query on ``MEDS_DEATH`` occurring in-window resolves True: the death row is kept (``<=``, not
-        ``<``) and occurrence takes priority over censoring."""
-        events = pl.DataFrame(
-            {
-                "subject_id": [1, 1],
-                "time": [self.BASE + timedelta(days=3), self.BASE + timedelta(days=10)],
-                "code": ["B", death_code],
-            }
-        )
-        assert self._label(events, query=death_code, duration_days=30.0) is True
-
-    def test_no_death_row_is_unaffected(self):
-        """No ``MEDS_DEATH`` for the subject → truncation is a no-op; day-100 event keeps the 7d window fully
-        observed → False."""
-        events = pl.DataFrame(
-            {
-                "subject_id": [1],
-                "time": [self.BASE + timedelta(days=100)],
-                "code": ["B"],
-            }
-        )
+        events = self._events([(100, "X")])
         assert self._label(events, query="A", duration_days=7.0) is False
 
-    def test_duplicate_death_rows_use_earliest(self):
-        """Two ``MEDS_DEATH`` rows (data-quality edge) truncate at the *earlier* one: the "A" event between
-        the two death times must not match → censored null."""
-        events = pl.DataFrame(
-            {
-                "subject_id": [1, 1, 1],
-                "time": [
-                    self.BASE + timedelta(days=10),
-                    self.BASE + timedelta(days=15),  # between the two death rows → dropped
-                    self.BASE + timedelta(days=20),
-                ],
-                "code": [death_code, "A", death_code],
-            }
-        )
+    def test_alive_no_occurrence_window_past_record_is_censored_null(self):
+        """No occurrence + window past ``max_time`` (alive) → ``null`` (censored).
+
+        The only event is at day 10 (``max_time = day 10``); the 30d window's tail (day 10→30) is
+        unobserved, so the label is unknown.
+        """
+        events = self._events([(10, "B")])
         assert self._label(events, query="A", duration_days=30.0) is None
 
+    def test_alive_occurrence_but_window_past_record_is_censored_null(self):
+        """Censoring beats occurrence: an observed ``A`` at day 3 is still ``null`` when the window
+        runs past ``max_time`` for a living subject.
 
-class TestBooleanValueTruthTable:
-    """One test per row of the spec's labeling truth table (redesign-spec.md §Stage 4).
-
-    For each ``(subject_id, prediction_time)`` row the observed window is
-    ``(prediction_time, min(prediction_time + duration_days, max_time[subject_id])]``.
-    Occurrence is resolved first; censoring applies only when the event did **not** occur:
-
-    | occurs in observed window | censored | ``boolean_value`` |
-    | ------------------------- | -------- | ----------------- |
-    | yes                       | —        | True              |
-    | no                        | yes      | null              |
-    | no                        | no       | False             |
-
-    Each case is a single index row over a single subject so the resolved label is
-    unambiguously the table row under test, pinned independently of the other two.
-    """
-
-    BASE = datetime(2020, 1, 1)
-
-    def _evaluate_one(self, events: pl.DataFrame, duration_days: float) -> bool | None:
-        """Label a single index row (subject 1, code ``A``, ``prediction_time = BASE``) and return its
-        ``boolean_value``."""
-        events = events.with_columns(pl.col("time").cast(pl.Datetime("us"))).sort(["subject_id", "time"])
-        index_df = pl.DataFrame(
-            {
-                "subject_id": [1],
-                "prediction_time": [self.BASE],
-                "query": ["A"],
-                "duration_days": [duration_days],
-            }
-        ).with_columns(pl.col("prediction_time").cast(pl.Datetime("us")))
-        result = evaluate_index_df(index_df, events)
-        assert result.height == 1
-        return result["boolean_value"].to_list()[0]
-
-    def test_occurs_in_observed_window_is_true(self):
-        """Row 1: a matching event falls in the observed window → ``True``.
-
-        Event ``A`` at day 3 is strictly within ``(day 0, day 7]``; the later event at day 100
-        pushes ``max_time`` well past the window so occurrence — not censoring — decides the label.
+        ``A`` at day 3 is the subject's last event, so ``max_time = day 3`` and the 30d window's
+        tail (day 3→30) is unobserved.  Even though the query demonstrably occurred at day 3, the
+        unknown tail wins (spec §Stage 4: censoring resolved first) → ``null``.
         """
-        events = pl.DataFrame(
-            {
-                "subject_id": [1, 1],
-                "time": [self.BASE + timedelta(days=3), self.BASE + timedelta(days=100)],
-                "code": ["A", "A"],
-            }
-        )
-        assert self._evaluate_one(events, duration_days=7.0) is True
+        events = self._events([(3, "A")])
+        assert self._label(events, query="A", duration_days=30.0) is None
 
-    def test_occurs_takes_priority_over_censoring_is_true(self):
-        """Row 1, censored column ``—``: occurrence wins even when the requested window runs past ``max_time``
-        → ``True``, never ``null``.
+    def test_no_death_row_leaves_censoring_on_max_time(self):
+        """A subject with no ``MEDS_DEATH`` row is censored purely on ``max_time`` (the null-death guard must
+        not launder a past-record window into ``False``).
 
-        The subject's last (and only matching) event is ``A`` at day 3, so ``max_time = day 3``.
-        The requested window end (day 30) exceeds ``max_time`` — the censoring predicate
-        ``prediction_time + duration_days > max_time`` is **true** — but the ``A`` at day 3 falls
-        in the observed window ``(day 0, day 3]``.  Per the spec, occurrence is resolved first, so
-        the label is ``True`` and censoring never applies.
+        Regression guard for the ``death_time`` null-handling: with ``death_time`` null the
+        observed test collapses to ``window_end <= max_time``; here day-100 event keeps the 7d
+        window observed → ``False`` (and, per the case above, a past-record window would be null).
         """
-        events = pl.DataFrame(
-            {
-                "subject_id": [1],
-                "time": [self.BASE + timedelta(days=3)],
-                "code": ["A"],
-            }
-        )
-        assert self._evaluate_one(events, duration_days=30.0) is True
+        events = self._events([(100, "B")])
+        assert self._label(events, query="A", duration_days=7.0) is False
 
-    def test_no_occurrence_and_censored_is_null(self):
-        """Row 2: no matching event in the observed window **and** the window runs past
-        ``max_time`` → ``null`` (censored).
+    # -- Dead subject (MEDS_DEATH terminates the record) ------------------------------------------
 
-        The subject's only event is at day 10 (so ``max_time = day 10``) and carries a
-        non-matching code, so no ``A`` occurs in ``(day 0, day 10]``.  The requested window
-        end (day 30) exceeds ``max_time``, so the unobserved tail is unknown → censored.
+    def test_dead_occurrence_before_death_is_true(self):
+        """Occurrence before death, window past death → ``True`` (dead ⇒ observed, then occurrence).
+
+        ``A`` at day 3, death at day 10; the 30d window closes after death so it is fully observed,
+        and ``A`` in ``(day 0, day 30]`` makes it ``True``.
         """
-        events = pl.DataFrame(
-            {
-                "subject_id": [1],
-                "time": [self.BASE + timedelta(days=10)],
-                "code": ["B"],  # non-matching: no "A" anywhere
-            }
-        )
-        assert self._evaluate_one(events, duration_days=30.0) is None
+        events = self._events([(3, "A"), (10, death_code)])
+        assert self._label(events, query="A", duration_days=30.0) is True
 
-    def test_no_occurrence_and_fully_observed_is_false(self):
-        """Row 3: no matching event in the window and the full window is observed → ``False``.
+    def test_dead_no_occurrence_window_past_death_is_false(self):
+        """No occurrence, window past death → ``False``, NOT censored.
 
-        The matching event ``A`` lands at day 100 — outside ``(day 0, day 7]`` — and keeps
-        ``max_time`` (day 100) past the window end (day 7), so the window is fully observed
-        with no in-window occurrence.
+        Death (day 10) ends the record, so the day-30 window is fully observed even though it runs
+        past ``max_time = day 10``.  With no ``A``, the subject genuinely never has the event.
         """
-        events = pl.DataFrame(
-            {
-                "subject_id": [1],
-                "time": [self.BASE + timedelta(days=100)],
-                "code": ["A"],
-            }
-        )
-        assert self._evaluate_one(events, duration_days=7.0) is False
+        events = self._events([(3, "B"), (10, death_code)])
+        assert self._label(events, query="A", duration_days=30.0) is False
+
+    def test_dead_no_occurrence_window_within_record_is_false(self):
+        """No occurrence, window entirely before death → ``False`` (ordinary fully-observed case)."""
+        events = self._events([(3, "B"), (10, death_code)])
+        assert self._label(events, query="A", duration_days=5.0) is False
+
+    def test_dead_death_code_itself_is_queryable_true(self):
+        """The ``MEDS_DEATH`` row is kept (``<=``, not ``<``), so querying it in-window → ``True``."""
+        events = self._events([(3, "B"), (10, death_code)])
+        assert self._label(events, query=death_code, duration_days=30.0) is True
+
+    def test_dead_post_death_event_is_invisible(self):
+        """A matching event strictly after death is truncated → ``False``, not ``True`` or ``null``.
+
+        ``A`` at day 20 sits past the day-10 death and is dropped, so it neither matches nor extends
+        ``max_time``; the window is fully observed via death → ``False``.
+        """
+        events = self._events([(3, "C"), (10, death_code), (20, "A")])
+        assert self._label(events, query="A", duration_days=30.0) is False
+
+    def test_dead_duplicate_death_rows_use_earliest(self):
+        """Two ``MEDS_DEATH`` rows truncate at the *earlier* one: an ``A`` between them is dropped.
+
+        Death at day 10 and day 20; ``A`` at day 15 is post-earliest-death → invisible.  Observed
+        via death (day 10), no ``A`` → ``False``.
+        """
+        events = self._events([(10, death_code), (15, "A"), (20, death_code)])
+        assert self._label(events, query="A", duration_days=30.0) is False
 
 
 class TestReadEventShardDtypeNormalization:
@@ -676,16 +614,17 @@ class TestLabelOneShard:
         ``label_one_shard`` (not just ``evaluate_index_df`` in isolation)."""
         events = pl.DataFrame(
             {
-                "subject_id": [1, 1, 2, 2, 3, 3],
+                "subject_id": [1, 1, 1, 2, 2, 3, 3],
                 "time": [
                     self.BASE,
                     self.BASE + timedelta(days=5),  # event at day 5
+                    self.BASE + timedelta(days=10),  # max_time = day 10 (keeps the 7d window observed)
                     self.BASE,
                     self.BASE + timedelta(days=10),  # max_time = day 10
                     self.BASE,
                     self.BASE + timedelta(days=10),  # max_time = day 10
                 ],
-                "code": ["ICD//X", "ICD//A01", "ICD//X", "ICD//X", "ICD//X", "ICD//X"],
+                "code": ["ICD//X", "ICD//A01", "ICD//X", "ICD//X", "ICD//X", "ICD//X", "ICD//X"],
             }
         ).with_columns(pl.col("time").cast(pl.Datetime("us")))
 
@@ -694,7 +633,7 @@ class TestLabelOneShard:
                 "subject_id": [1, 2, 3],
                 "prediction_time": [self.BASE, self.BASE, self.BASE],
                 "query": ["ICD//A01", "ICD//A01", "ICD//A01"],
-                # subject 1: window 7d, event at day 5 → True
+                # subject 1: window 7d, event at day 5, max_time=10 ≥ 0+7 (observed) → True
                 # subject 2: window 7d, no ICD//A01 event, max_time=10 ≥ 0+7 → False
                 # subject 3: window 30d, no ICD//A01 event, max_time=10 < 0+30 → null (censored)
                 "duration_days": [7.0, 7.0, 30.0],

--- a/tests/test_generate_tasks.py
+++ b/tests/test_generate_tasks.py
@@ -24,6 +24,7 @@ from datetime import timedelta
 from typing import TYPE_CHECKING
 
 import polars as pl
+from meds import death_code
 
 from conftest import run_and_check
 
@@ -73,11 +74,13 @@ def test_labels_match_ground_truth(
 
     The sampler's documented semantics (``generate_tasks/sample_tasks.py::evaluate_index_df``):
 
+        # post-death events are dropped first (death is terminal); death_time = earliest MEDS_DEATH
         window_end    = prediction_time + duration_days
-        censored      = window_end > max_time[subject]
+        observed      = window_end <= max_time[subject] OR death_time[subject] <= window_end
+        censored      = not observed
         event_fires   = exists event(subject, code=query, time in (prediction_time, window_end])
-        boolean_value = True  if event_fires        # occurrence takes priority (spec §Stage 4)
-                        else None if censored        # unobserved tail → censored
+        boolean_value = None  if censored           # unobserved tail wins (spec §Stage 4)
+                        else True if event_fires     # observed occurrence
                         else False                   # full window observed, no event
 
     Recomputing row-by-row catches semantics-level bugs that a schema/shape assertion can't:
@@ -114,26 +117,46 @@ def test_labels_match_ground_truth(
             f"would be vacuous.  Check EQ_generate_training_tasks for empty-output regression."
         )
 
+        # Mirror _truncate_at_death: death is terminal, so events strictly after a subject's
+        # earliest MEDS_DEATH row are unobservable and must be dropped before computing max_time
+        # or occurrence — exactly as evaluate_index_df does.  The death row itself is kept (<=).
+        death_time_expr = pl.col("time").filter(pl.col("code") == death_code).min().over("subject_id")
+        events = events.filter(death_time_expr.is_null() | (pl.col("time") <= death_time_expr))
+
         max_time_per_subject = dict(
             events.group_by("subject_id").agg(pl.col("time").max().alias("max_time")).iter_rows()
+        )
+        # Earliest death timestamp per subject (from the truncated frame; null-absent = never dies).
+        death_time_per_subject = dict(
+            events.filter(pl.col("code") == death_code)
+            .group_by("subject_id")
+            .agg(pl.col("time").min().alias("death_time"))
+            .iter_rows()
         )
 
         # Walk every emitted row.  Simple Python — slow for millions of rows but fine for the
         # ~20-row fixture output, and the cost is bounded by CPU + parquet I/O, not test
         # complexity.  Favours readability + ground-truth correctness over vectorisation.
         #
-        # Collapsed nullable boolean_value per TaskQuerySchema (occurrence takes priority over
-        # censoring — spec §Stage 4 / evaluate_index_df line "Occurrence takes priority"):
-        #   True  → event occurred in (prediction_time, window_end], even if the window's tail
-        #           extends past max_time (an observed event is a definitive positive)
-        #   null  → no event in window AND censored (window_end > max_time OR subject absent)
-        #   False → no event in window and the full window is observed
+        # Collapsed nullable boolean_value per TaskQuerySchema — CENSORING takes priority over
+        # occurrence (spec §Stage 4 / evaluate_index_df "Censoring takes priority"):
+        #   null  → censored: window_end > max_time AND the subject is not dead by window_end
+        #           (unobserved tail is unknown, wins even over an in-window occurrence)
+        #   True  → not censored AND an event occurred in (prediction_time, window_end]
+        #   False → not censored AND no event in window (includes a subject dead by window_end)
         for row in labels.iter_rows(named=True):
             subj = row["subject_id"]
             window_end = row["prediction_time"] + timedelta(days=row["duration_days"])
 
             max_time = max_time_per_subject.get(subj)
-            expected_censored = max_time is None or window_end > max_time
+            death_t = death_time_per_subject.get(subj)
+            # Observed through window_end when the record spans it, OR the subject is dead by then
+            # (death ends the record).  Subject absent (max_time None) → mismatched inputs → censored
+            # (the sampler raises in that case, so this branch does not fire for emitted rows).
+            observed = (max_time is not None and window_end <= max_time) or (
+                death_t is not None and death_t <= window_end
+            )
+            expected_censored = not observed
 
             # Ground-truth event_fires: any event of the matching code in
             # (prediction_time, prediction_time + duration_days].  Sampler uses strict-> via
@@ -146,19 +169,19 @@ def test_labels_match_ground_truth(
                 & (pl.col("time") <= window_end)
             ).is_empty()
 
-            # Occurrence takes priority: an event observed in-window is True even when the
-            # window's tail is censored; null only when there is no event AND the tail is censored.
-            if event_fires:
-                expected_boolean = True
-            elif expected_censored:
+            # Censoring wins: an unobserved tail is null even when an event was observed earlier in
+            # the window.  Occurrence only decides True/False once the window is known-observed.
+            if expected_censored:
                 expected_boolean = None
+            elif event_fires:
+                expected_boolean = True
             else:
                 expected_boolean = False
 
             ctx = (
                 f"split={split}, subject_id={subj}, query={row['query']!r}, "
                 f"prediction_time={row['prediction_time']}, duration_days={row['duration_days']}, "
-                f"max_time={max_time}"
+                f"max_time={max_time}, death_time={death_t}"
             )
             assert row["boolean_value"] == expected_boolean, (
                 f"boolean_value mismatch: sampler={row['boolean_value']!r}, "


### PR DESCRIPTION
## What

Two coupled semantics changes to `evaluate_index_df` (Stage 4 labeling), with docstring, spec, and tests brought in line.

### 1. Censoring is resolved *before* occurrence
A living subject whose window closes past their last observed event is now `null` (censored) **even if the query occurred in the observed span**. Previously an in-window occurrence won and produced `True`.

- Contract row: living subject, only event is the queried code at day 3 (`max_time = day 3`), 30-day window → **`null`** (was `True`).

### 2. A subject dead by `window_end` is never censored
Death terminates the record, so a non-occurrence past death is a genuine `False`, not `null`. `death_time` (earliest `MEDS_DEATH`) is aggregated alongside `max_time` and folded into the observed test:

```
observed = (death_time <= window_end) | (window_end <= max_time)
```

The null-death comparison is pinned with `.fill_null(False)` so a *living* subject's past-record window isn't laundered into `False` by Kleene-null propagation.

## Changes
- `sample_tasks.py` — `observed`/`censored` logic, `when/then` order (censored first), docstring + inline comment.
- `redesign-spec.md` §Stage 4 — truth table and prose flipped to censored-first + dead-is-observed.
- `tests/sampler/test_stage4_labeling.py` — replaced `TestDeathTruncation` + `TestBooleanValueTruthTable` with a single `TestLabelContract` pinning all 11 rows of the new contract (incl. the two load-bearing cases above and a regression guard for the `fill_null` fix). Fixed `test_censoring_logic` fixture whose subject 1 accidentally ran past `max_time`.
- `tests/test_generate_tasks.py` — rewrote the end-to-end ground-truth model to mirror `_truncate_at_death` and censored-first (it previously assumed occurrence-first and did no death truncation).

## Test
`35 passed` across `tests/sampler/test_stage4_labeling.py`, `tests/test_generate_tasks.py`, `tests/test_sampler_dataset_integration.py`, `tests/training_validity/test_training_validity.py`.

## Note for reviewers
Change #1 means a **demonstrably observed** positive (event seen at day 3) is discarded as `null` when the record ends before the requested window closes. That's the intended contract, now locked by `test_alive_occurrence_but_window_past_record_is_censored_null`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)