### PR TITLE
Fix off-by-one in eval min_context_per_subject gate (#298)

### DIFF
--- a/src/every_query/generate_tasks/sample_evaluation_tasks.py
+++ b/src/every_query/generate_tasks/sample_evaluation_tasks.py
@@ -11,7 +11,7 @@ Pipeline:
     1. For each shard discovered under ``{data_dir}/data/{split}/*.parquet``,
        sample up to ``K`` candidate prediction times per subject (any event time
        at which the subject has accumulated at least ``min_context_per_subject``
-       prior events).
+       strictly prior events — the candidate event itself does not count).
     2. Cross-join with the full ``(codes x durations)`` grid.
     3. Label via :func:`every_query.generate_tasks.sample_tasks.evaluate_index_df`
        (single ``join_asof`` across the whole index frame).
@@ -62,7 +62,8 @@ def sample_prediction_times_per_subject(
     """Sample up to ``k`` prediction times per subject from event times.
 
     A candidate prediction time is any event time at which the subject has
-    accumulated at least ``min_context_per_subject`` prior events.  Sampling is
+    accumulated at least ``min_context_per_subject`` strictly prior events — the
+    event at the candidate time itself is not counted as context.  Sampling is
     without replacement within each subject; subjects with fewer than ``k``
     candidates contribute all of them.
 
@@ -70,9 +71,12 @@ def sample_prediction_times_per_subject(
         events_df: Shard events with columns ``subject_id``, ``time``, ``code``
             (sorted by ``(subject_id, time)``).
         k: Max prediction times per subject.
-        min_context_per_subject: Minimum prior events a subject must have
-            accumulated before a given event time can be used as a prediction
-            time.
+        min_context_per_subject: Minimum number of events strictly before a given
+            event time that a subject must have accumulated for that time to be
+            usable as a prediction time.  A subject with exactly
+            ``min_context_per_subject`` events therefore has *no* eligible
+            prediction times; one with ``min_context_per_subject + 1`` has
+            exactly one (its last event).
         seed: PRNG seed.  Deterministic in ``(events_df, k, min_context_per_subject, seed)``.
 
     Returns:
@@ -93,9 +97,45 @@ def sample_prediction_times_per_subject(
         >>> out = sample_prediction_times_per_subject(events, k=2, min_context_per_subject=2, seed=0)
         >>> sorted(out["subject_id"].unique().to_list())
         [1, 2]
-        >>> # Each subject gets at most 2 sampled times
+        >>> # Subject 1's 3rd and 4th events have >= 2 prior events; subject 2 only
+        >>> # has a qualifying 3rd event.  Each subject gets at most 2 sampled times.
         >>> out.group_by("subject_id").len().sort("subject_id")["len"].to_list()
-        [2, 2]
+        [2, 1]
+
+        The context count is of events *strictly prior* to the prediction time, so
+        the qualifying times start at event ``min_context_per_subject + 1``:
+
+        >>> out.sort(["subject_id", "prediction_time"])["prediction_time"].dt.day().to_list()
+        [3, 4, 3]
+
+        Boundary: a subject with exactly ``min_context_per_subject`` events has no
+        eligible prediction time (its last event has only
+        ``min_context_per_subject - 1`` prior events)...
+
+        >>> exact = pl.DataFrame({
+        ...     "subject_id": [1, 1, 1],
+        ...     "time": [datetime(2024, 1, 1), datetime(2024, 1, 2), datetime(2024, 1, 3)],
+        ...     "code": ["A"] * 3,
+        ... })
+        >>> sample_prediction_times_per_subject(exact, k=5, min_context_per_subject=3, seed=0).height
+        0
+
+        ...while one more event yields exactly one eligible prediction time — that
+        last event, at which the subject has exactly ``min_context_per_subject``
+        prior events:
+
+        >>> one_more = pl.DataFrame({
+        ...     "subject_id": [1, 1, 1, 1],
+        ...     "time": [
+        ...         datetime(2024, 1, 1), datetime(2024, 1, 2),
+        ...         datetime(2024, 1, 3), datetime(2024, 1, 4),
+        ...     ],
+        ...     "code": ["A"] * 4,
+        ... })
+        >>> sample_prediction_times_per_subject(one_more, k=5, min_context_per_subject=3, seed=0)[
+        ...     "prediction_time"
+        ... ].to_list()
+        [datetime.datetime(2024, 1, 4, 0, 0)]
 
         ``min_context_per_subject`` filters out subjects who don't have enough
         history yet:
@@ -114,11 +154,17 @@ def sample_prediction_times_per_subject(
     if k < 0:
         raise ValueError(f"k must be >= 0 (got {k})")
 
+    # ``cum_count`` is inclusive of the current row, so the count of events *strictly
+    # prior* to a candidate prediction time is ``cum_count - 1``.  Gating on the
+    # inclusive count would admit prediction times with only
+    # ``min_context_per_subject - 1`` prior events (#298).
+    prior_events = (
+        pl.col(DataSchema.time_name).cum_count().over(DataSchema.subject_id_name).cast(pl.Int64) - 1
+    )
+
     candidates = (
-        events_df.with_columns(
-            pl.col(DataSchema.time_name).cum_count().over(DataSchema.subject_id_name).alias("_ccs")
-        )
-        .filter(pl.col("_ccs") >= min_context_per_subject)
+        events_df.with_columns(prior_events.alias("_prior_events"))
+        .filter(pl.col("_prior_events") >= min_context_per_subject)
         .select([DataSchema.subject_id_name, DataSchema.time_name])
         .unique()
         .rename({DataSchema.time_name: TaskQuerySchema.prediction_time_name})


### PR DESCRIPTION
Fixes #298.

## The bug

`sample_prediction_times_per_subject` built its eligibility filter with an inclusive cumulative count:

```python
.with_columns(pl.col(time).cum_count().over(subject_id).alias("_ccs"))
.filter(pl.col("_ccs") >= min_context_per_subject)
```

`cum_count` includes the current row, so a candidate prediction time at a subject's *n*-th event had `_ccs == n` while having only `n - 1` strictly prior events. The gate therefore admitted prediction times with `min_context_per_subject - 1` prior events — one short of the docstring's promise and weaker than the training-side rule. With `min_context_per_subject=1`, every subject's very first event was a valid prediction time with zero context.

## The fix

Gate on the count of events *strictly prior* to the candidate (`cum_count() - 1`), named at the call site so the semantics are readable:

```python
prior_events = pl.col(time).cum_count().over(subject_id).cast(pl.Int64) - 1
...
.filter(pl.col("_prior_events") >= min_context_per_subject)
```

Docstrings (module, function summary, `min_context_per_subject` arg) now say "strictly prior" explicitly and spell out the boundary.

## Doctests

- The `k=2, min_context_per_subject=2` example now yields `[2, 1]` per-subject counts instead of `[2, 2]` — subject 2 (3 events) has only one qualifying time. Added an assertion on the actual times to pin *which* events qualify.
- The `min_context_per_subject=10` example still yields 0 rows (unchanged).
- New boundary doctests pin the off-by-one: a subject with exactly `min_context_per_subject` events yields **zero** eligible prediction times; one with `min_context_per_subject + 1` yields exactly one (its last event).

> Note on the issue text: issue #298's "Also required" bullet describes the boundary as "a subject with exactly `min_context_per_subject` events should yield exactly one eligible prediction time." That doesn't follow from the fix the issue itself prescribes (`_ccs > min_context_per_subject`) — under strictly-prior semantics such a subject's last event has only `min_context_per_subject - 1` prior events, so it yields zero. The doctests here encode the arithmetically consistent boundary (zero at exactly `m` events, one at `m + 1`).

## Downstream

Checked the callers and configs threading `min_context_per_subject` (`run_worker`, the CLI at the bottom of the module, `sample_evaluation_tasks_config.yaml`, and the CLI tests). Nothing compensated for the old semantics — the config comment already described the intended strictly-prior meaning, and the default of `50` keeps its meaning (now genuinely 50 prior events). No changes needed there.

## Testing

- `pytest --doctest-modules src/every_query/generate_tasks/sample_evaluation_tasks.py` — 2 passed
- Full suite: **322 passed**, 1 deselected (6m45s)
- `ruff check` / `ruff format --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
