### PR TITLE
Let the query token use the patient code dtype (#291)

### DIFF
--- a/src/every_query/data/dataset.py
+++ b/src/every_query/data/dataset.py
@@ -145,6 +145,44 @@ class EveryQueryBatch(MEDSTorchBatch):
             self._MEDSTorchBatch__check_shape("duration_days", (self.batch_size,))
 
 
+def _code_dtype(schema: dict[str, np.dtype]) -> np.dtype | type:
+    """Returns the dtype the `code` arrays are stored in, per a `JointNestedRaggedTensorDict` schema.
+
+    Schema keys are dim-qualified (`dim0/code` in `SM` mode, `dim1/code` in `SEM` mode) when the schema
+    was carried over from disk, but bare (`code`) when the tensor dict derived it from its own arrays, so
+    match on the trailing component either way.
+
+    Args:
+        schema: A JNRT schema, mapping (possibly dim-qualified) tensor names to dtypes.
+
+    Returns:
+        The dtype stored for the `code` key, or `np.int64` if the schema does not mention one.
+
+    Examples:
+        >>> _code_dtype({"dim0/code": np.dtype("int64"), "dim0/numeric_value": np.dtype("float32")})
+        dtype('int64')
+        >>> _code_dtype({"dim1/code": np.dtype("int32")})
+        dtype('int32')
+        >>> _code_dtype({"code": np.dtype("int16")})
+        dtype('int16')
+
+    A schema with no `code` entry falls back to the widest signed integer, which never truncates a
+    vocabulary index:
+
+        >>> _code_dtype({"dim0/numeric_value": np.dtype("float32")})
+        <class 'numpy.int64'>
+
+    Keys that merely end in "code" do not match:
+
+        >>> _code_dtype({"dim0/static_code": np.dtype("int8")})
+        <class 'numpy.int64'>
+    """
+    for key, dtype in schema.items():
+        if key.rsplit("/", 1)[-1] == DataSchema.code_name:
+            return dtype
+    return np.int64
+
+
 class QueryData(NamedTuple):
     """Simple data structure to hold query data, capturing codes.
 
@@ -405,10 +443,23 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
         out = super()._seeded_getitem(idx, seed)
 
         dynamic_data = out["dynamic"]
-        schema = dynamic_data.schema
-        schema["code"] = np.int16
+        # `JointNestedRaggedTensorDict.schema` hands back the tensor dict's internal `_schema` by
+        # reference, and the JNRT constructor writes the dtype of every bare key it builds straight
+        # into whatever dict it is handed.  Build the query against a copy so constructing it can't
+        # mutate the patient tensors' schema as a side effect.
+        patient_schema = dynamic_data.schema
+        query_schema = dict(patient_schema)
+        # The query token shares the patient code vocabulary, so it must be stored in the same dtype
+        # the patient `code` array uses.  Pinning a narrow dtype here silently caps the vocabulary
+        # (int16 overflows past 32,767) and omitting the entry is no better: the constructor then
+        # infers a minimal — possibly unsigned — width from the single value it is given.
+        query_schema[DataSchema.code_name] = _code_dtype(patient_schema)
         query_data = QueryData(code=[self.encode_query(self.query[idx])])
-        query_as_JNRT = query_data.to_JNRT(self.config.batch_mode, schema)
+        query_as_JNRT = query_data.to_JNRT(self.config.batch_mode, query_schema)
+        # `concatenate` requires the schemas to compare equal, but the constructor has just added
+        # bare-key entries to `query_schema` that the patient's dim-qualified schema lacks.  The
+        # arrays themselves are already built, so re-align the query's schema with the patient's.
+        query_as_JNRT._schema = dict(patient_schema)
         out["dynamic"] = JointNestedRaggedTensorDict.concatenate([query_as_JNRT, dynamic_data])
 
         if getattr(self, "has_occurs", False):

--- a/tests/test_dataset_logic.py
+++ b/tests/test_dataset_logic.py
@@ -231,3 +231,61 @@ class TestDifferentQueryStringProducesDifferentIndex:
             f"Position 0 for sample 1 should carry encoded {query_b!r} ({enc_b}), "
             f"got {batch.code[1, 0].item()}"
         )
+
+
+class TestQueryTokenSupportsLargeVocabularies:
+    """The query token must not impose a vocabulary cap of its own.
+
+    ``_seeded_getitem`` used to pin the query token's dtype to ``np.int16`` before building
+    its JNRT, which made any vocabulary index above 32,767 raise ``OverflowError``.  Nothing
+    else bounds the vocabulary — ``train.py`` sizes ``vocab_size`` from the data — so a large
+    merged cohort trained fine until the first query token overflowed.  See issue #291.
+    """
+
+    LARGE_INDEX = 40_000
+
+    def test_large_query_index_survives_round_trip(self, demo_dataset):
+        """A vocab index well past the int16 ceiling must round-trip intact."""
+        idx = 0
+        query = demo_dataset.query[idx]
+        original = dict(demo_dataset.code_to_index)
+        demo_dataset.code_to_index[query] = self.LARGE_INDEX
+        try:
+            assert demo_dataset.encode_query(query) == self.LARGE_INDEX, (
+                "Precondition: the patched vocabulary must encode the query to the large index"
+            )
+            item = demo_dataset._seeded_getitem(idx)
+            first_code = int(item["dynamic"].to_dense()["code"][0])
+        finally:
+            demo_dataset.code_to_index = original
+
+        assert first_code == self.LARGE_INDEX, (
+            f"Position-0 code should carry the large query index ({self.LARGE_INDEX}) "
+            f"intact, got {first_code} — the query token dtype is truncating the vocabulary"
+        )
+
+    def test_building_the_query_does_not_mutate_the_patient_schema(self, demo_dataset, monkeypatch):
+        """``dynamic_data.schema`` is the JNRT's internal dict; building the query must not touch it.
+
+        The patient tensor dict is rebuilt per item, so the mutation has to be observed on the very
+        object ``_seeded_getitem`` works with — hence the spy on the upstream implementation.
+        """
+        from meds_torchdata import MEDSPytorchDataset
+
+        captured = {}
+        upstream = MEDSPytorchDataset._seeded_getitem
+
+        def spy(self, idx, seed=None):
+            out = upstream(self, idx, seed)
+            captured["dynamic"] = out["dynamic"]
+            captured["before"] = dict(out["dynamic"].schema)
+            return out
+
+        monkeypatch.setattr(MEDSPytorchDataset, "_seeded_getitem", spy)
+        demo_dataset._seeded_getitem(0, 0)
+
+        assert captured, "Precondition: the spy must have observed the upstream patient tensors"
+        after = dict(captured["dynamic"].schema)
+        assert after == captured["before"], (
+            f"Building the query JNRT mutated the patient tensors' schema: {captured['before']} -> {after}"
+        )


### PR DESCRIPTION
Fixes #291.

## The vocabulary cap

`EveryQueryPytorchDataset._seeded_getitem` pinned the query token's dtype with `schema["code"] = np.int16` before building the query JNRT, so `np.array(vals, dtype=np.int16)` raised `OverflowError` for any vocab index past 32,767. Nothing else enforced that bound — `train.py` sizes `vocab_size` from the data — so a cohort with a merged vocabulary larger than 32k trained fine until the first query token overflowed.

The dtype now comes from the patient `code` array itself, via a small `_code_dtype` helper that matches the trailing key component so it works for both `SM` (`dim0/code`) and `SEM` (`dim1/code`) schemas.

Worth noting: **simply deleting the override is not enough.** With no entry for `code`, the JNRT constructor infers a minimal — and possibly unsigned — width from the single value it is handed (`uint16` for 40,000), which just relocates the cap.

## The shared-dict mutation

`dynamic_data.schema` returns the tensor dict's internal `_schema` by reference, and the JNRT constructor writes the dtypes of every bare key it builds into whatever dict it is given — so building the query mutated the patient tensors' schema as a side effect. The query is now built against a copy.

One subtlety surfaced while fixing this: the mutation was *load-bearing*. `concatenate` compares schemas for strict equality, and the old code passed that check only because both tensors ended up sharing one dict object. Copying alone makes `concatenate` fail with `Schema inconsistent!`, because the constructor adds bare-key entries that the patient's dim-qualified schema lacks. The query's schema is therefore re-aligned with the patient's after its arrays are built.

## Tests

Two regression tests in `TestQueryTokenSupportsLargeVocabularies`; both fail on the old code (`OverflowError: Python integer 40000 out of bounds for int16` and the schema-mutation assertion) and pass here. The mutation test spies on the upstream `_seeded_getitem` — the patient tensor dict is rebuilt per item, so the mutation has to be observed on the very object the method works with.

- Default suite: **325 passed**, 1 deselected
- Slow suite (`-m slow`, trains a real model through this data path): **1 passed**
- `ruff check` / `ruff format` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)