### PR TITLE
Size the model from the data instead of ModernBERT's defaults

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -69,7 +69,6 @@ DEMO_CONFIG_OVERRIDES: dict[str, int] = {
     "intermediate_size": 128,
     "max_position_embeddings": 128,
     "vocab_size": 100,
-    "pad_token_id": 0,
     "cls_token_id": 1,
     "bos_token_id": 1,
     "sep_token_id": 2,

--- a/src/every_query/model/model.py
+++ b/src/every_query/model/model.py
@@ -319,6 +319,11 @@ class EveryQueryModel(torch.nn.Module):
         self.HF_model_config.output_attentions = False
         self.HF_model_config.use_cache = False
         self.HF_model_config.mlp_dropout = float(mlp_dropout)
+        # Not a knob: this must be the collate's pad index, since `_hf_inputs` builds the
+        # attention mask from the same constant and ModernBERT passes it to
+        # `nn.Embedding(..., padding_idx=...)`.  ModernBERT's own default is its tokenizer's
+        # [PAD] (50283), which is out of range once `vocab_size` is sized from the data.
+        self.HF_model_config.pad_token_id = EveryQueryBatch.PAD_INDEX
 
         self.HF_model = ModernBertModel._from_config(self.HF_model_config, **extra_kwargs)
 

--- a/src/every_query/model/model.py
+++ b/src/every_query/model/model.py
@@ -272,6 +272,14 @@ class EveryQueryModel(torch.nn.Module):
         "transformer-engine": torch.bfloat16,
     }
 
+    # Keys this class derives or forces later in ``__init__``, so a ``config_overrides`` entry for
+    # any of them would be accepted, recorded in ``hparams``/``resolved_config.yaml``, and then
+    # silently discarded.  Reject instead, naming the real control surface — the same guard
+    # MEDS_EIC_AR applies via ``Model._RESERVED_ROLLING_KWARGS``.
+    _DERIVED_CONFIG_KEYS: ClassVar[frozenset[str]] = frozenset(
+        {"pad_token_id", "mlp_dropout", "output_hidden_states", "output_attentions", "use_cache"}
+    )
+
     def __init__(
         self,
         precision: str = "32-true",
@@ -288,7 +296,22 @@ class EveryQueryModel(torch.nn.Module):
         self.HF_model_config: ModernBertConfig = AutoConfig.from_pretrained(model_name)
 
         if config_overrides:
+            derived = self._DERIVED_CONFIG_KEYS.intersection(config_overrides)
+            if derived:
+                raise ValueError(
+                    f"These config keys are derived, not configurable: {sorted(derived)}.  "
+                    f"pad_token_id is fixed to EveryQueryBatch.PAD_INDEX ({EveryQueryBatch.PAD_INDEX}) "
+                    "so the embedding's padding row matches the mask `_hf_inputs` builds; "
+                    "mlp_dropout is the `mlp_dropout=` argument; the output/cache flags are forced "
+                    "off for training."
+                )
             for key, value in config_overrides.items():
+                # Blind setattr would accept a typo (`hiden_size`), store it in `hparams`, and
+                # leave the model quietly training at the HF default.
+                if not hasattr(self.HF_model_config, key):
+                    raise ValueError(
+                        f"Config for HF model {self.HF_model_config.model_type} does not have attribute {key}"
+                    )
                 setattr(self.HF_model_config, key, value)
 
         # Applied after config_overrides so the explicit parameter takes precedence

--- a/src/every_query/train/configs/_demo_train.yaml
+++ b/src/every_query/train/configs/_demo_train.yaml
@@ -42,13 +42,9 @@ lightning_module:
       num_hidden_layers: 2
       num_attention_heads: 2
       intermediate_size: 128
-      max_position_embeddings: 128
-      vocab_size: 100
-      pad_token_id: 0
-      cls_token_id: 1
-      bos_token_id: 1
-      sep_token_id: 2
-      eos_token_id: 2
+      # Dictated by the data — filled in by train.py from the datamodule config.
+      vocab_size: ???
+      max_position_embeddings: ???
   optimizer:
     _target_: torch.optim.AdamW
     _partial_: true

--- a/src/every_query/train/configs/config.yaml
+++ b/src/every_query/train/configs/config.yaml
@@ -50,6 +50,10 @@ lightning_module:
     mlp_dropout: 0.1
     num_hidden_layers: 22
     occurs_loss_weight: 0.5
+    config_overrides:
+      # Dictated by the data — filled in by train.py from the datamodule config.
+      vocab_size: ???
+      max_position_embeddings: ???
   optimizer:
     _target_: torch.optim.AdamW
     _partial_: true

--- a/src/every_query/train/train.py
+++ b/src/every_query/train/train.py
@@ -270,6 +270,16 @@ def main(cfg: DictConfig) -> float | None:
     _init_env()
     validate_training_config(cfg)
 
+    # Size the model from the data: vocab from metadata/codes.parquet, positions from the
+    # datamodule window plus the two tokens the model adds — the query token (prepended in
+    # ``EveryQueryPytorchDataset._seeded_getitem``) and the duration token (spliced in
+    # ``EveryQueryModel._hf_inputs``).  Done here, before the config is saved and before
+    # ``validate_resume_directory`` diffs it, so the run dir records the real numbers and a
+    # resumed run compares like with like.
+    ds_cfg = instantiate(cfg.datamodule.config)
+    cfg.lightning_module.model.config_overrides.vocab_size = ds_cfg.vocab_size
+    cfg.lightning_module.model.config_overrides.max_position_embeddings = ds_cfg.max_seq_len + 2
+
     if cfg.do_overwrite and cfg.do_resume:
         logger.warning(
             "Both `do_overwrite` and `do_resume` are set to True. "

--- a/tests/test_model_logic.py
+++ b/tests/test_model_logic.py
@@ -7,7 +7,12 @@ dimension, and asserting the expected output change (or invariance).
 
 import copy
 
+import pytest
 import torch
+
+from conftest import DEMO_CONFIG_OVERRIDES
+from every_query.data.dataset import EveryQueryBatch
+from every_query.model.model import EveryQueryModel
 
 
 class TestQueryTokenPositionAffectsQueryEmbed:
@@ -510,3 +515,31 @@ class TestCrossLossTargetIndependence:
             "censor_loss must change when censor targets are flipped "
             "(proves censor_loss is not trivially constant)"
         )
+
+
+class TestConfigOverridesValidation:
+    """`config_overrides` rejects keys the model derives, and keys HF does not have.
+
+    Both used to be silent: a derived key was accepted and then clobbered by the forced
+    block, and a typo'd key was `setattr`-ed onto the config and recorded in `hparams`
+    while the model quietly trained at the HF default.
+    """
+
+    def test_derived_key_raises(self):
+        with pytest.raises(ValueError, match="derived, not configurable"):
+            EveryQueryModel(config_overrides={**DEMO_CONFIG_OVERRIDES, "pad_token_id": 7})
+
+    def test_derived_key_error_names_all_offenders(self):
+        with pytest.raises(ValueError, match=r"\['mlp_dropout', 'pad_token_id'\]"):
+            EveryQueryModel(config_overrides={**DEMO_CONFIG_OVERRIDES, "pad_token_id": 7, "mlp_dropout": 0.9})
+
+    def test_unknown_key_raises(self):
+        with pytest.raises(ValueError, match="does not have attribute hiden_size"):
+            EveryQueryModel(config_overrides={**DEMO_CONFIG_OVERRIDES, "hiden_size": 999})
+
+    def test_valid_overrides_still_apply(self):
+        model = EveryQueryModel(config_overrides=DEMO_CONFIG_OVERRIDES)
+        assert model.HF_model_config.hidden_size == DEMO_CONFIG_OVERRIDES["hidden_size"]
+        # Forced despite never appearing in config_overrides.
+        assert model.HF_model_config.pad_token_id == EveryQueryBatch.PAD_INDEX
+        assert model.HF_model.embeddings.tok_embeddings.padding_idx == EveryQueryBatch.PAD_INDEX

--- a/tests/training_validity/test_training_validity.py
+++ b/tests/training_validity/test_training_validity.py
@@ -235,7 +235,6 @@ def oracle_trained_model_dir(
             "lightning_module.model.config_overrides.num_hidden_layers=4",
             "lightning_module.model.config_overrides.num_attention_heads=4",
             "lightning_module.model.config_overrides.intermediate_size=256",
-            "lightning_module.model.config_overrides.max_position_embeddings=512",
             # 2000 steps is enough once the weight init is reproducible — the #124 fix moved
             # `seed_everything` above `instantiate(cfg.lightning_module)`, so weight init is
             # now platform-independent for a given `cfg.seed`.  Before that, an unlucky 3.12


### PR DESCRIPTION
## Problem

`EveryQueryModel` builds its encoder from `AutoConfig.from_pretrained("answerdotai/ModernBERT-base")` and never overrode the vocabulary. Every production run therefore allocated a **50368 x 768 embedding table — 38.7M parameters** — where only the rows corresponding to the real MEDS code vocabulary ever received a gradient. `_demo_train.yaml` pinned `vocab_size: 100`, so this only ever bit real runs.

`max_position_embeddings` had the same shape of problem at a much smaller cost: left at 8192 against a real maximum of `max_seq_len + 2`, which made the length guard in `_check_inputs` unreachable. (It allocates nothing — ModernBERT is RoPE-based and builds its cos/sin cache lazily from the actual batch length — so this half is a correctness-of-documentation fix, not a memory win.)

## Approach

Follows the [MEDS_EIC_AR](https://github.com/mmcdermott/MEDS_EIC_AR) convention: values dictated by the data are declared `???` in config and filled in from the instantiated datamodule config in `train.py`.

```python
ds_cfg = instantiate(cfg.datamodule.config)
cfg.lightning_module.model.config_overrides.vocab_size = ds_cfg.vocab_size
cfg.lightning_module.model.config_overrides.max_position_embeddings = ds_cfg.max_seq_len + 2
```

Two placement details differ from upstream:

- **It runs at the top of `main()`, not next to `D = instantiate(cfg.datamodule)`.** The values must land in `cfg` before `validate_resume_directory` diffs it and before `OmegaConf.save` — otherwise the first run saves real numbers, a resumed run still holds `???`, and the resume check rejects its own config. It also means `resolved_config.yaml` records `vocab_size: 6142` rather than `???`.
- **It instantiates `cfg.datamodule.config` (the `MEDSTorchDataConfig` dataclass), not the whole datamodule.** That is what lets it run before `seed_everything` without violating the seed-before-instantiate invariant from #124 — a dataclass plus one single-column parquet read consumes no RNG. `vocab_size` there is a `cached_property` reading the same `metadata/codes.parquet` that `dataset.py` already reads for `code_to_index`, so the two cannot drift.

Both keys ride in `config_overrides`, which already round-trips through `model.hparams`, so `load_from_checkpoint` and `EQ_predict` rebuild at the right size with no changes to either.

The `+2` covers the two tokens added *after* the datamodule truncates to `max_seq_len`: the query token prepended in `EveryQueryPytorchDataset._seeded_getitem`, and the duration token spliced in `EveryQueryModel._hf_inputs`.

## Latent crash this exposed

ModernBERT's default `pad_token_id` is its own tokenizer's `[PAD]` at **50283**, which `ModernBertEmbeddings` passes straight to `nn.Embedding(vocab_size, hidden_size, padding_idx=...)`. The moment `vocab_size` is sized from data, that index is out of range and construction raises `AssertionError: Padding_idx must be within num_embeddings`.

Only `_demo_train.yaml` had pinned `pad_token_id: 0` — production `config.yaml` never set it — which is why the full test suite passed while the first real run would have died at model construction.

Fixed in `model.py` rather than YAML, from `EveryQueryBatch.PAD_INDEX`:

```python
self.HF_model_config.pad_token_id = EveryQueryBatch.PAD_INDEX
```

It is a contract with the collate, not a hyperparameter: `_hf_inputs` already derives the attention mask from the same constant, and if YAML disagreed the mask and the frozen embedding row would point at different tokens with nothing to complain. Setting it in the forced-settings block also means a stray `config_overrides` entry cannot reintroduce the crash, and it drops out of `hparams` so reloaded checkpoints re-derive it.

Verified that MEDS reserves index 0: real `code/vocab_index` values start at 1, so `padding_idx=0` freezes a row no code occupies and `vocab_size = max_index + 1` correctly counts it.

## Also removed

- Hardcoded `vocab_size` / `max_position_embeddings` in `_demo_train.yaml`, now sentinels.
- `cls_token_id` / `bos_token_id` / `sep_token_id` / `eos_token_id` from `_demo_train.yaml` — referenced zero times in `modeling_modernbert.py`; they matter to tokenizers, not `ModernBertModel`. (`conftest.py`'s copy stays: `demo_model_config` builds a raw `ModernBertConfig` for doctests, bypassing `EveryQueryModel`.)
- `max_position_embeddings=512` in the validity test, which the injection now supersedes.

## Backward compatibility

Existing checkpoints keep working. `load_from_checkpoint` rebuilds from the checkpoint's *own* `hparams`, not from `config.yaml`, so a pre-PR checkpoint — whose `config_overrides` has no `vocab_size` — reconstructs at 50368 and matches its own weights. Verified:

```
old hparams config_overrides : {'hidden_size': 64, ...}   # no vocab_size, as before this PR
reloaded vocab_size          : 50368
weights identical            : True
```

The `pad_token_id` change does not interfere: `padding_idx` is an `nn.Embedding` attribute, not a state-dict entry, so it takes no part in loading. An old checkpoint reloads with `padding_idx=0` instead of `50283`, which is inert — neither row receives gradient (see below).

`EQ_predict` needs no changes. `predict.py:526` swaps only `task_labels_dir`; `tensorized_cohort_dir` is inherited untouched from the training run's `resolved_config.yaml`, so inference reads the same `metadata/codes.parquet` that sized the model and the vocabulary matches by construction. `_check_vocab` resolves its metadata from that same directory.

The one thing that will not work is *resuming* a pre-PR checkpoint into a run that now injects a smaller vocab — a genuine shape conflict. `validate_resume_directory` rejects the config diff before PyTorch would complain.

## Note: prior runs were not affected

Worth stating explicitly, since "the pad token was wrong" invites the question. The old `pad_token_id` was inert, not incorrect. Padding has always been excluded via `_hf_inputs`:

```python
attention_mask = batch.code != batch.PAD_INDEX
```

which uses the correct constant, and ModernBERT then drops those positions entirely in `_unpad_modernbert_input`. `pad_token_id` feeds only `nn.Embedding(..., padding_idx=...)`, whose sole effect is to freeze that row's gradient — redundant for a row the mask already excludes. Measured directly on a padded batch: with `padding_idx` at the mismatched value and at `PAD_INDEX`, the gradient on row 0 is `0.0` in both cases and the same rows stay live.

So the pre-existing cost was memory, not correctness: roughly 34M dead parameters (~23% of the model) plus their AdamW moments. Completed runs are valid.

## Testing

- Full non-slow suite: **255 passed**.
- Slow oracle training test (`-m slow`, 2000 steps): passes — note `pyproject.toml` sets `addopts = ["-m", "not slow"]`, so this needs `-m slow` explicitly.
- Composed production config builds: embedding `(6000, 768)`, `padding_idx: 0`.
- Demo run round-trips `vocab_size: 12` / `max_position_embeddings: 66` through `best_model.ckpt` via `load_from_checkpoint`.
- Codex review: no findings.

## Out of scope, found while tracing

Two pre-existing issues, untouched here:

- `encode_query` (`dataset.py:400`) maps an out-of-vocab query code to `PAD_INDEX`, i.e. position 0 — the exact position `_forward` pools from, and one the attention mask excludes. `predict.py:_check_vocab` guards this at predict time; I did not verify whether the training-side sampler can emit an OOV query.
- `local_attention: 128` against sequences up to 258 means roughly two-thirds of the layers cannot see the query token from the far end of a timeline, and the query token is the sole pooling site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
