### PR TITLE
Write config.yaml on first launch even under do_resume (#294)

### DIFF
--- a/src/every_query/train/train.py
+++ b/src/every_query/train/train.py
@@ -318,13 +318,17 @@ def main(cfg: DictConfig) -> float | None:
             )
 
     # Ensure run_dir exists *after* any overwrite rmtree above, then write the config for this
-    # run.  On resume (without overwrite) we keep the original run's config untouched so the
-    # resumed run stays bit-identical to the first.  On overwrite the previous rmtree wiped the
-    # old config; writing it here restores reproducibility for downstream tools that load
-    # ``resolved_config.yaml`` from the run dir.  Fixes #31.
+    # run.  The gate is "is there a config here already?", *not* the resume flag: resuming into a
+    # populated dir keeps the original run's config untouched so the resumed run stays
+    # bit-identical to the first, while a *fresh* dir gets a config written even under
+    # ``do_resume=True`` — the natural crash-safe invocation for a long job.  Without that, the
+    # first launch left no ``config.yaml``, so a post-crash relaunch failed the ``cfg_path.exists()``
+    # check above, discovered no checkpoint, and silently restarted from step 0 (#294).  On
+    # overwrite the rmtree above already wiped the old config, so this writes a fresh one and
+    # keeps ``resolved_config.yaml`` available to downstream tools that load it (#31).
     os.makedirs(run_dir, exist_ok=True)
-    if not cfg.do_resume or cfg.do_overwrite:
-        OmegaConf.save(cfg, run_dir / "config.yaml")
+    if not cfg_path.exists():
+        OmegaConf.save(cfg, cfg_path)
         save_resolved_config(cfg, run_dir / "resolved_config.yaml")
 
     # Kept in step with ``utils/model_loader.py`` so training and scoring use the same matmuls.

--- a/tests/test_train_cli.py
+++ b/tests/test_train_cli.py
@@ -195,6 +195,64 @@ class TestTrainOverwriteAndResumeBothTrue:
         assert (both_flags_output / "resolved_config.yaml").is_file()
 
 
+class TestFirstLaunchWithResumeWritesConfig:
+    """A *fresh* run started with ``do_resume=True, do_overwrite=False`` must still write its config.
+
+    Regression guard for #294.  That flag combination is the natural crash-safe invocation for a
+    long job, but the config write used to be gated on ``not cfg.do_resume or cfg.do_overwrite``,
+    so the first launch into an empty dir left no ``config.yaml``.  Checkpoint discovery keys off
+    ``cfg_path.exists()``, so the post-crash relaunch found no config, discovered no checkpoint,
+    and silently restarted from step 0 while the first attempt's checkpoints sat in the directory
+    (and ``EQ_predict`` had no ``resolved_config.yaml`` to load).
+    """
+
+    @pytest.fixture(scope="class")
+    def first_launch(self, task_labels_dir, tensorized_cohort_dir, tmp_path_factory) -> Path:
+        output_dir = tmp_path_factory.mktemp("cli_fresh_resume")
+        result = _run_train_subprocess(
+            task_labels_dir,
+            tensorized_cohort_dir,
+            output_dir,
+            do_resume=True,
+            do_overwrite=False,
+        )
+        assert result.returncode == 0, (
+            f"Fresh run with do_resume=True failed (rc={result.returncode}).\nstderr:\n{result.stderr}"
+        )
+        return output_dir
+
+    def test_config_yaml_written_on_fresh_resume_launch(self, first_launch):
+        assert (first_launch / "config.yaml").is_file()
+
+    def test_resolved_config_yaml_written_on_fresh_resume_launch(self, first_launch):
+        assert (first_launch / "resolved_config.yaml").is_file()
+
+    def test_relaunch_resumes_instead_of_restarting(
+        self, first_launch, task_labels_dir, tensorized_cohort_dir
+    ):
+        """The relaunch (same flags, as after a crash) must enter the resume branch."""
+        relaunch = _run_train_subprocess(
+            task_labels_dir,
+            tensorized_cohort_dir,
+            first_launch,
+            do_resume=True,
+            do_overwrite=False,
+            extra_overrides=["+trainer.max_steps=4"],
+        )
+        assert relaunch.returncode == 0, (
+            f"Relaunch failed (rc={relaunch.returncode}).\nstderr:\n{relaunch.stderr}"
+        )
+        combined = relaunch.stdout + relaunch.stderr
+        assert "Resuming training in existing run directory" in combined, (
+            "Relaunch did not enter the resume branch — it started a fresh run instead.\n"
+            f"stdout:\n{relaunch.stdout}\nstderr:\n{relaunch.stderr}"
+        )
+        assert "Restoring states from the checkpoint path" in combined, (
+            "Relaunch entered the resume branch but loaded no checkpoint state.\n"
+            f"stdout:\n{relaunch.stdout}\nstderr:\n{relaunch.stderr}"
+        )
+
+
 class TestTrainResumeRejectsStructuralDrift:
     """``do_resume=True`` must refuse to proceed when the new invocation disagrees with the resumed-from
     config on a structural key (anything not in ``ALLOWED_DIFFERENCE_KEYS``).


### PR DESCRIPTION
Closes #294.

## Problem

Checkpoint discovery on resume is gated on `cfg_path.exists()`, but the config was only written when `not cfg.do_resume or cfg.do_overwrite`. A *fresh* run started with `do_resume=True, do_overwrite=False` — the natural crash-safe invocation for a long job — therefore wrote neither `config.yaml` nor `resolved_config.yaml`.

So when the run crashed and was relaunched with the same flags, `cfg_path.exists()` was False, no checkpoint was discovered, and training silently restarted from step 0 while the first attempt's checkpoints sat in the run directory. `EQ_predict` also had no `resolved_config.yaml` to load even when training completed.

## Fix

Gate the write on "is there a config here already?" rather than on the resume flag:

```python
if not cfg_path.exists():
    OmegaConf.save(cfg, cfg_path)
    save_resolved_config(cfg, run_dir / "resolved_config.yaml")
```

The check runs *after* the overwrite `rmtree`, so all three existing behaviours are preserved:

- **fresh dir** (with or without `do_resume`) → config written;
- **resume into a populated dir** → original config left untouched, so the resumed run stays bit-identical to the first and `validate_resume_directory` still diffs against the original (#91);
- **overwrite** → the `rmtree` already removed the old config, so a fresh one is written (#31), including when `do_overwrite` and `do_resume` are both set.

## Tests

New `TestFirstLaunchWithResumeWritesConfig` in `tests/test_train_cli.py`: a fresh run with `do_resume=True, do_overwrite=False` must write `config.yaml`/`resolved_config.yaml`, and the relaunch with the same flags must enter the resume branch and restore checkpoint state instead of starting over. All three fail on the pre-fix code (verified by reverting the one-line gate) and pass with it.

Full suite: 325 passed, plus the `slow` training-validity test — green.

Note for reviewers: `torchdata` (declared at `pyproject.toml:39`) was missing from the local `.venv` and had to be installed before the suite could run; unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
