### PR TITLE
Fix silently-dropped epoch-end AUROC metrics under DDP (#295)

### DIFF
--- a/src/every_query/model/lightning_module.py
+++ b/src/every_query/model/lightning_module.py
@@ -152,17 +152,27 @@ class EveryQueryLightningModule(L.LightningModule):
         # checkpoints load unchanged and load_from_checkpoint needs no edits.
         self.grad_norm_log_every_n_steps = grad_norm_log_every_n_steps
 
-        self.metrics = {
-            train_split: {},
-            tuning_split: {
-                "censor_auc": BinaryAUROC().cpu(),
-                "occurs_auc": BinaryAUROC().cpu(),
-            },
-            held_out_split: {
-                "censor_auc": BinaryAUROC().cpu(),
-                "occurs_auc": BinaryAUROC().cpu(),
-            },
-        }
+        # Registered as submodules (not a plain dict) so the metrics follow the module onto its
+        # device: torchmetrics can only all-gather its states under NCCL if they live on the GPU.
+        # Splits without metrics (train, predict) are simply absent -- `_split_metrics` handles
+        # that, and `train_split` in particular cannot be a key here as `train` collides with
+        # `torch.nn.Module.train`.
+        self.metrics = torch.nn.ModuleDict(
+            {
+                tuning_split: torch.nn.ModuleDict(
+                    {
+                        "censor_auc": BinaryAUROC(),
+                        "occurs_auc": BinaryAUROC(),
+                    }
+                ),
+                held_out_split: torch.nn.ModuleDict(
+                    {
+                        "censor_auc": BinaryAUROC(),
+                        "occurs_auc": BinaryAUROC(),
+                    }
+                ),
+            }
+        )
 
         self.save_hyperparameters(
             {
@@ -173,20 +183,29 @@ class EveryQueryLightningModule(L.LightningModule):
             }
         )
 
-    def setup(self, stage=None):
-        # keep metrics on CPU even if model moves to GPU
-        for split in (tuning_split, held_out_split, "predict"):
-            for m in self.metrics.get(split, {}).values():
-                m.to("cpu")
+    def _split_metrics(self, split: str) -> dict[str, BinaryAUROC]:
+        """The metrics registered for ``split``, or an empty mapping if the split has none.
+
+        Examples:
+            >>> sorted(demo_lightning_module._split_metrics(tuning_split))
+            ['censor_auc', 'occurs_auc']
+            >>> demo_lightning_module._split_metrics(train_split)
+            {}
+            >>> demo_lightning_module._split_metrics("predict")
+            {}
+        """
+        if split not in self.metrics:
+            return {}
+        return dict(self.metrics[split].items())
 
     def _update_metric(self, name: str, split: str, **kwargs):
-        metric = self.metrics.get(split, {}).get(name)
+        metric = self._split_metrics(split).get(name)
         if metric is None:
             return
         safe = {}
         for k, v in kwargs.items():
             if isinstance(v, torch.Tensor):
-                v = v.detach().cpu()
+                v = v.detach().to(metric.device)
                 if k == "preds":
                     v = v.float()
                 elif k == "target":
@@ -194,26 +213,67 @@ class EveryQueryLightningModule(L.LightningModule):
             safe[k] = v
         metric.update(**safe)
 
+    def _epoch_end_metric_value(self, metric: BinaryAUROC, label: str) -> float | None:
+        """The metric's value over the epoch, or ``None`` if it cannot be computed on this epoch's data.
+
+        ``metric.compute()`` all-gathers the metric states across ranks, so the decision to call it has
+        to be *collective*: if one rank skipped it because its own slice looked unusable, the ranks that
+        did call it would block forever inside the gather. Every rank therefore reduces its label counts
+        first and branches on the same global numbers. ``None`` (on every rank at once) means either:
+
+        * the epoch saw only one class globally, so AUROC is undefined; or
+        * some rank contributed no data at all. torchmetrics pads such a rank with a placeholder in the
+          metric's own (float) dtype, which mismatches the int64 ``target`` state gathered from the ranks
+          that do have data and aborts the collective, so this case is skipped rather than synced.
+
+        Examples:
+            >>> metric = BinaryAUROC()
+            >>> print(demo_lightning_module._epoch_end_metric_value(metric, "tuning/demo_auc"))
+            None
+            >>> metric.update(torch.tensor([0.1, 0.2]), torch.tensor([0, 0]))  # one class only
+            >>> print(demo_lightning_module._epoch_end_metric_value(metric, "tuning/demo_auc"))
+            None
+            >>> metric.update(torch.tensor([0.9]), torch.tensor([1]))  # both classes present
+            >>> demo_lightning_module._epoch_end_metric_value(metric, "tuning/demo_auc")
+            1.0
+        """
+        target_state = getattr(metric, "target", None)
+        if isinstance(target_state, list) and target_state:
+            all_targets = torch.cat([t.flatten() for t in target_state], dim=0)
+            n_pos = int((all_targets > 0).sum())
+            n_neg = int(all_targets.numel()) - n_pos
+        else:
+            n_pos = n_neg = 0
+
+        world_size = 1
+        counts = torch.tensor([n_pos, n_neg, int(n_pos + n_neg > 0)], device=self.device)
+        if torch.distributed.is_available() and torch.distributed.is_initialized():
+            world_size = torch.distributed.get_world_size()
+            torch.distributed.all_reduce(counts, op=torch.distributed.ReduceOp.SUM)
+        n_pos, n_neg, ranks_with_data = (int(c) for c in counts)
+
+        if n_pos == 0 or n_neg == 0:
+            logger.warning(
+                f"Not logging {label}: this epoch saw {n_pos} positive and {n_neg} negative labels, "
+                "so AUROC is undefined."
+            )
+            return None
+        if ranks_with_data < world_size:
+            logger.warning(
+                f"Not logging {label}: only {ranks_with_data} of {world_size} ranks saw any data, and "
+                "the metric states of a rank with no data cannot be synced."
+            )
+            return None
+        return float(metric.compute())
+
     def _on_epoch_end(self, split: str):
-        for metric_name, metric in self.metrics.get(split, {}).items():
-            try:
-                preds_state = getattr(metric, "preds", None)
-                target_state = getattr(metric, "target", None)
-                has_state = (
-                    isinstance(preds_state, list)
-                    and isinstance(target_state, list)
-                    and len(preds_state) > 0
-                    and len(target_state) > 0
-                )
-
-                all_targets = torch.cat([t.flatten() for t in target_state], dim=0)
-                has_both_classes = all_targets.numel() >= 1 and all_targets.unique().numel() >= 2
-
-                if has_state and has_both_classes:
-                    self.log(f"{split}/{metric_name}", float(metric.compute()), sync_dist=True)
-
-            except Exception:
-                pass
+        for metric_name, metric in self._split_metrics(split).items():
+            label = f"{split}/{metric_name}"
+            value = self._epoch_end_metric_value(metric, label)
+            if value is not None:
+                # `value` is already reduced over ranks by the metric's own state sync, so re-reducing
+                # it via `sync_dist` would be a second (needless) collective over an identical number.
+                self.log(label, value, sync_dist=False)
 
             metric.reset()
 
@@ -273,16 +333,16 @@ class EveryQueryLightningModule(L.LightningModule):
                 self._update_metric(
                     name="censor_auc",
                     split=split,
-                    preds=outputs.censor_logits.detach().cpu().squeeze(1).float().sigmoid(),
-                    target=batch.censor.detach().cpu().long(),
+                    preds=outputs.censor_logits.detach().squeeze(1).float().sigmoid(),
+                    target=batch.censor.detach().long(),
                 )
             if (
                 getattr(outputs, "occurs_logits", None) is not None
                 and getattr(batch, "occurs", None) is not None
             ):
-                mask = (~batch.censor).detach().cpu().bool() if hasattr(batch, "censor") else None
-                preds = outputs.occurs_logits.detach().cpu().squeeze(1).float().sigmoid()
-                target = batch.occurs.detach().cpu().long()
+                mask = (~batch.censor).detach().bool() if hasattr(batch, "censor") else None
+                preds = outputs.occurs_logits.detach().squeeze(1).float().sigmoid()
+                target = batch.occurs.detach().long()
                 if mask is not None:
                     preds = preds[mask]
                     target = target[mask]

--- a/tests/test_lightning_logic.py
+++ b/tests/test_lightning_logic.py
@@ -5,10 +5,14 @@ specifically optimizer parameter-group construction via ``configure_optimizers``
 and the relationship between raw logits and predicted probabilities.
 """
 
+import contextlib
+import os
+import socket
 from functools import partial
 
 import pytest
 import torch
+from meds import tuning_split
 from meds_torchdata import MEDSTorchDataConfig
 
 from every_query.data.dataset import EveryQueryBatch
@@ -298,3 +302,159 @@ class TestCallbackHydraWiring:
         assert isinstance(callback, TaskAurocTrackingCallback)
         assert callback.batch_size == 256
         assert isinstance(callback.config, MEDSTorchDataConfig)
+
+
+def _stub_module() -> EveryQueryLightningModule:
+    """A lightning module with a throwaway model, for exercising the metric plumbing only."""
+    return EveryQueryLightningModule(model=_StubOccursModel([]))
+
+
+class TestEpochEndAUROCLogging:
+    """``_on_epoch_end`` must log the epoch AUROCs, and fail loudly instead of dropping them.
+
+    The metrics used to be plain CPU ``BinaryAUROC`` objects held in a plain dict, computed inside a bare
+    ``except Exception: pass`` — so under DDP the states never followed the module onto the GPU and every
+    failure of the distributed all-gather was swallowed silently.
+    """
+
+    @staticmethod
+    def _log_calls(module) -> dict[str, float]:
+        """Run ``_on_epoch_end`` for the tuning split, capturing what it logged."""
+        logged = {}
+        module.log = lambda name, value, **kw: logged.__setitem__(name, value)
+        module._on_epoch_end(tuning_split)
+        return logged
+
+    def test_metrics_are_registered_submodules(self):
+        """Registration is what makes torchmetrics' DDP sync work — a plain dict is invisible to ``.to()``."""
+        module = _stub_module()
+        named = dict(module.named_modules())
+
+        assert f"metrics.{tuning_split}.censor_auc" in named
+        assert f"metrics.{tuning_split}.occurs_auc" in named
+
+    def test_metric_states_follow_the_module_device(self):
+        module = _stub_module().to(torch.float64)
+        metric = module.metrics[tuning_split]["censor_auc"]
+
+        # CPU-only CI cannot check a real device move, so check the update path coerces onto the metric.
+        module._update_metric("censor_auc", tuning_split, preds=torch.tensor([0.1]), target=torch.tensor([0]))
+        assert metric.target[0].device == metric.device
+
+    def test_no_new_persistent_checkpoint_keys(self):
+        """Existing checkpoints must keep loading: metric states are non-persistent, so nothing is added."""
+        assert [k for k in _stub_module().state_dict() if "metrics" in k] == []
+
+    def test_logs_auroc_when_both_classes_present(self):
+        module = _stub_module()
+        module._update_metric(
+            "censor_auc", tuning_split, preds=torch.tensor([0.1, 0.9]), target=torch.tensor([0, 1])
+        )
+
+        logged = self._log_calls(module)
+
+        assert logged[f"{tuning_split}/censor_auc"] == pytest.approx(1.0)
+        # occurs_auc never got data, so it is undefined and simply absent.
+        assert f"{tuning_split}/occurs_auc" not in logged
+
+    def test_skips_and_resets_when_only_one_class_present(self):
+        module = _stub_module()
+        module._update_metric(
+            "censor_auc", tuning_split, preds=torch.tensor([0.1, 0.9]), target=torch.tensor([0, 0])
+        )
+
+        logged = self._log_calls(module)
+
+        assert logged == {}
+        assert module.metrics[tuning_split]["censor_auc"].target == []
+
+    def test_state_is_reset_between_epochs(self):
+        module = _stub_module()
+        module._update_metric(
+            "censor_auc", tuning_split, preds=torch.tensor([0.1, 0.9]), target=torch.tensor([0, 1])
+        )
+        self._log_calls(module)
+
+        assert module.metrics[tuning_split]["censor_auc"].target == []
+
+    def test_compute_failures_are_not_swallowed(self):
+        """The old bare ``except Exception: pass`` is what made the DDP breakage invisible."""
+        module = _stub_module()
+        metric = module.metrics[tuning_split]["censor_auc"]
+        module._update_metric(
+            "censor_auc", tuning_split, preds=torch.tensor([0.1, 0.9]), target=torch.tensor([0, 1])
+        )
+        metric.compute = lambda: (_ for _ in ()).throw(RuntimeError("all-gather blew up"))
+
+        with pytest.raises(RuntimeError, match="all-gather blew up"):
+            self._log_calls(module)
+
+
+def _free_port() -> int:
+    with contextlib.closing(socket.socket()) as s:
+        s.bind(("localhost", 0))
+        return s.getsockname()[1]
+
+
+def _ddp_epoch_end_worker(rank: int, world_size: int, port: int, queue) -> None:
+    """One rank of the DDP epoch-end test: update rank-specific data, then log the epoch metrics."""
+    os.environ["MASTER_ADDR"] = "localhost"
+    os.environ["MASTER_PORT"] = str(port)
+    torch.distributed.init_process_group("gloo", rank=rank, world_size=world_size)
+    try:
+        module = _stub_module()
+        if rank == 0:
+            # Both classes locally, plus the only data `occurs_auc` ever sees.
+            preds, target = torch.tensor([0.1, 0.9]), torch.tensor([0, 1])
+            module._update_metric(
+                "occurs_auc", tuning_split, preds=torch.tensor([0.1, 0.9]), target=torch.tensor([0, 1])
+            )
+        else:
+            # Negatives only: rank-dependent branching here is what used to hang the all-gather.
+            preds, target = torch.tensor([0.2, 0.95]), torch.tensor([0, 0])
+        module._update_metric("censor_auc", tuning_split, preds=preds, target=target)
+
+        logged = {}
+        module.log = lambda name, value, **kw: logged.__setitem__(name, value)
+        module._on_epoch_end(tuning_split)
+        queue.put((rank, logged))
+    finally:
+        torch.distributed.destroy_process_group()
+
+
+@pytest.mark.skipif(not torch.distributed.is_available(), reason="torch.distributed unavailable")
+class TestEpochEndAUROCUnderDDP:
+    """Two gloo ranks with rank-uneven, rank-degenerate data must both log the *global* AUROC.
+
+    Regression test for the reported multi-GPU failure: the per-rank ``has_both_classes`` guard let one
+    rank skip ``compute()`` while the other entered its blocking all-gather.
+    """
+
+    def test_both_ranks_log_the_global_auroc(self):
+        ctx = torch.multiprocessing.get_context("spawn")
+        queue = ctx.Queue()
+        port = _free_port()
+        procs = [ctx.Process(target=_ddp_epoch_end_worker, args=(r, 2, port, queue)) for r in range(2)]
+        for p in procs:
+            p.start()
+
+        results = {}
+        try:
+            for _ in procs:
+                results.update(dict([queue.get(timeout=180)]))
+        except Exception as e:  # pragma: no cover - only hit if the all-gather hangs
+            raise AssertionError(f"DDP epoch-end did not complete on both ranks: {e}") from e
+        finally:
+            for p in procs:
+                p.join(timeout=30)
+                if p.is_alive():
+                    p.terminate()
+
+        assert set(results) == {0, 1}
+        for rank, logged in results.items():
+            # Global pool: one positive (0.9) against negatives 0.1, 0.2 and 0.95 -> 2/3.
+            # Rank 0 alone would score 1.0, so this also proves the states really were gathered.
+            assert logged[f"{tuning_split}/censor_auc"] == pytest.approx(2 / 3), f"rank {rank}"
+            # Only rank 0 updated `occurs_auc`; syncing a rank with no data at all is unsupported, so
+            # every rank must skip it identically rather than one hanging or aborting the collective.
+            assert f"{tuning_split}/occurs_auc" not in logged, f"rank {rank}"


### PR DESCRIPTION
Fixes #295.

## The bug

The tuning/held-out `BinaryAUROC` metrics were plain CPU torchmetrics objects held in a plain
`dict`, and `_on_epoch_end` wrapped `compute()` + `self.log(..., sync_dist=True)` in a bare
`except Exception: pass`.

Because a plain dict is invisible to `nn.Module.to()`, the states never followed the module to the
GPU, so the default `sync_on_compute=True` tried to all-gather CPU list states:

- **NCCL** (default multi-GPU CUDA): the gather raises, the bare `except` swallows it, and
  `tuning/censor_auc` / `tuning/occurs_auc` are never logged in *any* DDP run — checkpoint selection
  then monitors a metric that does not exist.
- **gloo**: the states can sync, but the `has_state and has_both_classes` guard is evaluated
  per rank, so a rank whose own slice had only one class skipped `compute()` while the other ranks
  blocked inside its all-gather.

Single-GPU runs were unaffected.

## The fix

- **Register the metrics as submodules** (`nn.ModuleDict`) so they follow the module onto its device
  and torchmetrics can sync them; `_update_metric` moves inputs onto the metric's device rather than
  forcing CPU. (`train_split` cannot be a `ModuleDict` key — `train` collides with
  `nn.Module.train` — and it had no metrics anyway, so splits without metrics are simply absent.)
- **Make the guard collective.** Every rank all-reduces its label counts and branches on the same
  global numbers, so all ranks reach `compute()` together or none do. The resulting value is already
  reduced across ranks by the metric's own sync, so it is no longer re-reduced via `sync_dist`.
- **Skip loudly, rather than sync, when some rank saw no data at all.** torchmetrics pads an empty
  rank with a placeholder in the metric's own float dtype, which mismatches the int64 `target`
  state gathered from ranks that do have data and aborts the collective
  (`op.preamble.length <= op.nbytes. 8 vs 4`). This is now detected up front on every rank.
- **Drop the bare `except Exception: pass`**, and warn with the reason whenever a metric is not
  logged.

## Compatibility

Metric states are non-persistent, so `state_dict()` gains no keys and existing checkpoints load
unchanged. The AUROC states now accumulate on the GPU instead of CPU (~12 bytes per scored example
per metric, freed each epoch) — that is the cost of letting torchmetrics sync them under NCCL.

## Tests

`TestEpochEndAUROCLogging` covers submodule registration, device coercion, the absence of new
checkpoint keys, logging when both classes are present, skipping + resetting when only one class is,
and that `compute()` failures now propagate instead of being swallowed.

`TestEpochEndAUROCUnderDDP` spawns two gloo ranks with rank-uneven, rank-degenerate data and asserts
both ranks log the *global* AUROC (2/3 — rank 0's slice alone would score 1.0, so this also proves
the states really were gathered), and that the metric only rank 0 updated is skipped identically on
both ranks instead of hanging or aborting the collective.

Verified: `pytest` — 332 passed; `pytest -m slow` — 1 passed; ruff format/check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
