### PR TITLE
Remove trainer.max_steps from train configs; steps come from the data

### DIFF
--- a/src/every_query/train/configs/_demo_train.yaml
+++ b/src/every_query/train/configs/_demo_train.yaml
@@ -71,7 +71,6 @@ trainer:
   default_root_dir: ${output_dir}
   min_epochs: 0
   max_epochs: 1
-  max_steps: 2
   accelerator: cpu
   devices: 1
   precision: "bf16-mixed"

--- a/src/every_query/train/configs/config.yaml
+++ b/src/every_query/train/configs/config.yaml
@@ -117,8 +117,7 @@ trainer:
     task_auroc_tracking: null
   default_root_dir: ${hydra:runtime.output_dir} # single source of truth: run.dir OR sweep.dir/subdir
   min_epochs: 0 # prevents early stopping
-  max_epochs: null # We don't control the max epochs, we control the max steps.
-  max_steps: 80000
+  max_epochs: 1 # total steps come from the data: one pass over the train set
   accelerator: "auto"
   devices: 1
   strategy: "auto"

--- a/tests/test_train.py
+++ b/tests/test_train.py
@@ -69,14 +69,13 @@ def test_resolved_config_captures_overrides(
 
 
 def test_checkpoint_metadata(eq_trained_model_dir: Path) -> None:
-    """Lightning checkpoint carries the expected training-state keys and matches ``max_steps=2``."""
+    """Lightning checkpoint carries the expected training-state keys and shows training ran."""
     _, ckpt = _highest_step_checkpoint(eq_trained_model_dir)
     for key in ("state_dict", "optimizer_states", "global_step", "epoch", "hyper_parameters"):
         assert key in ckpt, f"checkpoint missing expected key {key!r}"
-    # Demo config has max_steps=2; global_step advances once per optimizer step.
-    assert ckpt["global_step"] == 2, (
-        f"demo training ran for {ckpt['global_step']} steps, expected 2 per _demo_train.yaml"
-    )
+    # Demo config trains one full epoch (max_epochs=1, no max_steps); the exact step count
+    # depends on the fixture dataset size, so just assert optimizer steps actually happened.
+    assert ckpt["global_step"] > 0, f"demo training ran for {ckpt['global_step']} steps, expected at least 1"
     # State dict is non-empty and carries the model-parameter keys Lightning persists
     # under the `HF_model.` / `model.` prefixes (loose check rather than a specific
     # architecture prefix — this test's job is to catch "checkpoint has no weights" as a
@@ -115,15 +114,17 @@ def test_resume_actually_loads_checkpoint_state(
     1. **No-op resume (``max_steps`` == starting ``global_step``)**: a real resume immediately
        exits ``trainer.fit`` because the max-steps budget is already spent — so both
        ``global_step`` and the weight tensors stay identical.  A silently-dropped resume
-       that started fresh training would run 2 new optimizer steps against random weights
-       and would land the state_dict somewhere completely different, with ``global_step``
-       back at 2 but tensors mismatching the pre-run snapshot.  Verifying **weights
+       that started fresh training would run new optimizer steps against random weights
+       and land the state_dict somewhere completely different.  Verifying **weights
        unchanged** here is what distinguishes "resume" from "coincidentally-same-step
-       fresh run" (both advance ``global_step`` to 2; only a real resume keeps the weights).
+       fresh run" (only a real resume keeps the weights).
     2. **Advancing resume (``max_steps`` > starting ``global_step``)**: after a real resume
-       from step 2 with ``max_steps=4``, at least one parameter tensor has to differ from
-       the starting snapshot (otherwise the optimizer isn't training anything — zero-lr
+       with ``max_steps = starting_step + 2``, at least one parameter tensor has to differ
+       from the starting snapshot (otherwise the optimizer isn't training anything — zero-lr
        bug, frozen params, or ``trainer.fit`` not actually running).
+
+    ``max_steps`` no longer lives in the demo config (steps come from the data), so both
+    overrides are added with ``+trainer.max_steps=...``.
 
     Bundling both into one test keeps them on the same staged resume-dir fixture so setup
     cost amortizes.  Pre-#86-style reinit-on-resume bugs fail the first check; zero-lr /
@@ -136,7 +137,7 @@ def test_resume_actually_loads_checkpoint_state(
 
     _, start_ckpt = _highest_step_checkpoint(resume_dir)
     starting_step = start_ckpt["global_step"]
-    assert starting_step == 2, f"sanity: fixture trained to step 2, got {starting_step}"
+    assert starting_step > 0, f"sanity: fixture checkpoint has no optimizer steps ({starting_step})"
     start_sd = start_ckpt["state_dict"]
 
     # ── (1) No-op resume — max_steps == starting global_step ─────────────────────
@@ -149,7 +150,7 @@ def test_resume_actually_loads_checkpoint_state(
             f"datamodule.config.task_labels_dir={eq_sampled_tasks_dir!s}",
             "do_overwrite=False",
             "do_resume=True",
-            f"trainer.max_steps={starting_step}",
+            f"+trainer.max_steps={starting_step}",
         ],
         timeout=300.0,
     )
@@ -180,7 +181,10 @@ def test_resume_actually_loads_checkpoint_state(
             f"datamodule.config.task_labels_dir={eq_sampled_tasks_dir!s}",
             "do_overwrite=False",
             "do_resume=True",
-            "trainer.max_steps=4",
+            # The fixture run spent its whole max_epochs=1 budget, so grant another epoch
+            # alongside the step bump — otherwise fit exits before taking any steps.
+            "trainer.max_epochs=2",
+            f"+trainer.max_steps={starting_step + 2}",
         ],
         timeout=300.0,
     )

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -99,7 +99,7 @@ class TestTrainResume:
             output_dir,
             do_resume=True,
             do_overwrite=False,
-            extra_overrides=["trainer.max_steps=4"],
+            extra_overrides=["+trainer.max_steps=4"],
         )
         assert resumed.returncode == 0, (
             f"Resumed training failed (rc={resumed.returncode}).\nstderr:\n{resumed.stderr}"
@@ -263,7 +263,7 @@ class TestWandbRunIdContinuity:
             output_dir,
             do_resume=True,
             do_overwrite=False,
-            extra_overrides=[logger_override, "trainer.max_steps=4"],
+            extra_overrides=[logger_override, "+trainer.max_steps=4"],
         )
         assert resumed.returncode == 0, (
             f"Resumed training failed (rc={resumed.returncode}).\nstderr:\n{resumed.stderr}"

--- a/tests/training_validity/test_training_validity.py
+++ b/tests/training_validity/test_training_validity.py
@@ -240,7 +240,7 @@ def oracle_trained_model_dir(
             # now platform-independent for a given `cfg.seed`.  Before that, an unlucky 3.12
             # init had the censor head stuck at AUROC 0.765 / flat duration means at 2000
             # steps; that can't happen anymore.
-            "trainer.max_steps=2000",
+            "+trainer.max_steps=2000",
             # CI runners are CPU-only and lack bf16 fast paths (AMX/AVX512-BF16), so the
             # _demo_train default of bf16-mixed runs ~3-4x slower than fp32 and blows the
             # 1800s timeout.  This test checks learning behavior, not AMP, so pin fp32.


### PR DESCRIPTION
## Summary
- `config.yaml`: drop the hardcoded `trainer.max_steps: 80000` and set `max_epochs: 1`, so the LR scheduler's total step count comes from the dataset via `trainer.estimated_stepping_batches` (one full pass over the train set). Previously a 20M-example run had its cosine schedule capped at 80k steps (~half an epoch at batch 128), with warmup at 4k.
- `_demo_train.yaml`: drop `max_steps: 2`; the demo now trains its one epoch of fixture data.
- `fast_config.yaml` is unchanged — it still layers `max_steps: 400` over the base config, which composes fine.

## Test updates
- CLI overrides of `trainer.max_steps` now need Hydra's `+` prefix since the key no longer exists in the config (`test_train.py`, `test_train_cli.py`, `test_training_validity.py`).
- `test_checkpoint_metadata` no longer hardcodes `global_step == 2` (was tied to the demo's `max_steps=2`); it asserts optimizer steps actually happened.
- The advancing-resume differential also passes `trainer.max_epochs=2`, because the fixture run now spends its full 1-epoch budget and resume would otherwise exit before taking any steps. Both `trainer.max_steps` and `trainer.max_epochs` are already in `ALLOWED_DIFFERENCE_KEYS`, so resume validation accepts them.

## Testing
- `tests/test_train.py`, `tests/test_train_cli.py`, `tests/test_e2e_foundation.py` pass locally (20 tests).
- Verified Hydra composition of all three configs, including `fast_config`'s `max_steps` overlay and a `+trainer.max_steps=4` CLI override on the demo config.
- `training_validity` (~30 min CPU) left for CI; its only change is the `+` prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)