### PR TITLE
LR warmup as a fraction of total optimizer steps via warmup_ratio

### DIFF
--- a/src/every_query/model/lightning_module.py
+++ b/src/every_query/model/lightning_module.py
@@ -1,4 +1,5 @@
 import copy
+import inspect
 import logging
 import re
 from collections.abc import Callable, Iterator
@@ -115,19 +116,38 @@ def _dict_to_factory(d: dict[str, Any] | None) -> partial | None:
 
 
 class EveryQueryLightningModule(L.LightningModule):
-    """LightningModule for EveryQuery with factory-friendly optimizers and metrics."""
+    """LightningModule for EveryQuery with factory-friendly optimizers and metrics.
+
+    ``warmup_ratio`` is the fraction of total optimizer steps spent in LR warmup; the
+    step counts themselves are derived from the trainer at fit time (see
+    ``configure_optimizers``).  It must lie in ``[0.0, 1.0]``:
+
+    Examples:
+        >>> EveryQueryLightningModule(model=demo_model, warmup_ratio=1.5)
+        Traceback (most recent call last):
+            ...
+        ValueError: warmup_ratio must be in [0.0, 1.0], got 1.5
+        >>> EveryQueryLightningModule(model=demo_model, warmup_ratio=-0.1)
+        Traceback (most recent call last):
+            ...
+        ValueError: warmup_ratio must be in [0.0, 1.0], got -0.1
+    """
 
     def __init__(
         self,
         model: EveryQueryModel,
         optimizer: Callable[[Iterator[torch.nn.parameter.Parameter]], torch.optim.Optimizer] | None = None,
-        LR_scheduler: Callable[[torch.optim.Optimizer], torch.optim.lr_scheduler._LRScheduler] | None = None,
+        LR_scheduler: Callable[..., Any] | None = None,
+        warmup_ratio: float = 0.0,
         grad_norm_log_every_n_steps: int = 1000,
     ):
         super().__init__()
+        if not 0.0 <= warmup_ratio <= 1.0:
+            raise ValueError(f"warmup_ratio must be in [0.0, 1.0], got {warmup_ratio}")
         self.model = model
         self.optimizer_factory = optimizer
         self.LR_scheduler_factory = LR_scheduler
+        self.warmup_ratio = warmup_ratio
         # Logging knob only — intentionally kept out of save_hyperparameters so old
         # checkpoints load unchanged and load_from_checkpoint needs no edits.
         self.grad_norm_log_every_n_steps = grad_norm_log_every_n_steps
@@ -149,6 +169,7 @@ class EveryQueryLightningModule(L.LightningModule):
                 "model": getattr(model, "hparams", {}),
                 "optimizer": _factory_to_dict(self.optimizer_factory),
                 "LR_scheduler": _factory_to_dict(self.LR_scheduler_factory),
+                "warmup_ratio": warmup_ratio,
             }
         )
 
@@ -515,6 +536,37 @@ class EveryQueryLightningModule(L.LightningModule):
             >>> result_sched['lr_scheduler']['interval']
             'step'
 
+            HF-style schedulers get their step counts from the trainer at fit time:
+            ``warmup_ratio=0.1`` of 10,000 estimated stepping batches gives 1,000
+            warmup steps, so the LR ramp is halfway done at step 500:
+
+            >>> from unittest.mock import Mock
+            >>> from transformers import get_cosine_schedule_with_warmup
+            >>> module_warm = EveryQueryLightningModule(
+            ...     model=demo_model,
+            ...     optimizer=partial(torch.optim.AdamW, lr=1e-4),
+            ...     LR_scheduler=partial(get_cosine_schedule_with_warmup),
+            ...     warmup_ratio=0.1,
+            ... )
+            >>> trainer = Mock(estimated_stepping_batches=10_000)
+            >>> module_warm.trainer = trainer
+            >>> sched_cfg = module_warm.configure_optimizers()['lr_scheduler']
+            >>> sched_cfg['interval'], sched_cfg['frequency']
+            ('step', 1)
+            >>> sched_cfg['scheduler'].lr_lambdas[0](500)
+            0.5
+
+            With the default ``warmup_ratio=0.0`` the schedule starts at full LR:
+
+            >>> module_no_warm = EveryQueryLightningModule(
+            ...     model=demo_model,
+            ...     optimizer=partial(torch.optim.AdamW, lr=1e-4),
+            ...     LR_scheduler=partial(get_cosine_schedule_with_warmup),
+            ... )
+            >>> module_no_warm.trainer = trainer
+            >>> module_no_warm.configure_optimizers()['lr_scheduler']['scheduler'].lr_lambdas[0](0)
+            1.0
+
             ``ReduceLROnPlateau`` gets epoch-level monitoring instead:
 
             >>> module_plateau = EveryQueryLightningModule(
@@ -541,7 +593,20 @@ class EveryQueryLightningModule(L.LightningModule):
         if self.LR_scheduler_factory is None:
             return optimizer
 
-        scheduler = self.LR_scheduler_factory(optimizer)
+        scheduler_kwargs = {}
+        # HF-style schedulers size warmup against the full schedule.  Both step counts
+        # are derived here at fit time — estimated_stepping_batches is Lightning's own
+        # accounting of epochs, accumulation, and world size — so the Hydra config only
+        # ever specifies warmup_ratio.  Torch schedulers (StepLR, ReduceLROnPlateau, ...)
+        # don't accept these kwargs, so only factories whose signature does get them.
+        if "num_training_steps" in inspect.signature(self.LR_scheduler_factory).parameters:
+            num_training_steps = self.trainer.estimated_stepping_batches
+            scheduler_kwargs = {
+                "num_warmup_steps": int(self.warmup_ratio * num_training_steps),
+                "num_training_steps": num_training_steps,
+            }
+
+        scheduler = self.LR_scheduler_factory(optimizer, **scheduler_kwargs)
 
         LR_config = {
             "scheduler": scheduler,
@@ -597,6 +662,37 @@ class EveryQueryLightningModule(L.LightningModule):
             >>> torch.equal(next(loaded.parameters()), next(demo_lightning_module.parameters()))
             True
 
+        ``warmup_ratio`` survives the round-trip too:
+
+            >>> module_warm = EveryQueryLightningModule(
+            ...     model=demo_model,
+            ...     optimizer=partial(torch.optim.AdamW, lr=1e-4),
+            ...     warmup_ratio=0.25,
+            ... )
+            >>> with tempfile.TemporaryDirectory() as tmpdir:
+            ...     warm_path = tmpdir + "/warm.ckpt"
+            ...     torch.save({
+            ...         'state_dict': module_warm.state_dict(),
+            ...         'hyper_parameters': dict(module_warm.hparams),
+            ...         'pytorch-lightning_version': L.__version__,
+            ...     }, warm_path)
+            ...     EveryQueryLightningModule.load_from_checkpoint(warm_path).warmup_ratio
+            0.25
+
+        Older checkpoints without a ``warmup_ratio`` hyper-parameter default to ``0.0``:
+
+            >>> old_hparams = dict(demo_lightning_module.hparams)
+            >>> _ = old_hparams.pop("warmup_ratio")
+            >>> with tempfile.TemporaryDirectory() as tmpdir:
+            ...     old_path = tmpdir + "/old.ckpt"
+            ...     torch.save({
+            ...         'state_dict': demo_lightning_module.state_dict(),
+            ...         'hyper_parameters': old_hparams,
+            ...         'pytorch-lightning_version': L.__version__,
+            ...     }, old_path)
+            ...     EveryQueryLightningModule.load_from_checkpoint(old_path).warmup_ratio
+            0.0
+
         A checkpoint missing a required hparam key raises ``KeyError``:
 
             >>> with tempfile.TemporaryDirectory() as tmpdir:
@@ -631,4 +727,6 @@ class EveryQueryLightningModule(L.LightningModule):
             model=model,
             optimizer=optimizer,
             LR_scheduler=LR_scheduler,
+            # Checkpoints predating warmup_ratio simply had no warmup.
+            warmup_ratio=hparams.get("warmup_ratio", 0.0),
         )

--- a/src/every_query/model/lightning_module.py
+++ b/src/every_query/model/lightning_module.py
@@ -1,5 +1,4 @@
 import copy
-import inspect
 import logging
 import re
 from collections.abc import Callable, Iterator
@@ -499,7 +498,9 @@ class EveryQueryLightningModule(L.LightningModule):
         """Builds optimizer (and optional LR scheduler) with norm/bias weight-decay separation.
 
         Returns an optimizer when no LR scheduler factory is set, or a dict with
-        ``"optimizer"`` and ``"lr_scheduler"`` keys when one is provided.
+        ``"optimizer"`` and ``"lr_scheduler"`` keys when one is provided.  The factory
+        must be HF-style, i.e. accept ``num_warmup_steps`` and ``num_training_steps``
+        keyword arguments (e.g. ``transformers.get_cosine_schedule_with_warmup``).
 
         Raises:
             ValueError: If no optimizer factory was provided at init time.
@@ -523,20 +524,8 @@ class EveryQueryLightningModule(L.LightningModule):
                 ...
             ValueError: Optimizer factory is not set. Cannot configure optimizers.
 
-            With an LR scheduler, returns a dict containing optimizer and scheduler config:
-
-            >>> module_with_sched = EveryQueryLightningModule(
-            ...     model=demo_model,
-            ...     optimizer=partial(torch.optim.AdamW, lr=1e-4),
-            ...     LR_scheduler=partial(torch.optim.lr_scheduler.StepLR, step_size=1),
-            ... )
-            >>> result_sched = module_with_sched.configure_optimizers()
-            >>> sorted(result_sched.keys())
-            ['lr_scheduler', 'optimizer']
-            >>> result_sched['lr_scheduler']['interval']
-            'step'
-
-            HF-style schedulers get their step counts from the trainer at fit time:
+            With an LR scheduler, returns a dict containing optimizer and scheduler config.
+            The scheduler's step counts come from the trainer at fit time:
             ``warmup_ratio=0.1`` of 10,000 estimated stepping batches gives 1,000
             warmup steps, so the LR ramp is halfway done at step 500:
 
@@ -550,10 +539,12 @@ class EveryQueryLightningModule(L.LightningModule):
             ... )
             >>> trainer = Mock(estimated_stepping_batches=10_000)
             >>> module_warm.trainer = trainer
-            >>> sched_cfg = module_warm.configure_optimizers()['lr_scheduler']
-            >>> sched_cfg['interval'], sched_cfg['frequency']
+            >>> result_sched = module_warm.configure_optimizers()
+            >>> sorted(result_sched.keys())
+            ['lr_scheduler', 'optimizer']
+            >>> result_sched['lr_scheduler']['interval'], result_sched['lr_scheduler']['frequency']
             ('step', 1)
-            >>> sched_cfg['scheduler'].lr_lambdas[0](500)
+            >>> result_sched['lr_scheduler']['scheduler'].lr_lambdas[0](500)
             0.5
 
             With the default ``warmup_ratio=0.0`` the schedule starts at full LR:
@@ -566,19 +557,6 @@ class EveryQueryLightningModule(L.LightningModule):
             >>> module_no_warm.trainer = trainer
             >>> module_no_warm.configure_optimizers()['lr_scheduler']['scheduler'].lr_lambdas[0](0)
             1.0
-
-            ``ReduceLROnPlateau`` gets epoch-level monitoring instead:
-
-            >>> module_plateau = EveryQueryLightningModule(
-            ...     model=demo_model,
-            ...     optimizer=partial(torch.optim.AdamW, lr=1e-4),
-            ...     LR_scheduler=partial(torch.optim.lr_scheduler.ReduceLROnPlateau),
-            ... )
-            >>> result_plateau = module_plateau.configure_optimizers()
-            >>> result_plateau['lr_scheduler']['interval']
-            'epoch'
-            >>> result_plateau['lr_scheduler']['monitor']
-            'tuning/loss'
         """
         if self.optimizer_factory is None:
             raise ValueError("Optimizer factory is not set. Cannot configure optimizers.")
@@ -593,40 +571,21 @@ class EveryQueryLightningModule(L.LightningModule):
         if self.LR_scheduler_factory is None:
             return optimizer
 
-        scheduler_kwargs = {}
         # HF-style schedulers size warmup against the full schedule.  Both step counts
         # are derived here at fit time — estimated_stepping_batches is Lightning's own
         # accounting of epochs, accumulation, and world size — so the Hydra config only
-        # ever specifies warmup_ratio.  Torch schedulers (StepLR, ReduceLROnPlateau, ...)
-        # don't accept these kwargs, so only factories whose signature does get them.
-        if "num_training_steps" in inspect.signature(self.LR_scheduler_factory).parameters:
-            num_training_steps = self.trainer.estimated_stepping_batches
-            scheduler_kwargs = {
-                "num_warmup_steps": int(self.warmup_ratio * num_training_steps),
-                "num_training_steps": num_training_steps,
-            }
+        # ever specifies warmup_ratio.
+        num_training_steps = self.trainer.estimated_stepping_batches
+        scheduler = self.LR_scheduler_factory(
+            optimizer,
+            num_warmup_steps=int(self.warmup_ratio * num_training_steps),
+            num_training_steps=num_training_steps,
+        )
 
-        scheduler = self.LR_scheduler_factory(optimizer, **scheduler_kwargs)
-
-        LR_config = {
-            "scheduler": scheduler,
-            "frequency": 1,
+        return {
+            "optimizer": optimizer,
+            "lr_scheduler": {"scheduler": scheduler, "interval": "step", "frequency": 1},
         }
-
-        if isinstance(scheduler, torch.optim.lr_scheduler.ReduceLROnPlateau):
-            # ReduceLROnPlateau requires observing stable trends to make a conclusion about LR decay, so an
-            # epcoh level interval is more appropriate.
-
-            LR_config["monitor"] = "tuning/loss"
-            LR_config["strict"] = True
-            LR_config["interval"] = "epoch"
-        else:
-            # All other schedulers operate at a step level as they do not monitor the loss to make a
-            # conclusion about LR decay.
-
-            LR_config["interval"] = "step"
-
-        return {"optimizer": optimizer, "lr_scheduler": LR_config}
 
     @classmethod
     def load_from_checkpoint(cls, ckpt_path: str | None = None) -> "EveryQueryLightningModule":

--- a/src/every_query/model/lightning_module.py
+++ b/src/every_query/model/lightning_module.py
@@ -1,5 +1,6 @@
 import copy
 import logging
+import math
 import re
 from collections.abc import Callable, Iterator
 from functools import partial
@@ -576,6 +577,13 @@ class EveryQueryLightningModule(L.LightningModule):
         # accounting of epochs, accumulation, and world size — so the Hydra config only
         # ever specifies warmup_ratio.
         num_training_steps = self.trainer.estimated_stepping_batches
+
+        if not math.isfinite(num_training_steps) or num_training_steps <= 0:
+            raise ValueError(
+                f"Cannot construct LR schedule with "
+                f"estimated_stepping_batches={num_training_steps}. "
+                "Set a finite Trainer(max_steps=...) or use a finite dataloader."
+            )
         scheduler = self.LR_scheduler_factory(
             optimizer,
             num_warmup_steps=int(self.warmup_ratio * num_training_steps),

--- a/src/every_query/train/configs/config.yaml
+++ b/src/every_query/train/configs/config.yaml
@@ -63,11 +63,12 @@ lightning_module:
     betas: [0.9, 0.999] # default betas (standard)
     amsgrad: false # default amsgrad (standard)
     fused: false # default fused (standard)
+  # Fraction of total optimizer steps spent in LR warmup; the module derives the
+  # actual step counts from trainer.estimated_stepping_batches at fit time.
+  warmup_ratio: 0.05
   LR_scheduler:
     _target_: transformers.get_cosine_schedule_with_warmup
     _partial_: true
-    num_warmup_steps: ${int_prod:0.05,${.num_training_steps}} # ~10% of training steps
-    num_training_steps: ${trainer.max_steps}
     num_cycles: 0.5
 
 trainer:

--- a/tests/test_lightning_logic.py
+++ b/tests/test_lightning_logic.py
@@ -94,6 +94,56 @@ class TestWeightDecayParamGroupSeparation:
         )
 
 
+class TestWarmupStepsFromRatio:
+    """``configure_optimizers`` sizes warmup as ``warmup_ratio * estimated_stepping_batches``."""
+
+    @pytest.mark.parametrize(
+        ("total_steps", "ratio", "expected_warmup"),
+        [(100, 0.10, 10), (1000, 0.0, 0), (7, 0.5, 3)],  # last case: int() truncates 3.5
+    )
+    def test_warmup_steps(self, demo_model, total_steps, ratio, expected_warmup):
+        from unittest.mock import Mock
+
+        captured = {}
+
+        def spy_scheduler(optimizer, num_warmup_steps, num_training_steps):
+            captured["num_warmup_steps"] = num_warmup_steps
+            captured["num_training_steps"] = num_training_steps
+            return Mock()
+
+        module = EveryQueryLightningModule(
+            model=demo_model,
+            optimizer=partial(torch.optim.AdamW, lr=1e-4),
+            LR_scheduler=partial(spy_scheduler),
+            warmup_ratio=ratio,
+        )
+        module.trainer = Mock(estimated_stepping_batches=total_steps)
+
+        module.configure_optimizers()
+
+        assert captured == {"num_warmup_steps": expected_warmup, "num_training_steps": total_steps}
+
+    def test_production_scheduler_partial_ramps_over_warmup(self, demo_model):
+        """The exact config.yaml partial (cosine + num_cycles=0.5) accepts the derived step counts."""
+        from unittest.mock import Mock
+
+        from transformers import get_cosine_schedule_with_warmup
+
+        module = EveryQueryLightningModule(
+            model=demo_model,
+            optimizer=partial(torch.optim.AdamW, lr=1e-4),
+            LR_scheduler=partial(get_cosine_schedule_with_warmup, num_cycles=0.5),
+            warmup_ratio=0.10,
+        )
+        module.trainer = Mock(estimated_stepping_batches=100)
+
+        scheduler = module.configure_optimizers()["lr_scheduler"]["scheduler"]
+
+        lr_lambda = scheduler.lr_lambdas[0]
+        assert lr_lambda(5) == pytest.approx(0.5)  # halfway through the 10-step warmup
+        assert lr_lambda(10) == pytest.approx(1.0)  # warmup complete at step 10
+
+
 class TestPredictProbsEqualSigmoidOfLogits:
     """``predict_step`` probabilities must numerically equal ``sigmoid(logits).squeeze()``.
 


### PR DESCRIPTION
## Summary

Replaces the previous design (deriving `trainer.max_steps` from the data) with a simpler one: `EveryQueryLightningModule` now takes a `warmup_ratio` argument and derives LR scheduler step counts from Lightning at fit time.

- New `warmup_ratio: float = 0.0` on `EveryQueryLightningModule`, validated to lie in `[0.0, 1.0]` and saved in hyperparameters.
- In `configure_optimizers()`, `num_training_steps` comes from `trainer.estimated_stepping_batches` (which accounts for gradient accumulation and world size) and `num_warmup_steps = int(warmup_ratio * num_training_steps)`; both are passed to the scheduler factory. The Hydra config no longer specifies step counts — just `warmup_ratio` and a bare `get_cosine_schedule_with_warmup` partial.
- LR scheduler factories are now committed to being HF-style (accepting `num_warmup_steps`/`num_training_steps`); the `ReduceLROnPlateau` epoch-interval branch and torch-scheduler support are removed.
- `load_from_checkpoint()` restores `warmup_ratio`; older checkpoints without it default to `0.0`.
- Doctests cover the 0.1 × 10,000 → 1,000 warmup-step derivation, `warmup_ratio=0.0`, invalid ratios, checkpoint round-trip, and old-checkpoint compatibility.

## Test plan

- `uv run pytest --doctest-modules src/every_query/model/lightning_module.py tests/test_lightning_logic.py tests/test_training.py` (38 passed)
- Verified the edited train config composes and instantiates the scheduler factory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)