### PR TITLE
Fail loud on unknown query codes instead of PAD-encoding them (#292)

### DIFF
--- a/src/every_query/data/dataset.py
+++ b/src/every_query/data/dataset.py
@@ -351,19 +351,17 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
         self.duration_days = (
             self.schema_df[TaskQuerySchema.duration_days_name] if self.has_duration_days else None
         )
-        # Load code vocabulary mapping (string code -> integer vocab index) for encoding queries
-        try:
-            code_meta = pl.read_parquet(
-                self.config.code_metadata_fp, columns=["code", "code/vocab_index"], use_pyarrow=True
-            )
-            codes = code_meta["code"].to_list()
-            vocab_indices = code_meta["code/vocab_index"].to_list()
-            self.code_to_index: dict[str, int] = {
-                c: int(i) for c, i in zip(codes, vocab_indices, strict=False)
-            }
-        except Exception as e:
-            logger.warning(f"Failed to load code metadata for query encoding: {e}")
-            self.code_to_index = {}
+        # Load code vocabulary mapping (string code -> integer vocab index) for encoding queries.
+        # Deliberately unguarded: an empty mapping would PAD-encode every query, and a PAD query
+        # token is dropped from the attention mask while its position is still pooled as "the
+        # query embedding" — so a stale/missing metadata path would silently degrade an entire
+        # run into confident answers about queries the model never saw.  Fail loud instead.
+        code_meta = pl.read_parquet(
+            self.config.code_metadata_fp, columns=["code", "code/vocab_index"], use_pyarrow=True
+        )
+        codes = code_meta["code"].to_list()
+        vocab_indices = code_meta["code/vocab_index"].to_list()
+        self.code_to_index: dict[str, int] = {c: int(i) for c, i in zip(codes, vocab_indices, strict=False)}
 
     @property
     def labels_df(self) -> pl.DataFrame:
@@ -395,11 +393,32 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
         return pl.concat([read_df(fp) for fp in self.config.task_labels_fps], how="vertical")
 
     def encode_query(self, code_name: str) -> int:
-        """Encode query using the canonical code vocabulary mapping."""
-        try:
-            return int(self.code_to_index.get(code_name, EveryQueryBatch.PAD_INDEX))
-        except Exception:
-            return EveryQueryBatch.PAD_INDEX
+        """Encode query using the canonical code vocabulary mapping.
+
+        Raises:
+            KeyError: if ``code_name`` is not in the cohort's code vocabulary.  Falling back to
+                ``PAD_INDEX`` would be silent corruption rather than a missing feature: the query
+                token is masked out of attention (``attention_mask = code != PAD_INDEX``) while
+                position 0 is still pooled as the query embedding, so the model would answer a
+                query it never saw with plausible-looking, near-uniform probabilities.
+
+        Examples:
+            >>> from unittest.mock import Mock
+            >>> EveryQueryPytorchDataset.encode_query(Mock(code_to_index={"A//B": 3}), "A//B")
+            3
+            >>> EveryQueryPytorchDataset.encode_query(Mock(code_to_index={"A//B": 3}), "typo")
+            Traceback (most recent call last):
+                ...
+            KeyError: "Query code 'typo' is not in the code vocabulary...
+        """
+        if code_name not in self.code_to_index:
+            raise KeyError(
+                f"Query code {code_name!r} is not in the code vocabulary ({len(self.code_to_index)} "
+                f"codes).  Out-of-vocab queries cannot be encoded: PAD-encoding them would mask the "
+                f"query token out of attention while still pooling its position, silently producing "
+                f"meaningless predictions.  Check the task queries and the code metadata path."
+            )
+        return int(self.code_to_index[code_name])
 
     def _seeded_getitem(self, idx: int, seed: int | None = None) -> dict[str, torch.Tensor]:
         out = super()._seeded_getitem(idx, seed)

--- a/src/every_query/model/task_auroc_callback.py
+++ b/src/every_query/model/task_auroc_callback.py
@@ -20,7 +20,7 @@ from lightning.pytorch import Callback
 from lightning.pytorch.utilities import move_data_to_device
 from meds import tuning_split
 from meds_torchdata import MEDSTorchDataConfig
-from torch.utils.data import DataLoader
+from torch.utils.data import DataLoader, Subset
 
 from every_query.data.dataset import EveryQueryBatch, EveryQueryPytorchDataset
 
@@ -54,20 +54,22 @@ class TaskAurocTrackingCallback(Callback):
 
         dataset = EveryQueryPytorchDataset(self.config, split=tuning_split)
 
-        # Out-of-vocab query codes encode to PAD_INDEX (0); distinct OOV tasks would otherwise
-        # collide there and corrupt the estimate, so they're skipped at scoring — warn here so
-        # a silently-shrunk tracking set is visible.
-        queries = dataset.query.to_list() if dataset.query is not None else []
-        n_oov = sum(1 for q in queries if q not in dataset.code_to_index)
-        if n_oov:
-            logger.warning(
-                "%d/%d task-tracking rows have out-of-vocab query codes; they are skipped "
-                "(untrainable, and would otherwise collide at PAD_INDEX).",
-                n_oov,
-                len(queries),
-            )
+        # Out-of-vocab query codes can't be encoded at all (``encode_query`` raises), and they're
+        # untrainable anyway — drop those rows from the tracking set rather than fail the run over
+        # an auxiliary metric, and warn so a silently-shrunk tracking set is visible.
+        keep = list(range(len(dataset)))
+        if dataset.query is not None:
+            queries = dataset.query.to_list()
+            keep = [i for i, q in enumerate(queries) if q in dataset.code_to_index]
+            if len(keep) < len(queries):
+                logger.warning(
+                    "%d/%d task-tracking rows have out-of-vocab query codes; they are dropped "
+                    "(untrainable, and not encodable against this cohort's vocabulary).",
+                    len(queries) - len(keep),
+                    len(queries),
+                )
 
-        if len(dataset) == 0:
+        if not keep:
             logger.warning(
                 "Task-tracking dataset (tuning split) is empty; %r will not be logged.",
                 "tuning/occurs_auroc_macro_sampled",
@@ -75,7 +77,7 @@ class TaskAurocTrackingCallback(Callback):
             return
 
         self._loader = DataLoader(
-            dataset,
+            dataset if len(keep) == len(dataset) else Subset(dataset, keep),
             batch_size=self.batch_size,
             shuffle=False,
             collate_fn=dataset.collate,
@@ -112,7 +114,10 @@ class TaskAurocTrackingCallback(Callback):
                 labels = batch.occurs.detach().cpu().tolist()
                 for query, duration, label, prob in zip(queries, durations, labels, probs, strict=True):
                     if query == EveryQueryBatch.PAD_INDEX:
-                        continue  # OOV/pad — see setup() warning
+                        # setup() already drops OOV rows, so this is belt-and-braces for a
+                        # hand-built loader: distinct PAD-encoded tasks would collide into one
+                        # bogus (0, duration) task and corrupt the estimate.
+                        continue
                     probs_by_task.setdefault((query, duration), {})[int(label)] = prob
 
         indicators = []

--- a/src/every_query/predict/predict.py
+++ b/src/every_query/predict/predict.py
@@ -137,12 +137,11 @@ def _validate_tasks_dir(tasks_dir: Path) -> None:
 def _check_vocab(task_codes: set[str], train_cfg: DictConfig) -> None:
     """Raise if any task-query codes are missing from the trained model's vocabulary.
 
-    Out-of-vocab query codes survive the predict loop (``encode_query`` silently falls
-    back to ``PAD_INDEX``) but produce effectively-uniform (garbage) predictions — so
-    the caller's ``predictions.parquet`` would silently contain rows whose probabilities
-    have no relationship to the model.  Raise at startup rather than write misleading
-    output.  Missing metadata is also a hard error: without the training vocab we can't
-    validate inputs at all.
+    ``encode_query`` raises on an out-of-vocab code, but that fires mid-loop, per row, with
+    no view of how much of the task file is affected.  Checking the whole task-code set up
+    front turns that into one actionable startup error naming every missing code, before any
+    batches are scored.  Missing metadata is also a hard error: without the training vocab we
+    can't validate inputs at all.
 
     Examples:
         Happy path — every task code is present in the training vocab:
@@ -191,8 +190,8 @@ def _check_vocab(task_codes: set[str], train_cfg: DictConfig) -> None:
     if missing:
         raise ValueError(
             f"{len(missing)} of {len(task_codes)} task-query codes are not in the model's training "
-            f"vocabulary.  Out-of-vocab codes would be PAD-encoded and produce near-uniform "
-            f"probabilities; refuse rather than write misleading predictions.  Missing codes: "
+            f"vocabulary.  Out-of-vocab codes cannot be encoded, so those rows could not be "
+            f"predicted at all; refuse up front rather than fail partway through.  Missing codes: "
             f"{sorted(missing)[:10]}{'...' if len(missing) > 10 else ''}"
         )
 

--- a/tests/test_dataset_logic.py
+++ b/tests/test_dataset_logic.py
@@ -7,7 +7,9 @@ the ``collate`` method correctly maps label fields to batch annotations.
 
 import copy
 
+import pytest
 import torch
+from meds import train_split
 
 from every_query.data.dataset import EveryQueryBatch, EveryQueryPytorchDataset
 
@@ -231,3 +233,38 @@ class TestDifferentQueryStringProducesDifferentIndex:
             f"Position 0 for sample 1 should carry encoded {query_b!r} ({enc_b}), "
             f"got {batch.code[1, 0].item()}"
         )
+
+
+class TestUnknownQueryCodesFailLoud:
+    """Out-of-vocab query codes must raise, not silently PAD-encode (issue #292).
+
+    A PAD-encoded query token is excluded from attention (``attention_mask = code != PAD_INDEX``)
+    while position 0 is still pooled as "the query embedding", so a typo'd code or a stale
+    metadata path would otherwise degrade a whole run into confident, near-uniform nonsense with
+    no error anywhere.
+    """
+
+    def test_encode_query_raises_on_unknown_code(self, demo_dataset):
+        with pytest.raises(KeyError, match="not in the code vocabulary"):
+            demo_dataset.encode_query("NOT//A//REAL//CODE")
+
+    def test_collate_raises_on_unknown_query(self, demo_dataset):
+        item = copy.copy(demo_dataset[0])
+        item["query"] = "NOT//A//REAL//CODE"
+
+        with pytest.raises(KeyError, match="not in the code vocabulary"):
+            demo_dataset.collate([item])
+
+    def test_missing_code_metadata_propagates(self, demo_dataset, tmp_path):
+        """Unreadable code metadata must fail construction, not degrade to an empty vocab."""
+        import dataclasses
+        import shutil
+
+        cohort_copy = tmp_path / "cohort"
+        shutil.copytree(demo_dataset.config.tensorized_cohort_dir, cohort_copy)
+        (cohort_copy / "metadata" / "codes.parquet").unlink()
+
+        cfg = dataclasses.replace(demo_dataset.config, tensorized_cohort_dir=cohort_copy)
+
+        with pytest.raises(Exception):  # noqa: B017 — polars' read error type is not part of the contract
+            EveryQueryPytorchDataset(cfg, split=train_split)

--- a/tests/test_lightning_logic.py
+++ b/tests/test_lightning_logic.py
@@ -298,3 +298,41 @@ class TestCallbackHydraWiring:
         assert isinstance(callback, TaskAurocTrackingCallback)
         assert callback.batch_size == 256
         assert isinstance(callback.config, MEDSTorchDataConfig)
+
+
+class TestTrackingSetupDropsOOVRows:
+    """``TaskAurocTrackingCallback.setup`` must drop out-of-vocab tracking rows (issue #292).
+
+    ``encode_query`` now raises on an unknown code rather than PAD-encoding it, so an OOV row left
+    in the tracking set would blow up the whole training run over an auxiliary metric.  They're
+    untrainable anyway, so ``setup`` filters them out (and warns) instead.
+    """
+
+    def test_oov_rows_are_filtered_out_of_the_loader(self, tensorized_cohort_dir, task_labels_dir, tmp_path):
+        import polars as pl
+        from meds import tuning_split
+
+        tracking_dir = tmp_path / "tracking"
+        (tracking_dir / tuning_split).mkdir(parents=True)
+        in_vocab = pl.read_parquet(task_labels_dir / tuning_split / "0.parquet")
+        oov = in_vocab.head(1).with_columns(pl.lit("NOT//A//REAL//CODE").alias("query"))
+        pl.concat([in_vocab, oov]).write_parquet(tracking_dir / tuning_split / "0.parquet")
+
+        cfg = MEDSTorchDataConfig(
+            tensorized_cohort_dir=str(tensorized_cohort_dir),
+            task_labels_dir=str(tracking_dir),
+            max_seq_len=64,
+            seq_sampling_strategy="to_end",
+            static_inclusion_mode="omit",
+            batch_mode="SM",
+        )
+        callback = TaskAurocTrackingCallback(config=cfg, batch_size=8)
+        callback.setup(trainer=None, pl_module=None, stage="fit")
+
+        assert callback._loader is not None, "In-vocab rows remain, so a loader must be built"
+        assert len(callback._loader.dataset) == in_vocab.height, (
+            f"Expected the {oov.height} OOV row(s) to be dropped, leaving {in_vocab.height}"
+        )
+        # Iterating must not raise: every surviving row encodes against the cohort vocabulary.
+        n_scored = sum(batch.query.numel() for batch in callback._loader)
+        assert n_scored == in_vocab.height


### PR DESCRIPTION
Fixes #292.

## Problem

`EveryQueryPytorchDataset.encode_query` returned `PAD_INDEX` (0) for any code absent from `code_to_index`, and the metadata load in `__init__` was wrapped in a catch-all that left `code_to_index = {}` behind a logged warning. A PAD-encoded query token is excluded from attention (`attention_mask = code != PAD_INDEX`) while position 0 is still pooled as "the query embedding" — so a typo'd code list or a stale metadata path silently degraded an entire run into confident, near-uniform predictions with no error anywhere.

## Change

- `encode_query` raises `KeyError` naming the offending code and the vocabulary size.
- The code-metadata read in `__init__` propagates its error instead of degrading to an empty mapping.
- `TaskAurocTrackingCallback.setup` previously *relied* on the PAD fallback (it warned about OOV rows and skipped them at scoring). It now drops those rows from the tracking loader up front via `Subset`, so an OOV tracking row can't fail a training run over an auxiliary metric. The PAD skip in `_compute_and_log` stays as belt-and-braces for a hand-built loader.
- `_check_vocab` (EQ_predict) is unchanged in behavior — it remains the up-front, whole-task-set guard that names every missing code before any batch is scored; its docstring and error message no longer describe the removed PAD fallback.

## Tests

New:
- `TestUnknownQueryCodesFailLoud` — `encode_query` and `collate` raise on an unknown code; construction fails when the code metadata is unreadable rather than yielding an empty vocab.
- `TestTrackingSetupDropsOOVRows` — an OOV row added to the tracking parquet is dropped from the callback's loader, and iterating the loader doesn't raise.
- A doctest on `encode_query` covering both the hit and the raise.

Full suite: `327 passed, 1 deselected` (`uv run pytest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)