### PR TITLE
Truncate eval prediction times at MEDS_DEATH (#290)

### DIFF
--- a/src/every_query/generate_tasks/sample_evaluation_tasks.py
+++ b/src/every_query/generate_tasks/sample_evaluation_tasks.py
@@ -11,7 +11,9 @@ Pipeline:
     1. For each shard discovered under ``{data_dir}/data/{split}/*.parquet``,
        sample up to ``K`` candidate prediction times per subject (any event time
        at which the subject has accumulated at least ``min_context_per_subject``
-       prior events).
+       prior events), after truncating each subject's record at ``MEDS_DEATH``
+       so post-death timestamps are neither prediction times nor context (#290,
+       matching training's Stage 0).
     2. Cross-join with the full ``(codes x durations)`` grid.
     3. Label via :func:`every_query.generate_tasks.sample_tasks.evaluate_index_df`
        (single ``join_asof`` across the whole index frame).
@@ -40,6 +42,7 @@ from every_query.generate_tasks.sample_tasks import (
     _read_event_shard,
     _require_path_arg,
     _split_shards,
+    _truncate_at_death,
     evaluate_index_df,
     read_query_codes,
 )
@@ -347,9 +350,25 @@ def run_worker(
             subject_subsample_fraction,
         )
 
+    # Death is terminal (#257/#265/#290): a timestamp strictly after a subject's earliest
+    # ``MEDS_DEATH`` row must not become a prediction time, nor count as context toward
+    # ``min_context_per_subject``.  Training's Stage 0 truncates before sampling
+    # (:func:`~every_query.generate_tasks.sample_tasks._read_prediction_time_shard`); doing the
+    # same here keeps the eval prediction-time distribution matched to training's instead of
+    # scoring the model on post-death contexts it never saw.  Labeling below still receives the
+    # untruncated ``events_df`` — :func:`evaluate_index_df` applies its own truncation, mirroring
+    # the training pipeline's split between prediction-time truncation and labeling.
+    pt_events_df = _truncate_at_death(events_df)
+    if pt_events_df.height != events_df.height:
+        logger.info(
+            "Dropped %d post-death events before prediction-time sampling (%d remain)",
+            events_df.height - pt_events_df.height,
+            pt_events_df.height,
+        )
+
     pt_seed = derive_seed(seed, "prediction_times", split, input_shard)
     pred_times = sample_prediction_times_per_subject(
-        events_df=events_df,
+        events_df=pt_events_df,
         k=prediction_times_per_subject,
         min_context_per_subject=min_context_per_subject,
         seed=pt_seed,

--- a/src/every_query/generate_tasks/sample_tasks.py
+++ b/src/every_query/generate_tasks/sample_tasks.py
@@ -357,8 +357,10 @@ def _truncate_at_death(events_df: pl.DataFrame) -> pl.DataFrame:
 
     ``<=`` keeps the death row itself, so ``MEDS_DEATH`` remains answerable as a query code and the
     death timestamp remains a valid prediction time.  Subjects with no death row are unaffected.
-    Shared by Stage 4 labeling (:func:`evaluate_index_df`) and Stage 0
-    (:func:`_read_prediction_time_shard`) so the two stages can't drift on the death rule.
+    Shared by Stage 4 labeling (:func:`evaluate_index_df`), Stage 0
+    (:func:`_read_prediction_time_shard`), and the evaluation sampler
+    (``sample_evaluation_tasks.run_worker``, #290) so no stage or pipeline can drift on the
+    death rule.
     """
     death_time = (
         pl.col(DataSchema.time_name)

--- a/tests/test_generate_evaluation_tasks_cli.py
+++ b/tests/test_generate_evaluation_tasks_cli.py
@@ -15,16 +15,17 @@ Checks:
 
 from __future__ import annotations
 
+from datetime import datetime, timedelta
 from typing import TYPE_CHECKING
 
 import polars as pl
 import pyarrow.parquet as pq
 import pytest
-from meds import DataSchema
+from meds import DataSchema, death_code
 
 from conftest import run_and_check
 from every_query.data.schema import TaskQuerySchema
-from every_query.generate_tasks.sample_evaluation_tasks import subsample_subject_ids
+from every_query.generate_tasks.sample_evaluation_tasks import run_worker, subsample_subject_ids
 
 if TYPE_CHECKING:
     from pathlib import Path
@@ -287,3 +288,127 @@ def test_subsample_subject_ids_handles_empty_frame() -> None:
     df = _events([])
     out = subsample_subject_ids(df, 0.1, seed=0)
     assert out.height == 0
+
+
+# ---------------------------------------------------------------------------
+# Death truncation of eval prediction times (#290)
+# ---------------------------------------------------------------------------
+
+
+_BASE = datetime(2024, 1, 1)
+
+
+def _write_eval_shard(root: Path, split: str, shard: str, events: pl.DataFrame) -> Path:
+    """Write ``events`` as ``{root}/data/{split}/{shard}.parquet`` and return ``root``."""
+    shard_fp = root / "data" / split / f"{shard}.parquet"
+    shard_fp.parent.mkdir(parents=True, exist_ok=True)
+    events.write_parquet(shard_fp)
+    return root
+
+
+def _subject_rows(subject_id: int, n_days: int, code: str = "HR") -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            DataSchema.subject_id_name: [subject_id] * n_days,
+            DataSchema.time_name: [_BASE + timedelta(days=i) for i in range(n_days)],
+            DataSchema.code_name: [code] * n_days,
+        }
+    )
+
+
+def _death_row(subject_id: int, day: int) -> pl.DataFrame:
+    return pl.DataFrame(
+        {
+            DataSchema.subject_id_name: [subject_id],
+            DataSchema.time_name: [_BASE + timedelta(days=day)],
+            DataSchema.code_name: [death_code],
+        }
+    )
+
+
+def test_run_worker_never_samples_post_death_prediction_times(tmp_path: Path) -> None:
+    """Post-death timestamps must not become evaluation prediction times (#290).
+
+    Training's Stage 0 truncates each subject's candidate times at ``MEDS_DEATH`` (#265); the
+    eval sampler must do the same or the two pipelines disagree about which contexts exist,
+    deflating measured prevalence on death-adjacent tasks.  Subject 1 dies on day 2 but carries
+    administrative rows on days 3-4; only days 0-2 are legal prediction times.  The death
+    timestamp itself stays eligible (truncation is ``<=``).
+    """
+    data_dir = _write_eval_shard(
+        tmp_path / "cohort",
+        "held_out",
+        "0",
+        pl.concat([_subject_rows(1, 5), _death_row(1, 2), _subject_rows(2, 4)]),
+    )
+
+    labels_fp = run_worker(
+        data_dir=data_dir,
+        out_dir=tmp_path / "eval_tasks",
+        split="held_out",
+        input_shard="0",
+        codes=["HR"],
+        durations=[1.0],
+        prediction_times_per_subject=10,  # > candidates, so every legal time is sampled
+        min_context_per_subject=1,
+        seed=0,
+        write_unique_prediction_times=False,
+    )
+    assert labels_fp is not None
+
+    labels = pl.read_parquet(labels_fp)
+    dead_times = sorted(
+        labels.filter(pl.col(TaskQuerySchema.subject_id_name) == 1)[TaskQuerySchema.prediction_time_name]
+        .unique()
+        .to_list()
+    )
+    assert dead_times == [_BASE, _BASE + timedelta(days=1), _BASE + timedelta(days=2)], (
+        f"subject 1 died on day 2; post-death days 3-4 must not be prediction times: {dead_times}"
+    )
+
+    # The living subject is untouched by truncation (uncensored windows only: day 3 closes past
+    # the record's end and is dropped as censored).
+    alive_times = sorted(
+        labels.filter(pl.col(TaskQuerySchema.subject_id_name) == 2)[TaskQuerySchema.prediction_time_name]
+        .unique()
+        .to_list()
+    )
+    assert alive_times == [_BASE, _BASE + timedelta(days=1), _BASE + timedelta(days=2)]
+
+
+def test_run_worker_post_death_events_dont_count_toward_min_context(tmp_path: Path) -> None:
+    """Post-death rows must not push a subject over ``min_context_per_subject`` (#290).
+
+    Subject 1 has 4 rows through death (days 0-2 plus the death row) and 2 post-death rows.  At
+    ``min_context_per_subject=5`` it has no legal prediction time at all; untruncated, days 3-4
+    would clear the bar on post-death context alone.  Subject 2 (no death) still contributes, so
+    an empty output can't pass this test vacuously.
+    """
+    data_dir = _write_eval_shard(
+        tmp_path / "cohort",
+        "held_out",
+        "0",
+        pl.concat([_subject_rows(1, 5), _death_row(1, 2), _subject_rows(2, 7)]),
+    )
+
+    labels_fp = run_worker(
+        data_dir=data_dir,
+        out_dir=tmp_path / "eval_tasks",
+        split="held_out",
+        input_shard="0",
+        codes=["HR"],
+        durations=[1.0],
+        prediction_times_per_subject=10,
+        min_context_per_subject=5,
+        seed=0,
+        write_unique_prediction_times=False,
+    )
+    assert labels_fp is not None
+
+    labels = pl.read_parquet(labels_fp)
+    assert labels.filter(pl.col(TaskQuerySchema.subject_id_name) == 1).height == 0, (
+        "subject 1 has < 5 events before death; post-death rows must not make it eligible"
+    )
+    assert labels.filter(pl.col(TaskQuerySchema.subject_id_name) == 2).height > 0, (
+        "subject 2 (no death, 7 events) should still contribute prediction times"
+    )


### PR DESCRIPTION
Fixes #290.

## Problem

Training's Stage 0 truncates each subject's candidate prediction times at their earliest `MEDS_DEATH` row (#265/#266), but the evaluation sampler did not: `sample_evaluation_tasks.run_worker` fed the raw `_read_event_shard(shard_path)` output straight into per-subject prediction-time sampling.

On any cohort whose extract carries post-death rows (billing/administrative events after `MEDS_DEATH` are common), those timestamps became evaluation prediction times. Labels there are trivially False for nearly every query, deflating measured prevalence and distorting AUROC on death-adjacent tasks — a systematic train/eval mismatch, since the model never trained on post-death contexts.

## Fix

Route the eval sampler's event frame through the same `_truncate_at_death` helper Stage 0 uses, before prediction-time sampling. Consequences:

- Post-death timestamps are no longer sampled as prediction times (the death timestamp itself stays eligible — truncation is `<=`, matching Stage 0 and Stage 4).
- Post-death rows no longer count as context toward `min_context_per_subject`, closing the same eligibility-inflation case #265 fixed for training.
- Labeling is unchanged: `evaluate_index_df` still receives the untruncated frame and applies its own truncation, mirroring the training pipeline's split between prediction-time truncation and labeling.

## Tests

Two regression tests in `tests/test_generate_evaluation_tasks_cli.py`, both driving `run_worker` on a synthetic shard:

- `test_run_worker_never_samples_post_death_prediction_times` — subject dies on day 2 with administrative rows on days 3-4; only days 0-2 may appear. A living subject in the same shard is unaffected.
- `test_run_worker_post_death_events_dont_count_toward_min_context` — post-death rows must not push a subject over `min_context_per_subject`.

Both fail on the pre-fix code (the first reports days 3-4 sampled as prediction times); both pass with the fix. Full non-slow suite: 324 passed.

Scoped to #290 only. (Two pre-existing `RUF059` lint errors in `tests/test_model_logic.py` are untouched.)