### PR TITLE
Fix no-decay regex to match all norm params (ModernBERT norms were fully decayed)

### DIFF
--- a/src/every_query/model/lightning_module.py
+++ b/src/every_query/model/lightning_module.py
@@ -439,7 +439,7 @@ class EveryQueryLightningModule(L.LightningModule):
 
     @staticmethod
     def _is_norm_bias_param(n: str) -> bool:
-        """True when *n* is a bias or layer-norm weight (these get zero weight decay).
+        """True when *n* is a bias or norm weight (these get zero weight decay).
 
         Examples:
             >>> EveryQueryLightningModule._is_norm_bias_param("encoder.attention.self.query.bias")
@@ -456,15 +456,28 @@ class EveryQueryLightningModule(L.LightningModule):
             >>> EveryQueryLightningModule._is_norm_bias_param("bert.encoder.layer.0.output.LayerNorm.weight")
             True
 
-        The regex requires a ``layer`` prefix, so ModernBERT-style norm names
-        (``attn_norm``, ``mlp_norm``, ``final_norm``, bare ``norm``) are **not** matched:
+        Any ``*norm``-named component counts, so ModernBERT-style norm names
+        (``attn_norm``, ``mlp_norm``, ``final_norm``, bare ``norm``) match too:
 
             >>> EveryQueryLightningModule._is_norm_bias_param("layers.1.attn_norm.weight")
-            False
+            True
+            >>> EveryQueryLightningModule._is_norm_bias_param("layers.1.mlp_norm.weight")
+            True
             >>> EveryQueryLightningModule._is_norm_bias_param("final_norm.weight")
+            True
+            >>> EveryQueryLightningModule._is_norm_bias_param("model.embeddings.norm.weight")
+            True
+
+        Ordinary projection weights are still decayed:
+
+            >>> EveryQueryLightningModule._is_norm_bias_param("layers.1.attn.Wqkv.weight")
+            False
+            >>> EveryQueryLightningModule._is_norm_bias_param("layers.1.mlp.Wo.weight")
+            False
+            >>> EveryQueryLightningModule._is_norm_bias_param("encoder.layer.0.output.dense.weight")
             False
         """
-        return bool(re.search(r"(bias|layer(_?)norm(\d*)\.weight)", n, re.IGNORECASE))
+        return bool(re.search(r"(bias|(^|[._])[a-z0-9_]*norm(\d*)\.weight)", n, re.IGNORECASE))
 
     def _norm_bias_params(self) -> Iterator[torch.nn.parameter.Parameter]:
         for name, p in self.named_parameters():

--- a/tests/test_lightning_logic.py
+++ b/tests/test_lightning_logic.py
@@ -5,6 +5,7 @@ specifically optimizer parameter-group construction via ``configure_optimizers``
 and the relationship between raw logits and predicted probabilities.
 """
 
+import re
 from functools import partial
 
 import pytest
@@ -75,6 +76,25 @@ class TestWeightDecayParamGroupSeparation:
             assert not EveryQueryLightningModule._is_norm_bias_param(name), (
                 f"{name!r} is in the non-norm/bias group but _is_norm_bias_param returns True"
             )
+
+    def test_group1_contains_norm_weights_not_only_biases(self, demo_model):
+        """The no-decay group must hold norm *weights*, not just biases.
+
+        Regression guard for #297: the no-decay regex used to require a ``layer``
+        prefix, so every ModernBERT norm weight (``attn_norm``, ``mlp_norm``,
+        ``final_norm``, ``embeddings.norm``) was silently weight-decayed while the
+        biases kept the group non-empty and all other assertions green.
+        """
+        module, optimizer = self._build_module_and_optimizer(demo_model)
+        ptr_to_name = self._param_name_map(module)
+
+        group1_names = [ptr_to_name[p.data_ptr()] for p in optimizer.param_groups[1]["params"]]
+        norm_weights = [n for n in group1_names if re.search(r"norm.*\.weight$", n, re.IGNORECASE)]
+
+        assert norm_weights, (
+            "no-decay group contains no norm weights, only "
+            f"{group1_names!r} — norm params are being weight-decayed"
+        )
 
     def test_all_params_accounted_for(self, demo_model):
         module, optimizer = self._build_module_and_optimizer(demo_model)


### PR DESCRIPTION
Fixes #297 (split out of #296, finding 1).

## Problem

`EveryQueryLightningModule._is_norm_bias_param` used:

```python
re.search(r"(bias|layer(_?)norm(\d*)\.weight)", n, re.IGNORECASE)
```

The `layer` prefix is mandatory, so ModernBERT-style norm names — `layers.1.attn_norm.weight`, `layers.1.mlp_norm.weight`, `final_norm.weight`, `model.embeddings.norm.weight` — never matched. The stated intent ("bias/norm weights get zero weight decay") applied to **zero** norm weights of the backbone we actually use: every norm weight in a ModernBERT run received full weight decay. Biases still landed in the no-decay group, so the existing param-group tests all passed and the bug was invisible.

## Fix

```python
re.search(r"(bias|(^|[._])[a-z0-9_]*norm(\d*)\.weight)", n, re.IGNORECASE)
```

Matches any `*norm`-named component: `attn_norm.weight`, `mlp_norm.weight`, `final_norm.weight`, `embeddings.norm.weight`, `LayerNorm.weight`, `layer_norm.weight`, `layernorm2.weight` — while ordinary projection weights (`attn.Wqkv.weight`, `mlp.Wo.weight`, `dense.weight`, `self.query.weight`) still do not match.

- Doctests updated: the ModernBERT examples flip from `False` to `True`, the "the regex requires a `layer` prefix" prose is gone, and negative examples for projection weights were added.
- New regression test `TestWeightDecayParamGroupSeparation::test_group1_contains_norm_weights_not_only_biases` asserts the no-decay group contains at least one name matching `norm.*\.weight`. Verified non-vacuous: it fails against the old regex ("no-decay group contains no norm weights") and passes with the fix.

## ⚠️ Behavior change

**This changes optimization behavior for existing configs.** Norm weights move from the decayed group to the non-decayed group, so runs before and after this change are not directly comparable. Any in-flight comparison against a pre-fix baseline should be re-baselined.

## Testing

`uv run pytest -q` → 323 passed, 1 deselected (the `slow` marker, skipped by default). Ruff check and format clean on both touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
