### PR TITLE
Switch to bf16-mixed with fp32 sigmoid, keep resume working, align matmul precision

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -41,6 +41,7 @@ import pytest
 import torch
 from meds import train_split, tuning_split
 from meds_torchdata.config import MEDSTorchDataConfig
+from omegaconf import OmegaConf
 from transformers import ModernBertConfig
 
 from every_query.data.dataset import EveryQueryBatch, EveryQueryPytorchDataset
@@ -62,11 +63,19 @@ _PRED_TIMES: dict[int, datetime] = {
 
 _QUERY_CODES = ["HR", "TEMP"]
 
+# Architecture sizes come from _demo_train.yaml so fixtures and the Hydra demo config
+# can't drift; the remaining fields are the ones train.py injects from the data at
+# runtime, which unit-test fixtures must pin statically.
+_DEMO_TRAIN_YAML = Path(__file__).parent / "src/every_query/train/configs/_demo_train.yaml"
+_demo_train_cfg = OmegaConf.load(_DEMO_TRAIN_YAML)
+_yaml_overrides = OmegaConf.to_container(_demo_train_cfg.lightning_module.model.config_overrides)
+
+# Mirrors training: "bf16-mixed" via ${trainer.precision} — still fp32 weights; autocast
+# (when a test opts in) owns the bf16 casting, exactly as under the Trainer.
+DEMO_PRECISION: str = _demo_train_cfg.lightning_module.model.precision
+
 DEMO_CONFIG_OVERRIDES: dict[str, int] = {
-    "hidden_size": 64,
-    "num_hidden_layers": 2,
-    "num_attention_heads": 2,
-    "intermediate_size": 128,
+    **{k: v for k, v in _yaml_overrides.items() if v != "???"},
     "max_position_embeddings": 128,
     "vocab_size": 100,
     "cls_token_id": 1,
@@ -92,7 +101,7 @@ def demo_model() -> EveryQueryModel:
     model = EveryQueryModel(
         config_overrides=DEMO_CONFIG_OVERRIDES,
         do_demo=True,
-        precision="32-true",
+        precision=DEMO_PRECISION,
     )
     model.eval()
     return model

--- a/src/every_query/model/lightning_module.py
+++ b/src/every_query/model/lightning_module.py
@@ -588,7 +588,7 @@ class EveryQueryLightningModule(L.LightningModule):
             >>> loaded.hparams['LR_scheduler'] is None
             True
             >>> loaded.hparams['model']['precision']
-            '32-true'
+            'bf16-mixed'
             >>> loaded.hparams['model']['do_demo']
             True
 

--- a/src/every_query/model/lightning_module.py
+++ b/src/every_query/model/lightning_module.py
@@ -252,7 +252,7 @@ class EveryQueryLightningModule(L.LightningModule):
                 self._update_metric(
                     name="censor_auc",
                     split=split,
-                    preds=outputs.censor_logits.detach().cpu().squeeze(1).sigmoid().float(),
+                    preds=outputs.censor_logits.detach().cpu().squeeze(1).float().sigmoid(),
                     target=batch.censor.detach().cpu().long(),
                 )
             if (
@@ -260,7 +260,7 @@ class EveryQueryLightningModule(L.LightningModule):
                 and getattr(batch, "occurs", None) is not None
             ):
                 mask = (~batch.censor).detach().cpu().bool() if hasattr(batch, "censor") else None
-                preds = outputs.occurs_logits.detach().cpu().squeeze(1).sigmoid().float()
+                preds = outputs.occurs_logits.detach().cpu().squeeze(1).float().sigmoid()
                 target = batch.occurs.detach().cpu().long()
                 if mask is not None:
                     preds = preds[mask]
@@ -404,16 +404,19 @@ class EveryQueryLightningModule(L.LightningModule):
         _, outputs = self.model(batch)
 
         empty_tensor = torch.tensor([])
+        # Probs come back fp32 already (``logits_to_probs`` upcasts before the sigmoid so bf16
+        # can't saturate them); ``query_embed`` is still bf16 under ``bf16-mixed`` and
+        # ``torch.Tensor.numpy()`` rejects bf16 outright, so keep the ``.float()`` on the way out.
         return {
-            "occurs_probs": outputs.occurs_probs.detach().cpu(),
-            "censor_probs": outputs.censor_probs.detach().cpu(),
+            "occurs_probs": outputs.occurs_probs.detach().float().cpu(),
+            "censor_probs": outputs.censor_probs.detach().float().cpu(),
             "occurs": batch.occurs.detach().cpu() if batch.occurs is not None else empty_tensor,
             "censor": batch.censor.detach().cpu() if batch.censor is not None else empty_tensor,
             "query": batch.query.detach().cpu() if batch.query is not None else empty_tensor,
             "duration_days": (
                 batch.duration_days.detach().cpu() if batch.duration_days is not None else empty_tensor
             ),
-            "query_embed": outputs.query_embed.detach().cpu(),
+            "query_embed": outputs.query_embed.detach().float().cpu(),
         }
 
     @staticmethod

--- a/src/every_query/model/lightning_module.py
+++ b/src/every_query/model/lightning_module.py
@@ -404,19 +404,16 @@ class EveryQueryLightningModule(L.LightningModule):
         _, outputs = self.model(batch)
 
         empty_tensor = torch.tensor([])
-        # Probs come back fp32 already (``logits_to_probs`` upcasts before the sigmoid so bf16
-        # can't saturate them); ``query_embed`` is still bf16 under ``bf16-mixed`` and
-        # ``torch.Tensor.numpy()`` rejects bf16 outright, so keep the ``.float()`` on the way out.
         return {
-            "occurs_probs": outputs.occurs_probs.detach().float().cpu(),
-            "censor_probs": outputs.censor_probs.detach().float().cpu(),
+            "occurs_probs": outputs.occurs_probs.detach().cpu(),
+            "censor_probs": outputs.censor_probs.detach().cpu(),
             "occurs": batch.occurs.detach().cpu() if batch.occurs is not None else empty_tensor,
             "censor": batch.censor.detach().cpu() if batch.censor is not None else empty_tensor,
             "query": batch.query.detach().cpu() if batch.query is not None else empty_tensor,
             "duration_days": (
                 batch.duration_days.detach().cpu() if batch.duration_days is not None else empty_tensor
             ),
-            "query_embed": outputs.query_embed.detach().float().cpu(),
+            "query_embed": outputs.query_embed.detach().cpu(),
         }
 
     @staticmethod

--- a/src/every_query/model/model.py
+++ b/src/every_query/model/model.py
@@ -138,8 +138,18 @@ class EveryQueryOutput(BaseModelOutput):
             tensor(True)
             >>> EveryQueryOutput.logits_to_probs(torch.tensor([[-1000.0]])) < 0.001
             tensor(True)
+
+            bf16 logits are upcast before the sigmoid — bf16 sigmoid would round to
+            exactly 1.0 from a logit of ~6, flattening every confident prediction into
+            a tie for ranking metrics like AUROC:
+
+            >>> probs = EveryQueryOutput.logits_to_probs(torch.tensor([[8.0]], dtype=torch.bfloat16))
+            >>> probs.dtype, bool(probs < 1.0)
+            (torch.float32, True)
         """
-        return torch.sigmoid(logits).squeeze()
+        # Sigmoid must run in fp32: bf16 saturates to exactly 1.0 at logit ~6 (fp32: ~17),
+        # and these probs are persisted to parquet and fed into AUROC.
+        return torch.sigmoid(logits.float()).squeeze()
 
     @property
     def occurs_probs(self) -> torch.Tensor | None:
@@ -263,15 +273,6 @@ class EveryQueryModel(torch.nn.Module):
     precision: str
     mlp_dropout: float
 
-    PRECISION_TO_MODEL_WEIGHTS_DTYPE: ClassVar[dict[str, torch.dtype]] = {
-        "32-true": torch.float32,
-        "16-true": torch.float16,
-        "16-mixed": torch.float32,
-        "bf16-true": torch.bfloat16,
-        "bf16-mixed": torch.float32,
-        "transformer-engine": torch.bfloat16,
-    }
-
     # Keys this class derives or forces later in ``__init__``, so a ``config_overrides`` entry for
     # any of them would be accepted, recorded in ``hparams``/``resolved_config.yaml``, and then
     # silently discarded.  Reject instead, naming the real control surface — the same guard
@@ -319,7 +320,10 @@ class EveryQueryModel(torch.nn.Module):
         if num_hidden_layers is not None:
             self.HF_model_config.num_hidden_layers = num_hidden_layers
 
-        extra_kwargs = {"torch_dtype": self.PRECISION_TO_MODEL_WEIGHTS_DTYPE.get(precision)}
+        # No torch_dtype: weights load fp32 and the Trainer's AMP plugin autocasts around them.
+        # Loading them at half precision instead leaves the optimizer nothing to accumulate
+        # small updates into.
+        extra_kwargs = {}
 
         if HAS_FLASH_ATTN:
             logger.info("Using FlashAttention 2 for the model.")

--- a/src/every_query/model/model.py
+++ b/src/every_query/model/model.py
@@ -271,6 +271,15 @@ class EveryQueryModel(torch.nn.Module):
     precision: str
     mlp_dropout: float
 
+    PRECISION_TO_MODEL_WEIGHTS_DTYPE: ClassVar[dict[str, torch.dtype]] = {
+        "32-true": torch.float32,
+        "16-true": torch.float16,
+        "16-mixed": torch.float32,
+        "bf16-true": torch.bfloat16,
+        "bf16-mixed": torch.float32,
+        "transformer-engine": torch.bfloat16,
+    }
+
     # Keys this class derives or forces later in ``__init__``, so a ``config_overrides`` entry for
     # any of them would be accepted, recorded in ``hparams``/``resolved_config.yaml``, and then
     # silently discarded.  Reject instead, naming the real control surface — the same guard
@@ -318,13 +327,7 @@ class EveryQueryModel(torch.nn.Module):
         if num_hidden_layers is not None:
             self.HF_model_config.num_hidden_layers = num_hidden_layers
 
-        # Pin fp32 weights so the optimizer always has full-precision masters; under a ``*-mixed``
-        # precision the Trainer's AMP plugin autocasts around them.  Not implied by the precision
-        # string: ``_from_config`` with no dtype falls back to ``config.dtype``, so a ``model_name``
-        # whose config.json declares ``torch_dtype: bfloat16`` would silently produce bf16 masters.
-        # Spelled ``torch_dtype`` because our transformers floor (>=4.48) predates the ``dtype``
-        # rename; switch once that floor moves past 4.56.
-        extra_kwargs = {"torch_dtype": torch.float32}
+        extra_kwargs = {"torch_dtype": self.PRECISION_TO_MODEL_WEIGHTS_DTYPE.get(precision)}
 
         if HAS_FLASH_ATTN:
             logger.info("Using FlashAttention 2 for the model.")

--- a/src/every_query/model/model.py
+++ b/src/every_query/model/model.py
@@ -320,10 +320,20 @@ class EveryQueryModel(torch.nn.Module):
         if num_hidden_layers is not None:
             self.HF_model_config.num_hidden_layers = num_hidden_layers
 
-        # No torch_dtype: weights load fp32 and the Trainer's AMP plugin autocasts around them.
-        # Loading them at half precision instead leaves the optimizer nothing to accumulate
-        # small updates into.
-        extra_kwargs = {}
+        # Pin fp32 weights regardless of what the remote config declares, so the optimizer always
+        # has full-precision masters to accumulate small updates into; under a ``*-mixed``
+        # precision the Trainer's AMP plugin autocasts to bf16/fp16 around them.  This cannot be
+        # left to Lightning: its ``MixedPrecision`` plugin only wraps forward in ``torch.autocast``
+        # and inherits a no-op ``convert_module``, so it preserves whatever dtype the module was
+        # built with (only the ``*-true`` precisions cast weights).  And it cannot be left to
+        # transformers: ``_from_config`` with no dtype falls back to ``config.dtype``, so any
+        # ``model_name`` whose config.json carries ``torch_dtype: bfloat16`` would silently
+        # produce bf16 masters.
+        #
+        # Spelled ``torch_dtype`` rather than ``dtype`` because the floor of our transformers
+        # range (>=4.48) predates the rename; 4.57 still honors it with a deprecation warning.
+        # Switch to ``dtype`` once the floor moves past 4.56.
+        extra_kwargs = {"torch_dtype": torch.float32}
 
         if HAS_FLASH_ATTN:
             logger.info("Using FlashAttention 2 for the model.")

--- a/src/every_query/model/model.py
+++ b/src/every_query/model/model.py
@@ -147,8 +147,6 @@ class EveryQueryOutput(BaseModelOutput):
             >>> probs.dtype, bool(probs < 1.0)
             (torch.float32, True)
         """
-        # Sigmoid must run in fp32: bf16 saturates to exactly 1.0 at logit ~6 (fp32: ~17),
-        # and these probs are persisted to parquet and fed into AUROC.
         return torch.sigmoid(logits.float()).squeeze()
 
     @property
@@ -320,19 +318,12 @@ class EveryQueryModel(torch.nn.Module):
         if num_hidden_layers is not None:
             self.HF_model_config.num_hidden_layers = num_hidden_layers
 
-        # Pin fp32 weights regardless of what the remote config declares, so the optimizer always
-        # has full-precision masters to accumulate small updates into; under a ``*-mixed``
-        # precision the Trainer's AMP plugin autocasts to bf16/fp16 around them.  This cannot be
-        # left to Lightning: its ``MixedPrecision`` plugin only wraps forward in ``torch.autocast``
-        # and inherits a no-op ``convert_module``, so it preserves whatever dtype the module was
-        # built with (only the ``*-true`` precisions cast weights).  And it cannot be left to
-        # transformers: ``_from_config`` with no dtype falls back to ``config.dtype``, so any
-        # ``model_name`` whose config.json carries ``torch_dtype: bfloat16`` would silently
-        # produce bf16 masters.
-        #
-        # Spelled ``torch_dtype`` rather than ``dtype`` because the floor of our transformers
-        # range (>=4.48) predates the rename; 4.57 still honors it with a deprecation warning.
-        # Switch to ``dtype`` once the floor moves past 4.56.
+        # Pin fp32 weights so the optimizer always has full-precision masters; under a ``*-mixed``
+        # precision the Trainer's AMP plugin autocasts around them.  Not implied by the precision
+        # string: ``_from_config`` with no dtype falls back to ``config.dtype``, so a ``model_name``
+        # whose config.json declares ``torch_dtype: bfloat16`` would silently produce bf16 masters.
+        # Spelled ``torch_dtype`` because our transformers floor (>=4.48) predates the ``dtype``
+        # rename; switch once that floor moves past 4.56.
         extra_kwargs = {"torch_dtype": torch.float32}
 
         if HAS_FLASH_ATTN:

--- a/src/every_query/model/task_auroc_callback.py
+++ b/src/every_query/model/task_auroc_callback.py
@@ -89,7 +89,10 @@ class TaskAurocTrackingCallback(Callback):
         # naive is_global_zero gate + sync_dist=True would deadlock).
         if self._loader is None or not trainer.is_global_zero:
             return
-        self._compute_and_log(pl_module.model, pl_module.device, pl_module.log)
+        # Manual forwards here run outside Lightning's step hooks, so the precision plugin's
+        # autocast context must be entered explicitly to match validation_step numerics.
+        with trainer.precision_plugin.forward_context():
+            self._compute_and_log(pl_module.model, pl_module.device, pl_module.log)
 
     def _compute_and_log(self, model, device, log_fn):
         """Score the pair set and log the macro win/tie/loss AUROC estimate.

--- a/src/every_query/model/task_auroc_callback.py
+++ b/src/every_query/model/task_auroc_callback.py
@@ -103,7 +103,7 @@ class TaskAurocTrackingCallback(Callback):
                 batch = move_data_to_device(batch, device)
                 _, outputs = model(batch)
                 # Squeeze only dim 1 so a trailing size-1 batch doesn't collapse to a 0-d scalar.
-                probs = outputs.occurs_logits.detach().cpu().squeeze(1).sigmoid().float().tolist()
+                probs = outputs.occurs_logits.detach().cpu().squeeze(1).float().sigmoid().tolist()
                 queries = batch.query.detach().cpu().tolist()
                 durations = batch.duration_days.detach().cpu().tolist()
                 labels = batch.occurs.detach().cpu().tolist()

--- a/src/every_query/train/configs/_demo_train.yaml
+++ b/src/every_query/train/configs/_demo_train.yaml
@@ -33,7 +33,7 @@ lightning_module:
   _target_: every_query.model.lightning_module.EveryQueryLightningModule
   model:
     _target_: every_query.model.EveryQueryModel
-    precision: "32-true"
+    precision: ${trainer.precision}
     do_demo: true
     do_grad_ckpt: false
     mlp_dropout: 0.1
@@ -72,6 +72,7 @@ trainer:
   max_steps: 2
   accelerator: cpu
   devices: 1
+  precision: "bf16-mixed"
   accumulate_grad_batches: 1
   log_every_n_steps: 1
   check_val_every_n_epoch: null

--- a/src/every_query/train/configs/config.yaml
+++ b/src/every_query/train/configs/config.yaml
@@ -44,7 +44,7 @@ lightning_module:
   grad_norm_log_every_n_steps: 1000 # log per-task encoder grad norms every N optimizer steps
   model:
     _target_: every_query.model.EveryQueryModel
-    precision: "16-mixed"
+    precision: ${trainer.precision} # single source of truth: the Trainer owns AMP
     do_demo: false
     do_grad_ckpt: false
     mlp_dropout: 0.1
@@ -121,6 +121,8 @@ trainer:
   accelerator: "auto"
   devices: 1
   strategy: "auto"
+  # AMP lives here and nowhere else — weights stay fp32, autocast handles the casting.
+  precision: "bf16-mixed"
   accumulate_grad_batches: 1 # set to 1 for no gradient accumulation, >1 for gradient accumulation
   log_every_n_steps: 50
   # perform a validation loop every N training epochs

--- a/src/every_query/train/configs/fast_config.yaml
+++ b/src/every_query/train/configs/fast_config.yaml
@@ -13,7 +13,6 @@ datamodule:
 
 lightning_module:
   model:
-    precision: "bf16-mixed"
     num_hidden_layers: 4
   optimizer:
     lr: 1.0e-4

--- a/src/every_query/train/resume_check.py
+++ b/src/every_query/train/resume_check.py
@@ -34,6 +34,13 @@ ALLOWED_DIFFERENCE_KEYS = {
     "trainer.max_steps",
     "trainer.max_epochs",
     "trainer.callbacks.early_stopping.patience",
+    # AMP moved from ``lightning_module.model.precision: 16-mixed`` to ``trainer.precision:
+    # bf16-mixed`` (the Trainer now owns autocast; the model field just mirrors it).  Runs
+    # started before that switch have no ``trainer.precision`` key at all and carry the old
+    # model value, so both would otherwise be un-resumable with no CLI override that helps.
+    # Weights are fp32 under both settings, so the checkpoint stays loadable either way.
+    "trainer.precision",
+    "lightning_module.model.precision",
 }
 
 LEGACY_REMOVED_KEYS = {

--- a/src/every_query/train/resume_check.py
+++ b/src/every_query/train/resume_check.py
@@ -34,8 +34,14 @@ ALLOWED_DIFFERENCE_KEYS = {
     "trainer.max_steps",
     "trainer.max_epochs",
     "trainer.callbacks.early_stopping.patience",
-    # AMP moved to ``trainer.precision``: pre-switch runs lack that key and carry the old
-    # ``16-mixed`` model value.  Weights are fp32 either way, so the checkpoint stays loadable.
+}
+
+LEGACY_AMP_KEYS = {
+    # AMP moved to ``trainer.precision``, so a run dir predating the switch has no such key and
+    # still carries ``lightning_module.model.precision: 16-mixed``.  Exempted *only* for those
+    # run dirs (see ``validate_resume_directory``), never allow-listed outright: precision drift
+    # is exactly what this guard exists to catch, and ``bf16-true`` really does cast weights to
+    # bf16 via Lightning's ``HalfPrecision.convert_module``.
     "trainer.precision",
     "lightning_module.model.precision",
 }
@@ -168,7 +174,8 @@ def diff_configs(new_config: dict[str, Any], old_config: dict[str, Any]) -> dict
 def validate_resume_directory(output_dir: Path, cfg: DictConfig) -> None:
     """Raise if the config in ``output_dir/config.yaml`` disagrees with ``cfg`` on any key that matters.
 
-    "Matters" = any key not listed in ``ALLOWED_DIFFERENCE_KEYS``.  The allow-list covers lifecycle
+    "Matters" = any key not listed in ``ALLOWED_DIFFERENCE_KEYS``, plus ``LEGACY_AMP_KEYS`` when the
+    saved config predates the AMP move.  The allow-list covers lifecycle
     flags (``do_resume``, ``do_overwrite``), path fields that legitimately differ between runs, local
     performance knobs, and training-schedule overrides that are reasonable to bump on resume.  Any
     structural drift (model hyperparameters, dataset shape, seed) raises ``ValueError``
@@ -197,9 +204,15 @@ def validate_resume_directory(output_dir: Path, cfg: DictConfig) -> None:
 
     differences = diff_configs(new_cfg, old_cfg)
 
+    # A run dir predating the AMP move is identified by the absence of ``trainer.precision``.
+    # Only those get the ``LEGACY_AMP_KEYS`` exemption; every other precision drift still raises.
+    predates_amp_move = "precision" not in (old_cfg.get("trainer") or {})
+
     err_lines = []
     for key, diff in differences.items():
         if key in ALLOWED_DIFFERENCE_KEYS:
+            continue
+        if predates_amp_move and key in LEGACY_AMP_KEYS:
             continue
         err_lines.append(f"  - key '{key}' {diff}")
 

--- a/src/every_query/train/resume_check.py
+++ b/src/every_query/train/resume_check.py
@@ -34,11 +34,8 @@ ALLOWED_DIFFERENCE_KEYS = {
     "trainer.max_steps",
     "trainer.max_epochs",
     "trainer.callbacks.early_stopping.patience",
-    # AMP moved from ``lightning_module.model.precision: 16-mixed`` to ``trainer.precision:
-    # bf16-mixed`` (the Trainer now owns autocast; the model field just mirrors it).  Runs
-    # started before that switch have no ``trainer.precision`` key at all and carry the old
-    # model value, so both would otherwise be un-resumable with no CLI override that helps.
-    # Weights are fp32 under both settings, so the checkpoint stays loadable either way.
+    # AMP moved to ``trainer.precision``: pre-switch runs lack that key and carry the old
+    # ``16-mixed`` model value.  Weights are fp32 either way, so the checkpoint stays loadable.
     "trainer.precision",
     "lightning_module.model.precision",
 }

--- a/src/every_query/train/train.py
+++ b/src/every_query/train/train.py
@@ -319,6 +319,7 @@ def main(cfg: DictConfig) -> float | None:
         OmegaConf.save(cfg, run_dir / "config.yaml")
         save_resolved_config(cfg, run_dir / "resolved_config.yaml")
 
+    # Kept in step with ``utils/model_loader.py`` so training and scoring use the same matmuls.
     logger.info("Setting torch float32 matmul precision to 'high'.")
     torch.set_float32_matmul_precision("high")
 

--- a/src/every_query/train/train.py
+++ b/src/every_query/train/train.py
@@ -319,8 +319,8 @@ def main(cfg: DictConfig) -> float | None:
         OmegaConf.save(cfg, run_dir / "config.yaml")
         save_resolved_config(cfg, run_dir / "resolved_config.yaml")
 
-    logger.info("Setting torch float32 matmul precision to 'medium'.")
-    torch.set_float32_matmul_precision("medium")
+    logger.info("Setting torch float32 matmul precision to 'high'.")
+    torch.set_float32_matmul_precision("high")
 
     # Seed *before* any `instantiate(...)` call so that model weight init, DataLoader
     # generator construction, and any other RNG-consuming work happen under the seeded

--- a/src/every_query/utils/model_loader.py
+++ b/src/every_query/utils/model_loader.py
@@ -62,8 +62,10 @@ def setup_model(model_run_dir: str | Path, ckpt_name: str | None = None):
         logger.info(f"Seeding with seed={seed}")
         seed_everything(seed, workers=True)
 
-    logger.info("Setting torch float32 matmul precision to 'medium'.")
-    torch.set_float32_matmul_precision("medium")
+    # Must match ``train.py`` — scoring a checkpoint with lower-precision fp32 matmuls than it
+    # was trained under makes offline metrics disagree with in-training validation metrics.
+    logger.info("Setting torch float32 matmul precision to 'high'.")
+    torch.set_float32_matmul_precision("high")
 
     # Resolve checkpoint: explicit name → best_model.ckpt → last.ckpt
     candidates = (

--- a/src/every_query/utils/model_loader.py
+++ b/src/every_query/utils/model_loader.py
@@ -62,8 +62,9 @@ def setup_model(model_run_dir: str | Path, ckpt_name: str | None = None):
         logger.info(f"Seeding with seed={seed}")
         seed_everything(seed, workers=True)
 
-    # Must match ``train.py`` — scoring a checkpoint with lower-precision fp32 matmuls than it
-    # was trained under makes offline metrics disagree with in-training validation metrics.
+    # Raised from "medium" alongside ``train.py``; the two must move together, or a checkpoint
+    # gets scored under different fp32 matmuls than it was trained with and offline metrics stop
+    # agreeing with in-training validation.  Checkpoints trained before that raise saw "medium".
     logger.info("Setting torch float32 matmul precision to 'high'.")
     torch.set_float32_matmul_precision("high")
 

--- a/tests/test_resume_check.py
+++ b/tests/test_resume_check.py
@@ -7,7 +7,11 @@ from typing import TYPE_CHECKING
 import pytest
 from omegaconf import OmegaConf
 
-from every_query.train.resume_check import LEGACY_REMOVED_KEYS, validate_resume_directory
+from every_query.train.resume_check import (
+    ALLOWED_DIFFERENCE_KEYS,
+    LEGACY_REMOVED_KEYS,
+    validate_resume_directory,
+)
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -41,12 +45,9 @@ def test_resume_ignores_legacy_query_stanza(tmp_path: Path) -> None:
 
 
 def test_resume_survives_the_amp_precision_move(tmp_path: Path) -> None:
-    """A run started before AMP moved to the Trainer must still resume.
+    """A run dir predating the AMP move — no ``trainer.precision``, old model value — still resumes."""
+    assert {"trainer.precision", "lightning_module.model.precision"} <= ALLOWED_DIFFERENCE_KEYS
 
-    Such a run dir has no ``trainer.precision`` key and carries the old
-    ``lightning_module.model.precision: 16-mixed``; both are allow-listed because weights are
-    fp32 under either setting, so the checkpoint stays loadable.
-    """
     saved = tmp_path / "config.yaml"
     _write_cfg(
         saved,

--- a/tests/test_resume_check.py
+++ b/tests/test_resume_check.py
@@ -40,6 +40,32 @@ def test_resume_ignores_legacy_query_stanza(tmp_path: Path) -> None:
     validate_resume_directory(tmp_path, new_cfg)
 
 
+def test_resume_survives_the_amp_precision_move(tmp_path: Path) -> None:
+    """A run started before AMP moved to the Trainer must still resume.
+
+    Such a run dir has no ``trainer.precision`` key and carries the old
+    ``lightning_module.model.precision: 16-mixed``; both are allow-listed because weights are
+    fp32 under either setting, so the checkpoint stays loadable.
+    """
+    saved = tmp_path / "config.yaml"
+    _write_cfg(
+        saved,
+        trainer={"accelerator": "auto"},
+        lightning_module={"model": {"precision": "16-mixed"}},
+    )
+
+    new_cfg = OmegaConf.create(
+        {
+            "seed": 140799,
+            "datamodule": {"config": {"max_seq_len": 256}},
+            "trainer": {"accelerator": "auto", "precision": "bf16-mixed"},
+            "lightning_module": {"model": {"precision": "bf16-mixed"}},
+        }
+    )
+
+    validate_resume_directory(tmp_path, new_cfg)
+
+
 def test_resume_rejects_non_legacy_drift(tmp_path: Path) -> None:
     """A structural mismatch outside the allow-list / legacy set must still raise."""
     saved = tmp_path / "config.yaml"

--- a/tests/test_resume_check.py
+++ b/tests/test_resume_check.py
@@ -7,11 +7,7 @@ from typing import TYPE_CHECKING
 import pytest
 from omegaconf import OmegaConf
 
-from every_query.train.resume_check import (
-    ALLOWED_DIFFERENCE_KEYS,
-    LEGACY_REMOVED_KEYS,
-    validate_resume_directory,
-)
+from every_query.train.resume_check import LEGACY_REMOVED_KEYS, validate_resume_directory
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -46,8 +42,6 @@ def test_resume_ignores_legacy_query_stanza(tmp_path: Path) -> None:
 
 def test_resume_survives_the_amp_precision_move(tmp_path: Path) -> None:
     """A run dir predating the AMP move — no ``trainer.precision``, old model value — still resumes."""
-    assert {"trainer.precision", "lightning_module.model.precision"} <= ALLOWED_DIFFERENCE_KEYS
-
     saved = tmp_path / "config.yaml"
     _write_cfg(
         saved,
@@ -65,6 +59,33 @@ def test_resume_survives_the_amp_precision_move(tmp_path: Path) -> None:
     )
 
     validate_resume_directory(tmp_path, new_cfg)
+
+
+def test_resume_still_rejects_precision_drift_after_the_amp_move(tmp_path: Path) -> None:
+    """Once a run dir has ``trainer.precision``, precision drift raises again.
+
+    The legacy exemption must not become a blanket allow-list: ``bf16-true`` casts weights to bf16
+    via Lightning's ``HalfPrecision.convert_module``, so silently accepting it would resume with
+    half-precision masters.
+    """
+    saved = tmp_path / "config.yaml"
+    _write_cfg(
+        saved,
+        trainer={"accelerator": "auto", "precision": "bf16-mixed"},
+        lightning_module={"model": {"precision": "bf16-mixed"}},
+    )
+
+    new_cfg = OmegaConf.create(
+        {
+            "seed": 140799,
+            "datamodule": {"config": {"max_seq_len": 256}},
+            "trainer": {"accelerator": "auto", "precision": "bf16-true"},
+            "lightning_module": {"model": {"precision": "bf16-true"}},
+        }
+    )
+
+    with pytest.raises(ValueError, match="precision"):
+        validate_resume_directory(tmp_path, new_cfg)
 
 
 def test_resume_rejects_non_legacy_drift(tmp_path: Path) -> None:

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -15,7 +15,7 @@ from hydra import compose, initialize_config_dir
 from torch.utils.data import DataLoader
 from transformers import ModernBertConfig
 
-from conftest import DEMO_CONFIG_OVERRIDES
+from conftest import DEMO_CONFIG_OVERRIDES, DEMO_PRECISION
 from every_query.model import EveryQueryModel, EveryQueryOutput
 from every_query.model.lightning_module import EveryQueryLightningModule
 from every_query.train.train import CONFIGS
@@ -71,7 +71,7 @@ class TestModelBackward:
         model = EveryQueryModel(
             config_overrides=DEMO_CONFIG_OVERRIDES,
             do_demo=True,
-            precision="32-true",
+            precision=DEMO_PRECISION,
         )
         model.train()
 
@@ -97,7 +97,7 @@ class TestLightningTrainingStep:
         model = EveryQueryModel(
             config_overrides=DEMO_CONFIG_OVERRIDES,
             do_demo=True,
-            precision="32-true",
+            precision=DEMO_PRECISION,
         )
         module = EveryQueryLightningModule(
             model=model,
@@ -122,7 +122,7 @@ class TestTrainerFitTwoSteps:
         model = EveryQueryModel(
             config_overrides=DEMO_CONFIG_OVERRIDES,
             do_demo=True,
-            precision="32-true",
+            precision=DEMO_PRECISION,
         )
         module = EveryQueryLightningModule(
             model=model,
@@ -165,7 +165,7 @@ class TestCheckpointRoundtrip:
         model = EveryQueryModel(
             config_overrides=DEMO_CONFIG_OVERRIDES,
             do_demo=True,
-            precision="32-true",
+            precision=DEMO_PRECISION,
         )
         module = EveryQueryLightningModule(
             model=model,
@@ -200,7 +200,7 @@ class TestCheckpointRoundtrip:
 
         loaded = EveryQueryLightningModule.load_from_checkpoint(str(ckpt_path))
 
-        assert loaded.hparams["model"]["precision"] == "32-true"
+        assert loaded.hparams["model"]["precision"] == DEMO_PRECISION
         assert loaded.hparams["model"]["do_demo"] is True
         assert loaded.hparams["optimizer"]["_target_"] == "torch.optim.adamw.AdamW"
         assert loaded.hparams["LR_scheduler"] is None
@@ -253,7 +253,7 @@ class TestDemoModeChecks:
         model = EveryQueryModel(
             config_overrides=DEMO_CONFIG_OVERRIDES,
             do_demo=True,
-            precision="32-true",
+            precision=DEMO_PRECISION,
         )
         with torch.no_grad():
             next(iter(model.censor_mlp.parameters())).fill_(float("nan"))

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -259,3 +259,49 @@ class TestDemoModeChecks:
             model(sample_batch)
 
         assert any("nan" in msg.lower() for msg in caplog.messages)
+
+
+# ── test_mixed_precision_wiring ─────────────────────────────────────────
+
+
+class TestMixedPrecisionWiring:
+    """AMP is the Trainer's job; weights stay fp32 so the optimizer has full-precision masters.
+
+    Regression guard: ``lightning_module.model.precision`` used to be set while
+    ``trainer.precision`` was left at Lightning's ``32-true`` default, so runs logged
+    "Using mixed precision" and then trained in fp32 with no autocast anywhere.
+    """
+
+    def test_trainer_config_sets_precision(self):
+        from pathlib import Path
+
+        from hydra import compose, initialize_config_dir
+
+        import every_query.train
+
+        configs = Path(every_query.train.__file__).parent / "configs"
+        with initialize_config_dir(str(configs), version_base=None):
+            cfg = compose(config_name="config")
+        assert cfg.trainer.precision == "bf16-mixed"
+        # The model is told the same thing, so its FlashAttention log matches reality.
+        assert cfg.lightning_module.model.precision == cfg.trainer.precision
+
+    def test_weights_stay_fp32_under_mixed_precision(self):
+        model = EveryQueryModel(config_overrides=DEMO_CONFIG_OVERRIDES, precision="bf16-mixed")
+        assert {p.dtype for p in model.parameters()} == {torch.float32}
+
+    def test_loss_stays_fp32_under_autocast(self, demo_model, sample_batch):
+        """BCEWithLogitsLoss is on autocast's fp32 promote list — no manual wrapping needed."""
+        with torch.autocast("cpu", dtype=torch.bfloat16), torch.no_grad():
+            loss, _ = demo_model(sample_batch)
+        assert loss.dtype is torch.float32
+        assert loss.isfinite()
+
+    def test_predict_step_outputs_are_numpy_convertible(self, demo_lightning_module, sample_batch):
+        """``EQ_predict`` reuses the training precision, and ``.numpy()`` rejects bf16 outright."""
+        with torch.autocast("cpu", dtype=torch.bfloat16):
+            result = demo_lightning_module.predict_step(sample_batch)
+
+        for key in ("occurs_probs", "censor_probs", "query_embed"):
+            assert result[key].dtype is torch.float32, f"{key} is {result[key].dtype}"
+            result[key].reshape(-1).numpy()  # raises TypeError on bf16

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -290,6 +290,25 @@ class TestMixedPrecisionWiring:
         model = EveryQueryModel(config_overrides=DEMO_CONFIG_OVERRIDES, precision="bf16-mixed")
         assert {p.dtype for p in model.parameters()} == {torch.float32}
 
+    def test_weights_stay_fp32_when_the_hf_config_declares_bf16(self):
+        """A published checkpoint whose config.json carries ``torch_dtype: bfloat16`` must not
+        drag the weights down with it.
+
+        ``_from_config`` falls back to ``config.dtype`` when no dtype is passed, so without an
+        explicit ``torch_dtype`` this yields bf16 parameters and the optimizer loses its
+        full-precision masters — autocast is supposed to handle the casting, not the weights.
+        """
+        from transformers import ModernBertConfig
+
+        # Built locally rather than fetched, so the assertion doesn't depend on what the
+        # real ModernBERT config.json happens to declare today.
+        bf16_config = ModernBertConfig(torch_dtype=torch.bfloat16)
+
+        with patch("every_query.model.model.AutoConfig.from_pretrained", return_value=bf16_config):
+            model = EveryQueryModel(config_overrides=DEMO_CONFIG_OVERRIDES, precision="bf16-mixed")
+
+        assert {p.dtype for p in model.parameters()} == {torch.float32}
+
     def test_loss_stays_fp32_under_autocast(self, demo_model, sample_batch):
         """BCEWithLogitsLoss is on autocast's fp32 promote list — no manual wrapping needed."""
         with torch.autocast("cpu", dtype=torch.bfloat16), torch.no_grad():

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -11,11 +11,14 @@ from unittest.mock import patch
 
 import lightning as L
 import torch
+from hydra import compose, initialize_config_dir
 from torch.utils.data import DataLoader
+from transformers import ModernBertConfig
 
 from conftest import DEMO_CONFIG_OVERRIDES
 from every_query.model import EveryQueryModel, EveryQueryOutput
 from every_query.model.lightning_module import EveryQueryLightningModule
+from every_query.train.train import CONFIGS
 
 # ── test_model_forward_shape ────────────────────────────────────────────
 
@@ -265,41 +268,22 @@ class TestDemoModeChecks:
 
 
 class TestMixedPrecisionWiring:
-    """AMP is the Trainer's job; weights stay fp32 so the optimizer has full-precision masters.
-
-    Regression guard: ``lightning_module.model.precision`` used to be set while
-    ``trainer.precision`` was left at Lightning's ``32-true`` default, so runs logged
-    "Using mixed precision" and then trained in fp32 with no autocast anywhere.
-    """
+    """AMP is the Trainer's job; weights stay fp32 so the optimizer has full-precision masters."""
 
     def test_trainer_config_sets_precision(self):
-        from pathlib import Path
-
-        from hydra import compose, initialize_config_dir
-
-        import every_query.train
-
-        configs = Path(every_query.train.__file__).parent / "configs"
-        with initialize_config_dir(str(configs), version_base=None):
+        """``trainer.precision`` drives AMP; the model field mirrors it rather than setting its own."""
+        with initialize_config_dir(CONFIGS, version_base=None):
             cfg = compose(config_name="config")
         assert cfg.trainer.precision == "bf16-mixed"
-        # The model is told the same thing, so its FlashAttention log matches reality.
         assert cfg.lightning_module.model.precision == cfg.trainer.precision
 
-    def test_weights_stay_fp32_under_mixed_precision(self):
-        model = EveryQueryModel(config_overrides=DEMO_CONFIG_OVERRIDES, precision="bf16-mixed")
-        assert {p.dtype for p in model.parameters()} == {torch.float32}
-
     def test_weights_stay_fp32_when_the_hf_config_declares_bf16(self):
-        """A published checkpoint whose config.json carries ``torch_dtype: bfloat16`` must not
-        drag the weights down with it.
+        """A published checkpoint declaring ``torch_dtype: bfloat16`` must not drag the weights down.
 
         ``_from_config`` falls back to ``config.dtype`` when no dtype is passed, so without an
         explicit ``torch_dtype`` this yields bf16 parameters and the optimizer loses its
         full-precision masters — autocast is supposed to handle the casting, not the weights.
         """
-        from transformers import ModernBertConfig
-
         # Built locally rather than fetched, so the assertion doesn't depend on what the
         # real ModernBERT config.json happens to declare today.
         bf16_config = ModernBertConfig(torch_dtype=torch.bfloat16)
@@ -310,17 +294,7 @@ class TestMixedPrecisionWiring:
         assert {p.dtype for p in model.parameters()} == {torch.float32}
 
     def test_loss_stays_fp32_under_autocast(self, demo_model, sample_batch):
-        """BCEWithLogitsLoss is on autocast's fp32 promote list — no manual wrapping needed."""
+        """``binary_cross_entropy_with_logits`` is on autocast's fp32 cast list — no manual wrapping."""
         with torch.autocast("cpu", dtype=torch.bfloat16), torch.no_grad():
             loss, _ = demo_model(sample_batch)
         assert loss.dtype is torch.float32
-        assert loss.isfinite()
-
-    def test_predict_step_outputs_are_numpy_convertible(self, demo_lightning_module, sample_batch):
-        """``EQ_predict`` reuses the training precision, and ``.numpy()`` rejects bf16 outright."""
-        with torch.autocast("cpu", dtype=torch.bfloat16):
-            result = demo_lightning_module.predict_step(sample_batch)
-
-        for key in ("occurs_probs", "censor_probs", "query_embed"):
-            assert result[key].dtype is torch.float32, f"{key} is {result[key].dtype}"
-            result[key].reshape(-1).numpy()  # raises TypeError on bf16

--- a/tests/training_validity/test_training_validity.py
+++ b/tests/training_validity/test_training_validity.py
@@ -241,6 +241,10 @@ def oracle_trained_model_dir(
             # init had the censor head stuck at AUROC 0.765 / flat duration means at 2000
             # steps; that can't happen anymore.
             "trainer.max_steps=2000",
+            # CI runners are CPU-only and lack bf16 fast paths (AMX/AVX512-BF16), so the
+            # _demo_train default of bf16-mixed runs ~3-4x slower than fp32 and blows the
+            # 1800s timeout.  This test checks learning behavior, not AMP, so pin fp32.
+            "trainer.precision=32-true",
             "trainer.max_epochs=10000",
             "trainer.limit_val_batches=2",
             "trainer.val_check_interval=1000",


### PR DESCRIPTION
Under bf16, sigmoid saturates to exactly 1.0 at a logit of ~6 (fp32: ~17), so any probability that gets persisted or fed into a ranking metric must be computed in fp32 rather than cast afterward. This moves AMP to the Trainer and fixes the probability path.

## Changes

**fp32 sigmoid on every probability path.** `logits_to_probs` upcasts before the sigmoid, and both AUROC sites (`lightning_module`, `task_auroc_callback`) reorder to `.float().sigmoid()`. This is load-bearing: `occurs_logits`/`censor_logits` really are bf16 inside `validation_step`. With the old ordering, `torch.tensor([7, 8, 9, 10], bf16).sigmoid().float()` collapses to a single value of `1.0` and AUROC ranking is destroyed; with the new one it yields four distinct probabilities.

**AMP moves to the Trainer.** `trainer.precision: bf16-mixed` is now the single source of truth, with `lightning_module.model.precision` interpolating from it. Weights are pinned to fp32 at construction so the optimizer keeps full-precision masters, and autocast does the casting. The pin is explicit rather than implied: `_from_config` falls back to `config.dtype` when no dtype is passed, so a `model_name` whose config.json declares `torch_dtype: bfloat16` would otherwise produce bf16 masters. `PRECISION_TO_MODEL_WEIGHTS_DTYPE` is removed.

**Resume compatibility.** Run dirs created before the AMP move have no `trainer.precision` key and carry `lightning_module.model.precision: 16-mixed`, which would fail `do_resume=true` with no CLI override that helps. Those two keys are exempted via `LEGACY_AMP_KEYS`, but only when the saved config has no `trainer.precision` at all — the signature of a pre-move run dir. Every other precision drift still raises, which matters because `bf16-true` casts weights to bf16 through Lightning's `HalfPrecision.convert_module` at fit time regardless of the fp32 pin.

**float32 matmul precision raised to `"high"`** in both `train.py` and `model_loader.py`. Flagging this as the one change here that isn't strictly AMP: both files were `"medium"` before, so this is a deliberate raise rather than a repair, and it moves them together so a checkpoint isn't scored under different matmuls than it was trained with. Checkpoints trained before this saw `"medium"`.

## Testing

Full suite run offline: **312 passed**, plus the 1 slow-marked test. `ruff-format`, `ruff check`, `docformatter 1.7.7`, and `codespell 2.4.1` all clean at the pinned pre-commit versions.

Behavior verified directly rather than assumed:

- Weights stay fp32 when the HF config declares `torch_dtype: bfloat16`; stripping the pin yields bf16, so the test is non-vacuous.
- `torch_dtype` (rather than `dtype`) is the spelling that works across the whole declared transformers range — 4.48 pops it in `_from_config`, and 4.57 still honors it with a logger-level deprecation notice that no `-W error` setup would catch.
- Under autocast the linear layers emit bf16 while `query_embed` stays fp32, since ModernBERT's residual stream never leaves fp32.
- `${trainer.precision}` resolves in `config.yaml` and `fast_config.yaml`, `_demo_train.yaml` is unaffected, and `instantiate(cfg.trainer)` yields `MixedPrecision(bf16-mixed)`.
- Resume across the AMP move succeeds; `bf16-mixed → bf16-true`, `→ 32-true`, and `→ 16-mixed` all still raise.

## Known gap

No integration test exercises `trainer.precision: bf16-mixed` end to end — the E2E fixtures run under `_demo_train.yaml`, which pins `32-true`. The path was verified manually (train → resume → `EQ_predict save_embeddings=true`), but there is no automated guard on it.