### PR TITLE
Don't rely on polars semi-join row order to align task annotations

### DIFF
--- a/src/every_query/data/dataset.py
+++ b/src/every_query/data/dataset.py
@@ -277,9 +277,16 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
 
         Delegates to the upstream implementation (memory-efficient `join_asof`-based) and then
         hstacks EveryQuery's task-specific annotation columns (`occurs`, `query`, `duration_days`)
-        onto the result. Alignment relies on the upstream guarantee that surviving rows are
-        returned in `label_df` input order; we semi-filter `label_df` to the same surviving
-        subject set so row `i` of `base` corresponds to row `i` of `surviving`.
+        onto the result. Upstream documents that its output preserves `label_df` input order for
+        the rows that survive its inner-join on `subject_id`; we reproduce exactly that row set
+        *and* that order here, so row `i` of `base` corresponds to row `i` of `surviving`.
+
+        A key join on `(subject_id, prediction_time)` would sidestep the ordering question, but
+        that pair is not unique in EveryQuery label frames — one subject/prediction_time carries
+        many rows, one per query — so it would fan out rather than align. Instead we carry an
+        explicit row index through the semi-join and re-sort on it, which makes the alignment
+        independent of whatever row order the join engine happens to return (polars' join
+        `maintain_order` defaults to `None`, i.e. no guarantee; see #299).
 
         Args:
             label_df: The DataFrame containing the task labels, in the MEDS Label DF schema.
@@ -295,10 +302,18 @@ class EveryQueryPytorchDataset(MEDSPytorchDataset):
         if not extras:
             return base
         sid = DataSchema.subject_id_name
-        # Upstream guarantees input-order preservation for surviving rows (inner-join on subject_id).
-        # hstack-align the extras by semi-filtering label_df to the same surviving row set.
-        surviving = label_df.join(schema_df.lazy().select(sid).unique().collect(), on=sid, how="semi")
-        return base.hstack(surviving.select(extras))
+        surviving = (
+            label_df.lazy()
+            .with_row_index("_row")
+            .join(schema_df.lazy().select(sid).unique(), on=sid, how="semi")
+            # The join may return rows in any order; `_row` is unique, so sorting on it
+            # restores `label_df` input order deterministically -- the same order upstream
+            # restores internally before returning `base`.
+            .sort("_row")
+            .select(extras)
+            .collect()
+        )
+        return base.hstack(surviving)
 
     def __init__(self, cfg: MEDSTorchDataConfig, split: str):
         super().__init__(cfg, split)

--- a/tests/test_task_seq_bounds.py
+++ b/tests/test_task_seq_bounds.py
@@ -73,6 +73,155 @@ class TestExtraColumnAlignment:
             assert out_row["duration_days"] == expected["duration_days"]
             assert out_row["boolean_value"] == expected["boolean_value"]
 
+    def test_extras_align_when_subject_ids_are_unsorted(self):
+        """Subject ids deliberately out of sorted order (#299).
+
+        The upstream implementation sorts by ``(subject_id, prediction_time)`` internally
+        before restoring input order, and the subclass's own semi-join carries no row-order
+        guarantee from polars. Both effects are invisible when the input happens to be sorted,
+        so this input is shuffled and every row's annotations are distinct.
+        """
+        label_df = pl.DataFrame(
+            {
+                DataSchema.subject_id_name: [3, 1, 2, 1, 99, 2],
+                LabelSchema.prediction_time_name: [
+                    datetime(2020, 1, 10),
+                    datetime(2020, 1, 3),
+                    datetime(2020, 1, 1),
+                    datetime(2020, 1, 2),
+                    datetime(2020, 1, 1),
+                    datetime(2020, 1, 5),
+                ],
+                "boolean_value": [True, False, True, True, False, False],
+                "occurs": [30, 12, 21, 11, 99, 22],
+                "query": [300, 120, 210, 110, 990, 220],
+                "duration_days": [3.0, 1.2, 2.1, 1.1, 9.9, 2.2],
+            }
+        )
+
+        result = EveryQueryPytorchDataset.get_task_seq_bounds_and_labels(label_df, _schema_df())
+
+        # Subject 99 is absent from schema_df → dropped.
+        assert result.height == 5
+
+        label_lookup = {
+            (row[DataSchema.subject_id_name], row[LabelSchema.prediction_time_name]): row
+            for row in label_df.iter_rows(named=True)
+        }
+        for out_row in result.iter_rows(named=True):
+            key = (out_row[DataSchema.subject_id_name], out_row[LabelSchema.prediction_time_name])
+            expected = label_lookup[key]
+            assert out_row["occurs"] == expected["occurs"], f"occurs misaligned for {key}"
+            assert out_row["query"] == expected["query"], f"query misaligned for {key}"
+            assert out_row["duration_days"] == expected["duration_days"], f"duration misaligned for {key}"
+            assert out_row["boolean_value"] == expected["boolean_value"], f"label misaligned for {key}"
+
+        # End indices are still the ones the (subject_id, prediction_time) pair implies.
+        end_idx = {
+            (r[DataSchema.subject_id_name], r[LabelSchema.prediction_time_name]): r[
+                EveryQueryPytorchDataset.END_IDX
+            ]
+            for r in result.iter_rows(named=True)
+        }
+        assert end_idx == {
+            (3, datetime(2020, 1, 10)): 1,
+            (1, datetime(2020, 1, 3)): 3,
+            (2, datetime(2020, 1, 1)): 1,
+            (1, datetime(2020, 1, 2)): 2,
+            (2, datetime(2020, 1, 5)): 2,
+        }
+
+    def test_extras_align_across_repeated_subject_prediction_time(self):
+        """Several query rows share one ``(subject_id, prediction_time)`` pair.
+
+        That pair is therefore not a unique key, so alignment cannot be re-derived by a key
+        join — it has to be positionally correct. Within each repeated group the rows are
+        distinguishable only by ``boolean_value``, so the annotations are built to encode it
+        (``occurs`` is even iff ``boolean_value`` is False) and the pairing is asserted per row.
+        """
+        label_df = pl.DataFrame(
+            {
+                DataSchema.subject_id_name: [2, 1, 2, 1, 2, 1],
+                LabelSchema.prediction_time_name: [
+                    datetime(2020, 1, 5),
+                    datetime(2020, 1, 2),
+                    datetime(2020, 1, 5),
+                    datetime(2020, 1, 2),
+                    datetime(2020, 1, 5),
+                    datetime(2020, 1, 2),
+                ],
+                "boolean_value": [True, False, False, True, True, False],
+                "occurs": [1, 2, 4, 3, 5, 6],
+                "query": [11, 22, 44, 33, 55, 66],
+                "duration_days": [1.0, 2.0, 4.0, 3.0, 5.0, 6.0],
+            }
+        )
+
+        result = EveryQueryPytorchDataset.get_task_seq_bounds_and_labels(label_df, _schema_df())
+
+        assert result.height == 6
+        for out_row in result.iter_rows(named=True):
+            occurs = out_row["occurs"]
+            assert (occurs % 2 == 0) is (out_row["boolean_value"] is False), (
+                f"annotation row {occurs} paired with the wrong label {out_row['boolean_value']}"
+            )
+            # `query` and `duration_days` travel with `occurs` on the same source row.
+            assert out_row["query"] == occurs * 11
+            assert out_row["duration_days"] == float(occurs)
+
+        # No annotation row was dropped or duplicated by the realignment.
+        assert sorted(result["occurs"].to_list()) == [1, 2, 3, 4, 5, 6]
+
+    def test_extras_align_when_the_join_engine_reorders_rows(self, monkeypatch):
+        """The alignment must not depend on join row order at all (#299).
+
+        Polars' `join` takes `maintain_order=None` by default, so the engine is free to emit
+        rows in any order; today's pinned version happens to preserve the left input's, which
+        is precisely why an order-dependent implementation passes the tests above. Here every
+        join is patched to reverse its output, standing in for a future engine that reorders.
+        """
+        # Only the lazy layer is patched: `DataFrame.join` delegates to `LazyFrame.join`, so
+        # patching both would reverse twice and cancel out. This single hook reverses every
+        # join in the call, eager and lazy alike.
+        original_join = pl.LazyFrame.join
+
+        def reversing_join(self, *args, **kwargs):
+            return original_join(self, *args, **kwargs).reverse()
+
+        monkeypatch.setattr(pl.LazyFrame, "join", reversing_join)
+
+        label_df = pl.DataFrame(
+            {
+                DataSchema.subject_id_name: [3, 1, 2, 1, 99, 2],
+                LabelSchema.prediction_time_name: [
+                    datetime(2020, 1, 10),
+                    datetime(2020, 1, 3),
+                    datetime(2020, 1, 1),
+                    datetime(2020, 1, 2),
+                    datetime(2020, 1, 1),
+                    datetime(2020, 1, 5),
+                ],
+                "boolean_value": [True, False, True, True, False, False],
+                "occurs": [30, 12, 21, 11, 99, 22],
+                "query": [300, 120, 210, 110, 990, 220],
+                "duration_days": [3.0, 1.2, 2.1, 1.1, 9.9, 2.2],
+            }
+        )
+
+        result = EveryQueryPytorchDataset.get_task_seq_bounds_and_labels(label_df, _schema_df())
+
+        assert result.height == 5
+        label_lookup = {
+            (row[DataSchema.subject_id_name], row[LabelSchema.prediction_time_name]): row
+            for row in label_df.iter_rows(named=True)
+        }
+        for out_row in result.iter_rows(named=True):
+            key = (out_row[DataSchema.subject_id_name], out_row[LabelSchema.prediction_time_name])
+            expected = label_lookup[key]
+            assert out_row["occurs"] == expected["occurs"], f"occurs misaligned for {key}"
+            assert out_row["query"] == expected["query"], f"query misaligned for {key}"
+            assert out_row["duration_days"] == expected["duration_days"], f"duration misaligned for {key}"
+
     def test_no_extras_passes_through(self):
         label_df = pl.DataFrame(
             {


### PR DESCRIPTION
Closes #299.

## The problem

`EveryQueryPytorchDataset.get_task_seq_bounds_and_labels` hstacked the EveryQuery annotation columns (`occurs`, `query`, `duration_days`) onto the upstream result positionally:

```python
base = super().get_task_seq_bounds_and_labels(label_df, schema_df)
surviving = label_df.join(schema_df.lazy().select(sid).unique().collect(), on=sid, how="semi")
return base.hstack(surviving.select(extras))
```

That assumes the semi-join returns surviving rows in `label_df` input order. Polars promises nothing of the sort — `maintain_order` defaults to `None` and the engine may reorder. It holds on the currently-pinned version, but the project allows `polars>=1.35,<2`, so any minor bump could silently shuffle annotations against sequence bounds and produce wrong training/eval targets with no error raised.

## The fix

Carry an explicit row index through the semi-join and sort on it before the hstack:

```python
surviving = (
    label_df.lazy()
    .with_row_index("_row")
    .join(schema_df.lazy().select(sid).unique(), on=sid, how="semi")
    .sort("_row")
    .select(extras)
    .collect()
)
return base.hstack(surviving)
```

`_row` is unique, so the sort restores `label_df` input order deterministically no matter what the join emits. This is the same trick upstream already uses internally before returning `base`, so both sides now establish their order explicitly rather than inheriting it from an engine detail.

**Why not the key join (option 2 in the issue).** `(subject_id, prediction_time)` is not unique in EveryQuery label frames — one subject/prediction_time carries many rows, one per query — so joining on it would fan out rather than align. There is no other unique key available on both sides. The docstring now records this, along with a corrected statement of what upstream actually guarantees (it does document input-order preservation for surviving rows; the previous comment asserted it a bit loosely).

Prefer `maintain_order="left"` over the row-index sort? It's a smaller diff, but it leaves the guarantee in the join engine's hands rather than in ours, and it doesn't cover the `DataFrame.join` → `LazyFrame.join` delegation as legibly. Happy to switch if you'd rather have the one-liner.

## Tests

Three cases added to `tests/test_task_seq_bounds.py`:

1. **`test_extras_align_when_subject_ids_are_unsorted`** — the case the issue asks for: subject ids deliberately out of sorted order, every row's annotations distinct. The pre-existing test used already-sorted ids, which hides both the upstream internal `(subject_id, prediction_time)` sort and any join reordering.
2. **`test_extras_align_across_repeated_subject_prediction_time`** — several query rows share one `(subject_id, prediction_time)`, so the pair is demonstrably not a usable key. Within a group only `boolean_value` distinguishes rows, so the annotations encode it (`occurs` even iff `boolean_value` is False) and the pairing is asserted per row.
3. **`test_extras_align_when_the_join_engine_reorders_rows`** — patches `pl.LazyFrame.join` to reverse every join, standing in for a future engine that reorders.

Test 3 is the one that actually has teeth. Tests 1 and 2 pass against the *old* implementation too, because today's polars happens to preserve left-input order — which is exactly why the bug is latent and why a test that only shuffles the input can't catch it. Verified by stashing the fix and re-running: test 3 fails on the old code with `AssertionError: occurs misaligned for (3, 2020-01-10) — assert 22 == 30`, and passes with the fix in place.

One wrinkle worth flagging for review: only `pl.LazyFrame.join` is patched, not `pl.DataFrame.join`. `DataFrame.join` delegates to the lazy implementation, so patching both reverses twice and cancels out — an earlier draft of the test did exactly that and passed against the buggy code, which is a nice illustration of how quietly this failure mode hides.

## Verification

- Full suite: 325 passed, 1 deselected.
- `ruff check` and `ruff format --check` clean on both changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
